### PR TITLE
feat: add cache-key parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,12 @@ jobs:
           wait-on: http://localhost:8080
 ```
 
+### More examples
+
+| Name                                                                               | Description                                                 |
+| ---------------------------------------------------------------------------------- | ----------------------------------------------------------- |
+| [cypress-gh-action-example](https://github.com/bahmutov/cypress-gh-action-example) | Uses Yarn, and runs in parallel on several versions of Node |
+
 ## Notes
 
 ### Installation

--- a/README.md
+++ b/README.md
@@ -162,7 +162,33 @@ jobs:
 Sometimes the default cache key does not work. For example, if you cannot share the Node modules across Node versions due to native extensions. In that case pass your own `cache-key` parameter.
 
 ```yml
-
+name: End-to-end tests
+on: [push]
+jobs:
+  cypress-run:
+    runs-on: ubuntu-latest
+    # let's make sure our "app" works on several versions of Node
+    strategy:
+      matrix:
+        node: [10, 12]
+    name: E2E on Node v${{ matrix.node }}
+    steps:
+      - name: Setup Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node }}
+      - name: Checkout
+        uses: actions/checkout@v1
+      # run Cypress tests and record them under the same run
+      # associated with commit SHA and just give a different group name
+      - name: Cypress run
+        uses: cypress-io/github-action@v1
+        with:
+          record: true
+          group: Tests on Node v${{ matrix.node }}
+          cache-key: node-v${{ matrix.node }}-on-${{ runner.os }}-hash-${{ hashFiles('yarn.lock') }}
+        env:
+          CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
 ```
 
 ### More examples

--- a/README.md
+++ b/README.md
@@ -157,6 +157,14 @@ jobs:
           wait-on: http://localhost:8080
 ```
 
+### Custom cache key
+
+Sometimes the default cache key does not work. For example, if you cannot share the Node modules across Node versions due to native extensions. In that case pass your own `cache-key` parameter.
+
+```yml
+
+```
+
 ### More examples
 
 | Name                                                                               | Description                                                 |

--- a/dist/index.js
+++ b/dist/index.js
@@ -1627,12 +1627,11 @@ const NPM_CACHE = (() => {
   const o = {}
   if (useYarn) {
     o.inputPath = path.join(homeDirectory, '.cache', 'yarn')
-    o.restoreKeys = `yarn-${platformAndArch}-`
+    o.restoreKeys = o.primaryKey = `yarn-${platformAndArch}-${lockHash}`
   } else {
     o.inputPath = NPM_CACHE_FOLDER
-    o.restoreKeys = `npm-${platformAndArch}-`
+    o.restoreKeys = o.primaryKey = `npm-${platformAndArch}-${lockHash}`
   }
-  o.primaryKey = o.restoreKeys + lockHash
   return o
 })()
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -1625,12 +1625,24 @@ const platformAndArch = `${process.platform}-${process.arch}`
 const NPM_CACHE_FOLDER = path.join(homeDirectory, '.npm')
 const NPM_CACHE = (() => {
   const o = {}
+  let key = core.getInput('cache-key')
+
+  if (!key) {
+    if (useYarn) {
+      key = `yarn-${platformAndArch}-${lockHash}`
+    } else {
+      key = `npm-${platformAndArch}-${lockHash}`
+    }
+  } else {
+    console.log('using custom cache key "%s"', key)
+  }
+
   if (useYarn) {
     o.inputPath = path.join(homeDirectory, '.cache', 'yarn')
-    o.restoreKeys = o.primaryKey = `yarn-${platformAndArch}-${lockHash}`
+    o.restoreKeys = o.primaryKey = key
   } else {
     o.inputPath = NPM_CACHE_FOLDER
-    o.restoreKeys = o.primaryKey = `npm-${platformAndArch}-${lockHash}`
+    o.restoreKeys = o.primaryKey = key
   }
   return o
 })()

--- a/index.js
+++ b/index.js
@@ -24,12 +24,11 @@ const NPM_CACHE = (() => {
   const o = {}
   if (useYarn) {
     o.inputPath = path.join(homeDirectory, '.cache', 'yarn')
-    o.restoreKeys = `yarn-${platformAndArch}-`
+    o.restoreKeys = o.primaryKey = `yarn-${platformAndArch}-${lockHash}`
   } else {
     o.inputPath = NPM_CACHE_FOLDER
-    o.restoreKeys = `npm-${platformAndArch}-`
+    o.restoreKeys = o.primaryKey = `npm-${platformAndArch}-${lockHash}`
   }
-  o.primaryKey = o.restoreKeys + lockHash
   return o
 })()
 

--- a/index.js
+++ b/index.js
@@ -22,12 +22,24 @@ const platformAndArch = `${process.platform}-${process.arch}`
 const NPM_CACHE_FOLDER = path.join(homeDirectory, '.npm')
 const NPM_CACHE = (() => {
   const o = {}
+  let key = core.getInput('cache-key')
+
+  if (!key) {
+    if (useYarn) {
+      key = `yarn-${platformAndArch}-${lockHash}`
+    } else {
+      key = `npm-${platformAndArch}-${lockHash}`
+    }
+  } else {
+    console.log('using custom cache key "%s"', key)
+  }
+
   if (useYarn) {
     o.inputPath = path.join(homeDirectory, '.cache', 'yarn')
-    o.restoreKeys = o.primaryKey = `yarn-${platformAndArch}-${lockHash}`
+    o.restoreKeys = o.primaryKey = key
   } else {
     o.inputPath = NPM_CACHE_FOLDER
-    o.restoreKeys = o.primaryKey = `npm-${platformAndArch}-${lockHash}`
+    o.restoreKeys = o.primaryKey = key
   }
   return o
 })()


### PR DESCRIPTION
- closes #23 

```yml
name: End-to-end tests
on: [push]
jobs:
  cypress-run:
    runs-on: ubuntu-latest
    # let's make sure our "app" works on several versions of Node
    strategy:
      matrix:
        node: [10, 12]
    name: E2E on Node v${{ matrix.node }}
    steps:
      - name: Setup Node
        uses: actions/setup-node@v1
        with:
          node-version: ${{ matrix.node }}
      - name: Checkout
        uses: actions/checkout@v1
      # run Cypress tests and record them under the same run
      # associated with commit SHA and just give a different group name
      - name: Cypress run
        uses: cypress-io/github-action@v1
        with:
          record: true
          group: Tests on Node v${{ matrix.node }}
          cache-key: node-v${{ matrix.node }}-on-${{ runner.os }}-hash-${{ hashFiles('yarn.lock') }}
        env:
          CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
```