### PR TITLE
feat: support yarn

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,21 @@ jobs:
           wait-on: http://localhost:8080
 ```
 
+## Notes
+
+### Installation
+
+This action installs local dependencies using lock files. If `yarn.lock` file is found, the install uses `yarn --frozen-lockfile` command. Otherwise it expects to find `package-lock.json` and install using `npm ci` command.
+
+### Debugging
+
+You can see verbose messages from GitHub Actions by setting the following secrets (from [Debugging Actions Guide](https://github.com/actions/toolkit/blob/master/docs/action-debugging.md#step-debug-logs))
+
+```
+ACTIONS_RUNNER_DEBUG: true
+ACTIONS_STEP_DEBUG: true
+```
+
 ## More information
 
 - [Building actions](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/building-actions) docs


### PR DESCRIPTION
If `yarn.lock` is found, then yarn will be used to install NPM dependencies

See https://github.com/bahmutov/yarn-cypress-cache/commit/264ea485d1256ad2ea297499cc22bed70290f082/checks?check_suite_id=307916678 for example