### PR TITLE
feat: support Mac and Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,21 @@ jobs:
           wait-on: http://localhost:8080
 ```
 
+## Notes
+
+### Installation
+
+This action installs local dependencies using lock files. If `yarn.lock` file is found, the install uses `yarn --frozen-lockfile` command. Otherwise it expects to find `package-lock.json` and install using `npm ci` command.
+
+### Debugging
+
+You can see verbose messages from GitHub Actions by setting the following secrets (from [Debugging Actions Guide](https://github.com/actions/toolkit/blob/master/docs/action-debugging.md#step-debug-logs))
+
+```
+ACTIONS_RUNNER_DEBUG: true
+ACTIONS_STEP_DEBUG: true
+```
+
 ## More information
 
 - [Building actions](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/building-actions) docs

--- a/dist/index.js
+++ b/dist/index.js
@@ -1140,6 +1140,7 @@ module.exports = require("os");
 // @ts-check
 const core = __webpack_require__(470)
 const exec = __webpack_require__(986)
+const io = __webpack_require__(1)
 const hasha = __webpack_require__(309)
 const execa = __webpack_require__(955)
 const { restoreCache, saveCache } = __webpack_require__(211)
@@ -1209,10 +1210,16 @@ const install = () => {
 
   if (useYarn) {
     console.log('installing NPM dependencies using Yarn')
-    return exec.exec('yarn --frozen-lockfile')
+    return io.which('yarn', true).then(yarnPath => {
+      console.log('yarn at "%s"', yarnPath)
+      return exec.exec(yarnPath, ['--frozen-lockfile'])
+    })
   } else {
     console.log('installing NPM dependencies')
-    return exec.exec('npm ci')
+    return io.which('npm', true).then(npmPath => {
+      console.log('npm at "%s"', npmPath)
+      return exec.exec(npmPath, ['ci'])
+    })
   }
 }
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -1155,13 +1155,15 @@ const lockFilename = useYarn ? 'yarn.lock' : 'package-lock.json'
 const lockHash = hasha.fromFileSync(lockFilename)
 const platformAndArch = `${process.platform}-${process.arch}`
 
+// enforce the same NPM cache folder across different operating systems
+const NPM_CACHE_FOLDER = path.join(homeDirectory, '.npm')
 const NPM_CACHE = (() => {
   const o = {}
   if (useYarn) {
     o.inputPath = path.join(homeDirectory, '.cache', 'yarn')
     o.restoreKeys = `yarn-${platformAndArch}-`
   } else {
-    o.inputPath = path.join(homeDirectory, '.npm')
+    o.inputPath = NPM_CACHE_FOLDER
     o.restoreKeys = `npm-${platformAndArch}-`
   }
   o.primaryKey = o.restoreKeys + lockHash
@@ -1171,6 +1173,8 @@ const NPM_CACHE = (() => {
 // custom Cypress binary cache folder
 // see https://on.cypress.io/caching
 const CYPRESS_CACHE_FOLDER = path.join(homeDirectory, '.cache', 'Cypress')
+console.log('using custom Cypress cache folder "%s"', CYPRESS_CACHE_FOLDER)
+
 const CYPRESS_BINARY_CACHE = (() => {
   const o = {
     inputPath: CYPRESS_CACHE_FOLDER,
@@ -1224,6 +1228,8 @@ const install = () => {
     })
   } else {
     console.log('installing NPM dependencies')
+    core.exportVariable('npm_config_cache', NPM_CACHE_FOLDER)
+
     return io.which('npm', true).then(npmPath => {
       console.log('npm at "%s"', npmPath)
       return exec.exec(npmPath, ['ci'])

--- a/dist/index.js
+++ b/dist/index.js
@@ -1145,6 +1145,10 @@ const hasha = __webpack_require__(309)
 const execa = __webpack_require__(955)
 const { restoreCache, saveCache } = __webpack_require__(211)
 const fs = __webpack_require__(747)
+const os = __webpack_require__(87)
+const path = __webpack_require__(622)
+
+const homeDirectory = os.homedir()
 
 const useYarn = fs.existsSync('yarn.lock')
 const lockFilename = useYarn ? 'yarn.lock' : 'package-lock.json'
@@ -1154,19 +1158,22 @@ const platformAndArch = `${process.platform}-${process.arch}`
 const NPM_CACHE = (() => {
   const o = {}
   if (useYarn) {
-    o.inputPath = '~/.cache/yarn'
+    o.inputPath = path.join(homeDirectory, '.cache', 'yarn')
     o.restoreKeys = `yarn-${platformAndArch}-`
   } else {
-    o.inputPath = '~/.npm'
+    o.inputPath = path.join(homeDirectory, '.npm')
     o.restoreKeys = `npm-${platformAndArch}-`
   }
   o.primaryKey = o.restoreKeys + lockHash
   return o
 })()
 
+// custom Cypress binary cache folder
+// see https://on.cypress.io/caching
+const CYPRESS_CACHE_FOLDER = path.join(homeDirectory, '.cache', 'Cypress')
 const CYPRESS_BINARY_CACHE = (() => {
   const o = {
-    inputPath: '~/.cache/Cypress',
+    inputPath: CYPRESS_CACHE_FOLDER,
     restoreKeys: `cypress-${platformAndArch}-`
   }
   o.primaryKey = o.restoreKeys + lockHash
@@ -1207,6 +1214,7 @@ const saveCachedCypressBinary = () => {
 const install = () => {
   // prevent lots of progress messages during install
   core.exportVariable('CI', '1')
+  core.exportVariable('CYPRESS_CACHE_FOLDER', CYPRESS_CACHE_FOLDER)
 
   if (useYarn) {
     console.log('installing NPM dependencies using Yarn')

--- a/dist/index.js
+++ b/dist/index.js
@@ -1147,6 +1147,7 @@ const { restoreCache, saveCache } = __webpack_require__(211)
 const fs = __webpack_require__(747)
 const os = __webpack_require__(87)
 const path = __webpack_require__(622)
+const quote = __webpack_require__(531)
 
 const homeDirectory = os.homedir()
 
@@ -1220,11 +1221,14 @@ const install = () => {
   core.exportVariable('CI', '1')
   core.exportVariable('CYPRESS_CACHE_FOLDER', CYPRESS_CACHE_FOLDER)
 
+  // Note: need to quote found tool to avoid Windows choking on
+  // npm paths with spaces like "C:\Program Files\nodejs\npm.cmd ci"
+
   if (useYarn) {
     console.log('installing NPM dependencies using Yarn')
     return io.which('yarn', true).then(yarnPath => {
       console.log('yarn at "%s"', yarnPath)
-      return exec.exec(yarnPath, ['--frozen-lockfile'])
+      return exec.exec(quote(yarnPath), ['--frozen-lockfile'])
     })
   } else {
     console.log('installing NPM dependencies')
@@ -1232,7 +1236,7 @@ const install = () => {
 
     return io.which('npm', true).then(npmPath => {
       console.log('npm at "%s"', npmPath)
-      return exec.exec(`"${npmPath}"`, ['ci'])
+      return exec.exec(quote(npmPath), ['ci'])
     })
   }
 }
@@ -1241,7 +1245,7 @@ const verifyCypressBinary = () => {
   console.log('Verifying Cypress')
   core.exportVariable('CYPRESS_CACHE_FOLDER', CYPRESS_CACHE_FOLDER)
   return io.which('npx', true).then(npxPath => {
-    return exec.exec(npxPath, ['cypress', 'verify'])
+    return exec.exec(quote(npxPath), ['cypress', 'verify'])
   })
 }
 
@@ -1304,7 +1308,7 @@ const waitOnMaybe = () => {
   console.log('waiting on "%s"', waitOn)
 
   return io.which('npx', true).then(npxPath => {
-    return exec.exec(npxPath, ['wait-on', `"${waitOn}"`])
+    return exec.exec(quote(npxPath), ['wait-on', quote(waitOn)])
   })
 }
 
@@ -1344,7 +1348,7 @@ const runTests = () => {
     console.log('Cypress test command: npx %s', cmd.join(' '))
 
     core.exportVariable('TERM', 'xterm')
-    return exec.exec(npxPath, cmd)
+    return exec.exec(quote(npxPath), cmd)
   })
 }
 
@@ -3850,6 +3854,57 @@ class NtlmCredentialHandler {
 }
 exports.NtlmCredentialHandler = NtlmCredentialHandler;
 
+
+/***/ }),
+
+/***/ 531:
+/***/ (function(module) {
+
+!function(e){if(true)module.exports=e();else { var f; }}(function(){var define,module,exports;module={exports:(exports={})};
+function emptyQuotes(options) {
+  return options.quotes + options.quotes;
+}
+
+function quoteString(options, str) {
+  if (str === '') {
+    return emptyQuotes(options);
+  }
+  if (str[0] !== options.quotes) {
+    str = options.quotes + str;
+  }
+  if (str[str.length - 1] !== options.quotes) {
+    str += options.quotes;
+  }
+  return str;
+}
+
+function quoteOptions(options, str) {
+  if (arguments.length === 1) {
+    str = options;
+    options = { quotes: '"' };
+  }
+
+  if (typeof str === 'string') {
+    return quoteString(options, str);
+  }
+
+  if (typeof str === 'undefined' || str === null) {
+    return emptyQuotes(options);
+  }
+
+  return str;
+}
+
+function quote(str) {
+  if (typeof str === 'object') {
+    return quoteOptions.bind(null, str);
+  }
+  return quoteOptions(str);
+}
+
+module.exports = quote;
+
+return module.exports;});
 
 /***/ }),
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -1233,6 +1233,7 @@ const install = () => {
 
 const verifyCypressBinary = () => {
   console.log('Verifying Cypress')
+  core.exportVariable('CYPRESS_CACHE_FOLDER', CYPRESS_CACHE_FOLDER)
   return io.which('npx', true).then(npxPath => {
     return exec.exec(npxPath, ['cypress', 'verify'])
   })
@@ -1314,6 +1315,8 @@ const runTests = () => {
   const parallel = getInputBool('parallel')
 
   return io.which('npx', true).then(npxPath => {
+    core.exportVariable('CYPRESS_CACHE_FOLDER', CYPRESS_CACHE_FOLDER)
+
     const cmd = ['cypress', 'run']
     if (record) {
       cmd.push(' --record')

--- a/dist/index.js
+++ b/dist/index.js
@@ -1225,7 +1225,9 @@ const install = () => {
 
 const verifyCypressBinary = () => {
   console.log('Verifying Cypress')
-  return exec.exec('npx cypress verify')
+  return io.which('npx', true).then(npxPath => {
+    return exec.exec(npxPath, ['cypress', 'verify'])
+  })
 }
 
 /**
@@ -1286,7 +1288,9 @@ const waitOnMaybe = () => {
 
   console.log('waiting on "%s"', waitOn)
 
-  return exec.exec(`npx wait-on "${waitOn}"`)
+  return io.which('npx', true).then(npxPath => {
+    return exec.exec(npxPath, ['wait-on', `"${waitOn}"`])
+  })
 }
 
 const runTests = () => {
@@ -1301,25 +1305,30 @@ const runTests = () => {
   const record = getInputBool('record')
   const parallel = getInputBool('parallel')
 
-  let cmd = 'npx cypress run'
-  if (record) {
-    cmd += ' --record'
-  }
-  if (parallel) {
-    // on GitHub Actions we can use workflow name and SHA commit to tie multiple jobs together
-    const parallelId = `${process.env.GITHUB_WORKFLOW} - ${
-      process.env.GITHUB_SHA
-    }`
-    cmd += ` --parallel --ci-build-id "${parallelId}"`
-  }
-  const group = core.getInput('group')
-  if (group) {
-    cmd += ` --group "${group}"`
-  }
-  console.log('Cypress test command: %s', cmd)
+  return io.which('npx', true).then(npxPath => {
+    const cmd = ['cypress', 'run']
+    if (record) {
+      cmd.push(' --record')
+    }
+    if (parallel) {
+      // on GitHub Actions we can use workflow name and SHA commit to tie multiple jobs together
+      const parallelId = `${process.env.GITHUB_WORKFLOW} - ${
+        process.env.GITHUB_SHA
+      }`
+      cmd.push(`--parallel`)
+      cmd.push('--ci-build-id')
+      cmd.push(`"${parallelId}"`)
+    }
+    const group = core.getInput('group')
+    if (group) {
+      cmd.push('--group')
+      cmd.push(`"${group}"`)
+    }
+    console.log('Cypress test command: npx %s', cmd.join(' '))
 
-  core.exportVariable('TERM', 'xterm')
-  return exec.exec(cmd)
+    core.exportVariable('TERM', 'xterm')
+    return exec.exec(npxPath, cmd)
+  })
 }
 
 Promise.all([restoreCachedNpm(), restoreCachedCypressBinary()])

--- a/dist/index.js
+++ b/dist/index.js
@@ -1232,7 +1232,7 @@ const install = () => {
 
     return io.which('npm', true).then(npmPath => {
       console.log('npm at "%s"', npmPath)
-      return exec.exec(npmPath, ['ci'])
+      return exec.exec(`"${npmPath}"`, ['ci'])
     })
   }
 }

--- a/dist/index.js
+++ b/dist/index.js
@@ -1165,10 +1165,6 @@ const NPM_CACHE = (() => {
     o.restoreKeys = `yarn-${platformAndArch}-`
   } else {
     o.inputPath = NPM_CACHE_FOLDER
-    o.inputPath = '~/.cache/yarn'
-    o.restoreKeys = `yarn-${platformAndArch}-`
-  } else {
-    o.inputPath = '~/.npm'
     o.restoreKeys = `npm-${platformAndArch}-`
   }
   o.primaryKey = o.restoreKeys + lockHash
@@ -1242,13 +1238,6 @@ const install = () => {
       console.log('npm at "%s"', npmPath)
       return exec.exec(quote(npmPath), ['ci'])
     })
-
-  if (useYarn) {
-    console.log('installing NPM dependencies using Yarn')
-    return exec.exec('yarn --frozen-lockfile')
-  } else {
-    console.log('installing NPM dependencies')
-    return exec.exec('npm ci')
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 // @ts-check
 const core = require('@actions/core')
 const exec = require('@actions/exec')
+const io = require('@actions/io')
 const hasha = require('hasha')
 const execa = require('execa')
 const { restoreCache, saveCache } = require('cache/lib/index')
@@ -70,10 +71,16 @@ const install = () => {
 
   if (useYarn) {
     console.log('installing NPM dependencies using Yarn')
-    return exec.exec('yarn --frozen-lockfile')
+    return io.which('yarn', true).then(yarnPath => {
+      console.log('yarn at "%s"', yarnPath)
+      return exec.exec(yarnPath, ['--frozen-lockfile'])
+    })
   } else {
     console.log('installing NPM dependencies')
-    return exec.exec('npm ci')
+    return io.which('npm', true).then(npmPath => {
+      console.log('npm at "%s"', npmPath)
+      return exec.exec(npmPath, ['ci'])
+    })
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -16,13 +16,15 @@ const lockFilename = useYarn ? 'yarn.lock' : 'package-lock.json'
 const lockHash = hasha.fromFileSync(lockFilename)
 const platformAndArch = `${process.platform}-${process.arch}`
 
+// enforce the same NPM cache folder across different operating systems
+const NPM_CACHE_FOLDER = path.join(homeDirectory, '.npm')
 const NPM_CACHE = (() => {
   const o = {}
   if (useYarn) {
     o.inputPath = path.join(homeDirectory, '.cache', 'yarn')
     o.restoreKeys = `yarn-${platformAndArch}-`
   } else {
-    o.inputPath = path.join(homeDirectory, '.npm')
+    o.inputPath = NPM_CACHE_FOLDER
     o.restoreKeys = `npm-${platformAndArch}-`
   }
   o.primaryKey = o.restoreKeys + lockHash
@@ -32,6 +34,8 @@ const NPM_CACHE = (() => {
 // custom Cypress binary cache folder
 // see https://on.cypress.io/caching
 const CYPRESS_CACHE_FOLDER = path.join(homeDirectory, '.cache', 'Cypress')
+console.log('using custom Cypress cache folder "%s"', CYPRESS_CACHE_FOLDER)
+
 const CYPRESS_BINARY_CACHE = (() => {
   const o = {
     inputPath: CYPRESS_CACHE_FOLDER,
@@ -85,6 +89,8 @@ const install = () => {
     })
   } else {
     console.log('installing NPM dependencies')
+    core.exportVariable('npm_config_cache', NPM_CACHE_FOLDER)
+
     return io.which('npm', true).then(npmPath => {
       console.log('npm at "%s"', npmPath)
       return exec.exec(npmPath, ['ci'])

--- a/index.js
+++ b/index.js
@@ -93,7 +93,7 @@ const install = () => {
 
     return io.which('npm', true).then(npmPath => {
       console.log('npm at "%s"', npmPath)
-      return exec.exec(npmPath, ['ci'])
+      return exec.exec(`"${npmPath}"`, ['ci'])
     })
   }
 }

--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ const { restoreCache, saveCache } = require('cache/lib/index')
 const fs = require('fs')
 const os = require('os')
 const path = require('path')
+const quote = require('quote')
 
 const homeDirectory = os.homedir()
 
@@ -81,11 +82,14 @@ const install = () => {
   core.exportVariable('CI', '1')
   core.exportVariable('CYPRESS_CACHE_FOLDER', CYPRESS_CACHE_FOLDER)
 
+  // Note: need to quote found tool to avoid Windows choking on
+  // npm paths with spaces like "C:\Program Files\nodejs\npm.cmd ci"
+
   if (useYarn) {
     console.log('installing NPM dependencies using Yarn')
     return io.which('yarn', true).then(yarnPath => {
       console.log('yarn at "%s"', yarnPath)
-      return exec.exec(yarnPath, ['--frozen-lockfile'])
+      return exec.exec(quote(yarnPath), ['--frozen-lockfile'])
     })
   } else {
     console.log('installing NPM dependencies')
@@ -93,7 +97,7 @@ const install = () => {
 
     return io.which('npm', true).then(npmPath => {
       console.log('npm at "%s"', npmPath)
-      return exec.exec(`"${npmPath}"`, ['ci'])
+      return exec.exec(quote(npmPath), ['ci'])
     })
   }
 }
@@ -102,7 +106,7 @@ const verifyCypressBinary = () => {
   console.log('Verifying Cypress')
   core.exportVariable('CYPRESS_CACHE_FOLDER', CYPRESS_CACHE_FOLDER)
   return io.which('npx', true).then(npxPath => {
-    return exec.exec(npxPath, ['cypress', 'verify'])
+    return exec.exec(quote(npxPath), ['cypress', 'verify'])
   })
 }
 
@@ -165,7 +169,7 @@ const waitOnMaybe = () => {
   console.log('waiting on "%s"', waitOn)
 
   return io.which('npx', true).then(npxPath => {
-    return exec.exec(npxPath, ['wait-on', `"${waitOn}"`])
+    return exec.exec(quote(npxPath), ['wait-on', quote(waitOn)])
   })
 }
 
@@ -205,7 +209,7 @@ const runTests = () => {
     console.log('Cypress test command: npx %s', cmd.join(' '))
 
     core.exportVariable('TERM', 'xterm')
-    return exec.exec(npxPath, cmd)
+    return exec.exec(quote(npxPath), cmd)
   })
 }
 

--- a/index.js
+++ b/index.js
@@ -94,6 +94,7 @@ const install = () => {
 
 const verifyCypressBinary = () => {
   console.log('Verifying Cypress')
+  core.exportVariable('CYPRESS_CACHE_FOLDER', CYPRESS_CACHE_FOLDER)
   return io.which('npx', true).then(npxPath => {
     return exec.exec(npxPath, ['cypress', 'verify'])
   })
@@ -175,6 +176,8 @@ const runTests = () => {
   const parallel = getInputBool('parallel')
 
   return io.which('npx', true).then(npxPath => {
+    core.exportVariable('CYPRESS_CACHE_FOLDER', CYPRESS_CACHE_FOLDER)
+
     const cmd = ['cypress', 'run']
     if (record) {
       cmd.push(' --record')

--- a/package-lock.json
+++ b/package-lock.json
@@ -591,6 +591,11 @@
         "once": "^1.3.1"
       }
     },
+    "quote": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/quote/-/quote-0.4.0.tgz",
+      "integrity": "sha1-EIOSF/bBNiuJGUBE0psjP9fzLwE="
+    },
     "read-pkg": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "@actions/io": "1.0.1",
     "cache": "github:cypress-io/github-actions-cache#8bec6cc",
     "execa": "3.3.0",
-    "hasha": "5.1.0"
+    "hasha": "5.1.0",
+    "quote": "0.4.0"
   },
   "devDependencies": {
     "@types/node": "^12.0.4",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "dependencies": {
     "@actions/core": "1.2.0",
     "@actions/exec": "1.0.1",
+    "@actions/io": "1.0.1",
     "cache": "github:cypress-io/github-actions-cache#8bec6cc",
     "execa": "3.3.0",
     "hasha": "5.1.0"


### PR DESCRIPTION
- closes #3 
- closes #4 

By enforcing custom NPM and Cypress caching folders across different platforms. Example build https://github.com/bahmutov/yarn-cypress-cache/commit/99d1ef534b434f2c96eea0a6859c3bb1ff78a3aa/checks?check_suite_id=308154793

```yml
jobs:
  build:

    # run test job on each OS
    strategy:
      matrix:
        os: ['ubuntu-latest', 'windows-latest', 'macos-latest']
    runs-on: ${{ matrix.os }}

    steps:
    - uses: actions/checkout@v1
    - name: Cypress run
      uses: cypress-io/github-action@0077a8c
```