### PR TITLE
feat: add env input - #25

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ jobs:
           env: host=api.dev.local,port=4222
 ```
 
-For more information, visit [the Cypress command-line docs](https://docs.cypress.io/guides/guides/command-line.html#cypress-run-env-lt-env-gt).
+For more information, visit [the Cypress command-line docs](https://on.cypress.io/command-line#cypress-run-env-lt-env-gt).
 
 ### Record test results on Cypress Dashboard
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,28 @@ jobs:
           browser: chrome
 ```
 
+### Env
+
+Specify the env argument with `env` parameter
+
+```yml
+name: Cypress tests
+on: [push]
+jobs:
+  cypress-run:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+
+      - name: Cypress run with env
+        uses: cypress-io/github-action@v1
+        with:
+          env: host=api.dev.local,port=4222
+```
+
+For more information, visit [the Cypress command-line docs](https://docs.cypress.io/guides/guides/command-line.html#cypress-run-env-lt-env-gt).
+
 ### Record test results on Cypress Dashboard
 
 ```yml

--- a/action.yml
+++ b/action.yml
@@ -7,6 +7,10 @@ inputs:
     description: 'Sends test results to Cypress Dashboard'
     required: false
     default: false
+  env:
+    description: 'Sets Cypress environment variables'
+    required: false
+    default: false
 runs:
   using: 'node12'
   main: 'dist/index.js'

--- a/dist/index.js
+++ b/dist/index.js
@@ -1907,6 +1907,14 @@ const runTests = () => {
       cmd.push(browser)
     }
 
+    const envInput = core.getInput('env')
+    if (envInput) {
+      // TODO should env be quoted?
+      // If it is a JSON, it might have spaces
+      cmd.push('--env')
+      cmd.push(envInput)
+    }
+
     console.log(
       'Cypress test command: npx %s',
       cmd.join(' ')

--- a/index.js
+++ b/index.js
@@ -304,6 +304,14 @@ const runTests = () => {
       cmd.push(browser)
     }
 
+    const envInput = core.getInput('env')
+    if (envInput) {
+      // TODO should env be quoted?
+      // If it is a JSON, it might have spaces
+      cmd.push('--env')
+      cmd.push(envInput)
+    }
+
     console.log(
       'Cypress test command: npx %s',
       cmd.join(' ')


### PR DESCRIPTION
* adds `env` input (closes [cypress-io/actions #25](https://github.com/cypress-io/github-action/issues/25))