### PR TITLE
feat: allow installing using "working-directory" folder parameter

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,17 +9,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v1
 
-      # caching NPM dependencies
-      # https://github.com/actions/cache/blob/master/examples.md#node---npm
-      - uses: actions/cache@v1
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
-
-      - run: node -v
-      - run: npm ci
+      - uses: bahmutov/npm-install@v1
+      - run: npm run format
+      - run: npm run build
+      - name: Detect changed files
+        run: npx stop-build
       - run: npm test
 
       # https://github.com/cycjimmy/semantic-release-action

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,6 +12,7 @@ jobs:
       - uses: bahmutov/npm-install@v1
       - run: npm run format
       - run: npm run build
+      - run: git diff
       - name: Detect changed files
         run: npx stop-build
       - run: npm test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,9 +12,6 @@ jobs:
       - uses: bahmutov/npm-install@v1
       - run: npm run format
       - run: npm run build
-      - run: git diff
-      - name: Detect changed files
-        run: npx stop-build
       - run: npm test
 
       # https://github.com/cycjimmy/semantic-release-action

--- a/README.md
+++ b/README.md
@@ -121,7 +121,6 @@ jobs:
 
 Specify [configuration](https://docs.cypress.io/guides/references/configuration.html) values with `config` parameter
 
-
 ```yml
 name: Cypress tests
 on: [push]
@@ -347,6 +346,49 @@ jobs:
 
 See [cypress-gh-action-monorepo](https://github.com/bahmutov/cypress-gh-action-monorepo) for a running example
 
+### Subfolders
+
+Sometimes Cypress and end-to-end tests have their own `package.json` file in a subfolder, like
+
+```text
+root/
+  e2e/
+    (code for installing and running Cypress tests)
+    package.json
+    package-lock.json
+    cypress.json
+    cypress
+
+  (code for running the "app" with "npm start")
+  package.json
+  yarn.lock
+```
+
+In that case you can combine this action with [bahmutov/npm-install](https://github.com/bahmutov/npm-install) action to install dependencies separately.
+
+```yml
+name: E2E
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: Install root dependencies
+        uses: bahmutov/npm-install@v1
+
+      - name: Start server in the background
+        run: npm start &
+
+      # Cypress has its own package.json in folder "e2e"
+      - name: Install Cypress and run tests
+        uses: cypress-io/github-action@v1
+        with:
+          working-directory: e2e
+```
+
+See [cypress-gh-action-subfolders](https://github.com/bahmutov/cypress-gh-action-subfolders) for example.
+
 ### Custom cache key
 
 Sometimes the default cache key does not work. For example, if you cannot share the Node modules across Node versions due to native extensions. In that case pass your own `cache-key` parameter.
@@ -412,10 +454,11 @@ See [cypress-gh-action-monorepo](https://github.com/bahmutov/cypress-gh-action-m
 
 ### More examples
 
-| Name                                                                                 | Description                                                                          |
-| ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------ |
-| [cypress-gh-action-example](https://github.com/bahmutov/cypress-gh-action-example)   | Uses Yarn, and runs in parallel on several versions of Node, also different browsers |
-| [cypress-gh-action-monorepo](https://github.com/bahmutov/cypress-gh-action-monorepo) | splits install and running tests commands, runs Cypress from sub-folder              |
+| Name                                                                                     | Description                                                                          |
+| ---------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| [cypress-gh-action-example](https://github.com/bahmutov/cypress-gh-action-example)       | Uses Yarn, and runs in parallel on several versions of Node, also different browsers |
+| [cypress-gh-action-monorepo](https://github.com/bahmutov/cypress-gh-action-monorepo)     | splits install and running tests commands, runs Cypress from sub-folder              |
+| [cypress-gh-action-subfolders](https://github.com/bahmutov/cypress-gh-action-subfolders) | separate folder for Cypress dependencies                                             |
 
 ## Notes
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -2469,7 +2469,7 @@ const lockHash = () => {
 
 // enforce the same NPM cache folder across different operating systems
 const NPM_CACHE_FOLDER = path.join(homeDirectory, '.npm')
-const NPM_CACHE = (() => {
+const getNpmCache = () => {
   const o = {}
   let key = core.getInput('cache-key')
   const hash = lockHash()
@@ -2491,7 +2491,7 @@ const NPM_CACHE = (() => {
 
   o.restoreKeys = o.primaryKey = key
   return o
-})()
+}
 
 // custom Cypress binary cache folder
 // see https://on.cypress.io/caching
@@ -2504,17 +2504,18 @@ core.debug(
   `using custom Cypress cache folder "${CYPRESS_CACHE_FOLDER}"`
 )
 
-const CYPRESS_BINARY_CACHE = (() => {
+const getCypressBinaryCache = () => {
   const o = {
     inputPath: CYPRESS_CACHE_FOLDER,
     restoreKeys: `cypress-${platformAndArch}-`
   }
   o.primaryKey = o.restoreKeys + lockHash()
   return o
-})()
+}
 
 const restoreCachedNpm = () => {
   core.debug('trying to restore cached NPM modules')
+  const NPM_CACHE = getNpmCache()
   return restoreCache(
     NPM_CACHE.inputPath,
     NPM_CACHE.primaryKey,
@@ -2524,6 +2525,7 @@ const restoreCachedNpm = () => {
 
 const saveCachedNpm = () => {
   core.debug('saving NPM modules')
+  const NPM_CACHE = getNpmCache()
   return saveCache(
     NPM_CACHE.inputPath,
     NPM_CACHE.primaryKey
@@ -2532,6 +2534,7 @@ const saveCachedNpm = () => {
 
 const restoreCachedCypressBinary = () => {
   core.debug('trying to restore cached Cypress binary')
+  const CYPRESS_BINARY_CACHE = getCypressBinaryCache()
   return restoreCache(
     CYPRESS_BINARY_CACHE.inputPath,
     CYPRESS_BINARY_CACHE.primaryKey,
@@ -2541,6 +2544,7 @@ const restoreCachedCypressBinary = () => {
 
 const saveCachedCypressBinary = () => {
   core.debug('saving Cypress binary')
+  const CYPRESS_BINARY_CACHE = getCypressBinaryCache()
   return saveCache(
     CYPRESS_BINARY_CACHE.inputPath,
     CYPRESS_BINARY_CACHE.primaryKey

--- a/dist/index.js
+++ b/dist/index.js
@@ -2435,6 +2435,8 @@ const ping = (url, timeout) => {
   })
 }
 
+const isWindows = () => os.platform() === 'win32'
+
 const homeDirectory = os.homedir()
 const platformAndArch = `${process.platform}-${process.arch}`
 
@@ -2638,7 +2640,7 @@ const buildAppMaybe = () => {
 const startServerMaybe = () => {
   let startCommand
 
-  if (os.platform() === 'win32') {
+  if (isWindows()) {
     // allow custom Windows start command
     startCommand =
       core.getInput('start-windows') ||
@@ -2712,8 +2714,7 @@ const runTests = () => {
   }
 
   core.debug('Running Cypress tests')
-  const quoteArgument =
-    os.platform() === 'win32' ? quote : I
+  const quoteArgument = isWindows() ? quote : I
 
   const record = getInputBool('record')
   const parallel = getInputBool('parallel')

--- a/dist/index.js
+++ b/dist/index.js
@@ -2408,6 +2408,10 @@ const path = __webpack_require__(622)
 const quote = __webpack_require__(531)
 const cliParser = __webpack_require__(880)()
 
+/**
+ * A small utility for checking when an URL responds, kind of
+ * a poor man's https://www.npmjs.com/package/wait-on
+ */
 const ping = (url, timeout) => {
   const start = +new Date()
   return got(url, {
@@ -2433,10 +2437,30 @@ const ping = (url, timeout) => {
 
 const homeDirectory = os.homedir()
 
-const useYarn = fs.existsSync('yarn.lock')
+const workingDirectory =
+  core.getInput('working-directory') || process.cwd()
+
+/**
+ * When running "npm install" or any other Cypress-related commands,
+ * use the install directory as current working directory
+ */
+const cypressCommandOptions = {
+  cwd: workingDirectory
+}
+
+const yarnFilename = path.join(
+  workingDirectory,
+  'yarn.lock'
+)
+const packageLockFilename = path.join(
+  workingDirectory,
+  'package-lock.json'
+)
+
+const useYarn = fs.existsSync(yarnFilename)
 const lockFilename = useYarn
-  ? 'yarn.lock'
-  : 'package-lock.json'
+  ? yarnFilename
+  : packageLockFilename
 const lockHash = hasha.fromFileSync(lockFilename)
 const platformAndArch = `${process.platform}-${process.arch}`
 
@@ -2535,9 +2559,11 @@ const install = () => {
     core.debug('installing NPM dependencies using Yarn')
     return io.which('yarn', true).then(yarnPath => {
       core.debug(`yarn at "${yarnPath}"`)
-      return exec.exec(quote(yarnPath), [
-        '--frozen-lockfile'
-      ])
+      return exec.exec(
+        quote(yarnPath),
+        ['--frozen-lockfile'],
+        cypressCommandOptions
+      )
     })
   } else {
     core.debug('installing NPM dependencies')
@@ -2548,7 +2574,11 @@ const install = () => {
 
     return io.which('npm', true).then(npmPath => {
       core.debug(`npm at "${npmPath}"`)
-      return exec.exec(quote(npmPath), ['ci'])
+      return exec.exec(
+        quote(npmPath),
+        ['ci'],
+        cypressCommandOptions
+      )
     })
   }
 }
@@ -2560,7 +2590,11 @@ const verifyCypressBinary = () => {
     CYPRESS_CACHE_FOLDER
   )
   return io.which('npx', true).then(npxPath => {
-    return exec.exec(quote(npxPath), ['cypress', 'verify'])
+    return exec.exec(
+      quote(npxPath),
+      ['cypress', 'verify'],
+      cypressCommandOptions
+    )
   })
 }
 
@@ -2590,6 +2624,7 @@ const buildAppMaybe = () => {
 
   core.debug(`building application using "${buildApp}"`)
 
+  // TODO: allow specifying custom working folder?
   return exec.exec(buildApp)
 }
 
@@ -2633,6 +2668,7 @@ const startServerMaybe = () => {
     )
     core.debug('without waiting for the promise to resolve')
 
+    // TODO specify working directory when running the server?
     exec.exec(quote(toolPath), toolArguments)
   })
 }
@@ -2740,19 +2776,15 @@ const runTests = () => {
 
     core.exportVariable('TERM', 'xterm')
     // since we have quoted arguments ourselves, do not double quote them
-    const options = {
+    const opts = {
+      ...cypressCommandOptions,
       windowsVerbatimArguments: false
     }
-    const workingDirectory = core.getInput(
-      'working-directory'
+
+    core.debug(
+      `in working directory "${cypressCommandOptions.workingDirectory}"`
     )
-    if (workingDirectory) {
-      options.cwd = workingDirectory
-      core.debug(
-        `in working directory "${workingDirectory}"`
-      )
-    }
-    return exec.exec(quote(npxPath), cmd, options)
+    return exec.exec(quote(npxPath), cmd, opts)
   })
 }
 

--- a/index.js
+++ b/index.js
@@ -75,7 +75,7 @@ const lockHash = () => {
 
 // enforce the same NPM cache folder across different operating systems
 const NPM_CACHE_FOLDER = path.join(homeDirectory, '.npm')
-const NPM_CACHE = (() => {
+const getNpmCache = () => {
   const o = {}
   let key = core.getInput('cache-key')
   const hash = lockHash()
@@ -97,7 +97,7 @@ const NPM_CACHE = (() => {
 
   o.restoreKeys = o.primaryKey = key
   return o
-})()
+}
 
 // custom Cypress binary cache folder
 // see https://on.cypress.io/caching
@@ -110,17 +110,18 @@ core.debug(
   `using custom Cypress cache folder "${CYPRESS_CACHE_FOLDER}"`
 )
 
-const CYPRESS_BINARY_CACHE = (() => {
+const getCypressBinaryCache = () => {
   const o = {
     inputPath: CYPRESS_CACHE_FOLDER,
     restoreKeys: `cypress-${platformAndArch}-`
   }
   o.primaryKey = o.restoreKeys + lockHash()
   return o
-})()
+}
 
 const restoreCachedNpm = () => {
   core.debug('trying to restore cached NPM modules')
+  const NPM_CACHE = getNpmCache()
   return restoreCache(
     NPM_CACHE.inputPath,
     NPM_CACHE.primaryKey,
@@ -130,6 +131,7 @@ const restoreCachedNpm = () => {
 
 const saveCachedNpm = () => {
   core.debug('saving NPM modules')
+  const NPM_CACHE = getNpmCache()
   return saveCache(
     NPM_CACHE.inputPath,
     NPM_CACHE.primaryKey
@@ -138,6 +140,7 @@ const saveCachedNpm = () => {
 
 const restoreCachedCypressBinary = () => {
   core.debug('trying to restore cached Cypress binary')
+  const CYPRESS_BINARY_CACHE = getCypressBinaryCache()
   return restoreCache(
     CYPRESS_BINARY_CACHE.inputPath,
     CYPRESS_BINARY_CACHE.primaryKey,
@@ -147,6 +150,7 @@ const restoreCachedCypressBinary = () => {
 
 const saveCachedCypressBinary = () => {
   core.debug('saving Cypress binary')
+  const CYPRESS_BINARY_CACHE = getCypressBinaryCache()
   return saveCache(
     CYPRESS_BINARY_CACHE.inputPath,
     CYPRESS_BINARY_CACHE.primaryKey

--- a/index.js
+++ b/index.js
@@ -41,6 +41,8 @@ const ping = (url, timeout) => {
   })
 }
 
+const isWindows = () => os.platform() === 'win32'
+
 const homeDirectory = os.homedir()
 const platformAndArch = `${process.platform}-${process.arch}`
 
@@ -244,7 +246,7 @@ const buildAppMaybe = () => {
 const startServerMaybe = () => {
   let startCommand
 
-  if (os.platform() === 'win32') {
+  if (isWindows()) {
     // allow custom Windows start command
     startCommand =
       core.getInput('start-windows') ||
@@ -318,8 +320,7 @@ const runTests = () => {
   }
 
   core.debug('Running Cypress tests')
-  const quoteArgument =
-    os.platform() === 'win32' ? quote : I
+  const quoteArgument = isWindows() ? quote : I
 
   const record = getInputBool('record')
   const parallel = getInputBool('parallel')

--- a/index.js
+++ b/index.js
@@ -42,6 +42,7 @@ const ping = (url, timeout) => {
 }
 
 const homeDirectory = os.homedir()
+const platformAndArch = `${process.platform}-${process.arch}`
 
 const workingDirectory =
   core.getInput('working-directory') || process.cwd()
@@ -63,30 +64,32 @@ const packageLockFilename = path.join(
   'package-lock.json'
 )
 
-const useYarn = fs.existsSync(yarnFilename)
-const lockFilename = useYarn
-  ? yarnFilename
-  : packageLockFilename
-const lockHash = hasha.fromFileSync(lockFilename)
-const platformAndArch = `${process.platform}-${process.arch}`
+const useYarn = () => fs.existsSync(yarnFilename)
+
+const lockHash = () => {
+  const lockFilename = useYarn()
+    ? yarnFilename
+    : packageLockFilename
+  return hasha.fromFileSync(lockFilename)
+}
 
 // enforce the same NPM cache folder across different operating systems
 const NPM_CACHE_FOLDER = path.join(homeDirectory, '.npm')
 const NPM_CACHE = (() => {
   const o = {}
   let key = core.getInput('cache-key')
-
+  const hash = lockHash()
   if (!key) {
-    if (useYarn) {
-      key = `yarn-${platformAndArch}-${lockHash}`
+    if (useYarn()) {
+      key = `yarn-${platformAndArch}-${hash}`
     } else {
-      key = `npm-${platformAndArch}-${lockHash}`
+      key = `npm-${platformAndArch}-${hash}`
     }
   } else {
     console.log('using custom cache key "%s"', key)
   }
 
-  if (useYarn) {
+  if (useYarn()) {
     o.inputPath = path.join(homeDirectory, '.cache', 'yarn')
   } else {
     o.inputPath = NPM_CACHE_FOLDER
@@ -112,7 +115,7 @@ const CYPRESS_BINARY_CACHE = (() => {
     inputPath: CYPRESS_CACHE_FOLDER,
     restoreKeys: `cypress-${platformAndArch}-`
   }
-  o.primaryKey = o.restoreKeys + lockHash
+  o.primaryKey = o.restoreKeys + lockHash()
   return o
 })()
 
@@ -161,7 +164,7 @@ const install = () => {
   // Note: need to quote found tool to avoid Windows choking on
   // npm paths with spaces like "C:\Program Files\nodejs\npm.cmd ci"
 
-  if (useYarn) {
+  if (useYarn()) {
     core.debug('installing NPM dependencies using Yarn')
     return io.which('yarn', true).then(yarnPath => {
       core.debug(`yarn at "${yarnPath}"`)

--- a/package-lock.json
+++ b/package-lock.json
@@ -96,6 +96,34 @@
         "debug": "^2.2.0"
       }
     },
+    "asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
+      "dev": true
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "bluebird": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
+      "integrity": "sha1-eRQg1/VR7qKJdFOop3ZT+WYG1nw=",
+      "dev": true
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
     "cache": {
       "version": "github:cypress-io/github-actions-cache#8bec6cc5864287529104deeda5b838244fc5f332",
       "from": "github:cypress-io/github-actions-cache#8bec6cc",
@@ -163,11 +191,67 @@
         "supports-color": "^5.3.0"
       }
     },
+    "chdir-promise": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/chdir-promise/-/chdir-promise-0.4.0.tgz",
+      "integrity": "sha1-RtxgLtGTGXRwFA8VJFmkOCz3mXQ=",
+      "dev": true,
+      "requires": {
+        "check-more-types": "2.23.0",
+        "debug": "^2.3.3",
+        "lazy-ass": "1.5.0",
+        "q": "1.1.2",
+        "spots": "0.4.0"
+      },
+      "dependencies": {
+        "check-more-types": {
+          "version": "2.23.0",
+          "resolved": "https://registry.npmjs.org/check-more-types/-/check-more-types-2.23.0.tgz",
+          "integrity": "sha1-YiYmTTCxCVqhwKW4dO291dLQpm8=",
+          "dev": true
+        },
+        "lazy-ass": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/lazy-ass/-/lazy-ass-1.5.0.tgz",
+          "integrity": "sha1-yhW+JDx8R1uFZc2/oPnC83TyoB0=",
+          "dev": true
+        },
+        "q": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/q/-/q-1.1.2.tgz",
+          "integrity": "sha1-Y1fikSBnAdmfGXq4TlforRlvKok=",
+          "dev": true
+        }
+      }
+    },
+    "check-more-types": {
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/check-more-types/-/check-more-types-2.24.0.tgz",
+      "integrity": "sha1-FCD/sQ/URNz8ebQ4kbv//TKoRgA=",
+      "dev": true
+    },
     "ci-info": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
       "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
       "dev": true
+    },
+    "cli-table": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz",
+      "integrity": "sha1-9TsFJmqLGguTSz0IIebi3FkUriM=",
+      "dev": true,
+      "requires": {
+        "colors": "1.0.3"
+      },
+      "dependencies": {
+        "colors": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+          "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
+          "dev": true
+        }
+      }
     },
     "clone-response": {
       "version": "1.0.2",
@@ -192,6 +276,27 @@
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
+    "colors": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
+      "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
+      "dev": true
+    },
+    "commander": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+      "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+      "dev": true,
+      "requires": {
+        "graceful-readlink": ">= 1.0.0"
+      }
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
     "cosmiconfig": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.2.1.tgz",
@@ -213,6 +318,12 @@
         "shebang-command": "^2.0.0",
         "which": "^2.0.1"
       }
+    },
+    "d3-helpers": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/d3-helpers/-/d3-helpers-0.3.0.tgz",
+      "integrity": "sha1-SzHc5KISGnczY4RXTYk/vtX7KT0=",
+      "dev": true
     },
     "debug": {
       "version": "2.6.9",
@@ -302,6 +413,12 @@
         "path-exists": "^4.0.0"
       }
     },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
     "get-stdin": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-7.0.0.tgz",
@@ -314,6 +431,61 @@
       "integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
       "requires": {
         "pump": "^3.0.0"
+      }
+    },
+    "ggit": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/ggit/-/ggit-1.15.1.tgz",
+      "integrity": "sha1-gNVS6OFxLJgF/luhzxGaTn472Zg=",
+      "dev": true,
+      "requires": {
+        "bluebird": "3.5.0",
+        "chdir-promise": "0.4.0",
+        "check-more-types": "2.24.0",
+        "cli-table": "0.3.1",
+        "colors": "1.1.2",
+        "commander": "2.9.0",
+        "d3-helpers": "0.3.0",
+        "debug": "2.6.3",
+        "glob": "7.1.1",
+        "lazy-ass": "1.6.0",
+        "lodash": "3.10.1",
+        "moment": "2.18.1",
+        "optimist": "0.6.1",
+        "q": "2.0.3",
+        "quote": "0.4.0",
+        "ramda": "0.9.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.3.tgz",
+          "integrity": "sha1-D364wwll7AjHKsz6ATDIt5mEFB0=",
+          "dev": true,
+          "requires": {
+            "ms": "0.7.2"
+          }
+        },
+        "ms": {
+          "version": "0.7.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+          "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U=",
+          "dev": true
+        }
+      }
+    },
+    "glob": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+      "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.2",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
     "got": {
@@ -343,6 +515,12 @@
           }
         }
       }
+    },
+    "graceful-readlink": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
+      "dev": true
     },
     "has-flag": {
       "version": "3.0.0",
@@ -494,6 +672,22 @@
         "resolve-from": "^3.0.0"
       }
     },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -551,6 +745,12 @@
         "json-buffer": "3.0.0"
       }
     },
+    "lazy-ass": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/lazy-ass/-/lazy-ass-1.6.0.tgz",
+      "integrity": "sha1-eZllXoZGwX8In90YfRUNMyTVRRM=",
+      "dev": true
+    },
     "lines-and-columns": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
@@ -565,6 +765,12 @@
       "requires": {
         "p-locate": "^4.1.0"
       }
+    },
+    "lodash": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+      "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
+      "dev": true
     },
     "lowercase-keys": {
       "version": "1.0.1",
@@ -585,6 +791,27 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
       "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ=="
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "minimist": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+      "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
+      "dev": true
+    },
+    "moment": {
+      "version": "2.18.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.18.1.tgz",
+      "integrity": "sha1-w2GT3Tzhwu7SrbfIAtu8d6gbHA8=",
+      "dev": true
     },
     "ms": {
       "version": "2.0.0",
@@ -644,6 +871,16 @@
       "integrity": "sha512-pVOEP16TrAO2/fjej1IdOyupJY8KDUM1CvsaScRbw6oddvpQoOfGk4ywha0HKKVAD6RkW4x6Q+tNBwhf3Bgpuw==",
       "dev": true
     },
+    "optimist": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+      "dev": true,
+      "requires": {
+        "minimist": "~0.0.1",
+        "wordwrap": "~0.0.2"
+      }
+    },
     "p-cancelable": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-1.1.0.tgz",
@@ -694,6 +931,12 @@
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
       "dev": true
     },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
     "path-key": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.0.tgz",
@@ -723,6 +966,18 @@
         "semver-compare": "^1.0.0"
       }
     },
+    "pluralize": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-5.0.0.tgz",
+      "integrity": "sha1-6LkHOvmgywLkwu+pW1W+u9vwEpk=",
+      "dev": true
+    },
+    "pop-iterate": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pop-iterate/-/pop-iterate-1.0.1.tgz",
+      "integrity": "sha1-zqz9q0q/NT16DyqqLB/Hs/lBO6M=",
+      "dev": true
+    },
     "prepend-http": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
@@ -743,10 +998,27 @@
         "once": "^1.3.1"
       }
     },
+    "q": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/q/-/q-2.0.3.tgz",
+      "integrity": "sha1-dbjbAlWhpa+C9Yw/Oqoe/sfQ0TQ=",
+      "dev": true,
+      "requires": {
+        "asap": "^2.0.0",
+        "pop-iterate": "^1.0.1",
+        "weak-map": "^1.0.5"
+      }
+    },
     "quote": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/quote/-/quote-0.4.0.tgz",
       "integrity": "sha1-EIOSF/bBNiuJGUBE0psjP9fzLwE="
+    },
+    "ramda": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.9.1.tgz",
+      "integrity": "sha1-zJFNw6gsYI0AMJAgN4fD9oJsHYc=",
+      "dev": true
     },
     "read-pkg": {
       "version": "5.2.0",
@@ -877,11 +1149,27 @@
       "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
       "dev": true
     },
+    "spots": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/spots/-/spots-0.4.0.tgz",
+      "integrity": "sha1-Ae7F78FDZp2dOiDj7si4y9mELfY=",
+      "dev": true
+    },
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
+    },
+    "stop-build": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/stop-build/-/stop-build-1.1.0.tgz",
+      "integrity": "sha1-BqexnZmKQ27TqLvpbI+zQekQab4=",
+      "dev": true,
+      "requires": {
+        "ggit": "1.15.1",
+        "pluralize": "5.0.0"
+      }
     },
     "strip-eof": {
       "version": "1.0.0",
@@ -955,6 +1243,12 @@
         "spdx-expression-parse": "^3.0.0"
       }
     },
+    "weak-map": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/weak-map/-/weak-map-1.0.5.tgz",
+      "integrity": "sha1-eWkVhNmGB/UHC9O3CkDmuyLkAes=",
+      "dev": true
+    },
     "which": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.1.tgz",
@@ -962,6 +1256,12 @@
       "requires": {
         "isexe": "^2.0.0"
       }
+    },
+    "wordwrap": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+      "dev": true
     },
     "wrappy": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "@types/node": "^12.0.4",
     "@zeit/ncc": "0.20.5",
     "husky": "3.0.9",
-    "prettier": "1.19.1"
+    "prettier": "1.19.1",
+    "stop-build": "1.1.0"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Installing dependencies should take into account "working-directory" parameter
- closes #46 

If your project structure is

```text
root/
  e2e/
    (code for installing and running Cypress tests)
    package.json
    package-lock.json
    cypress.json
    cypress

  (code for running the "app" with "npm start")
  package.json
  yarn.lock
```

Then this works

```yml
name: E2E
on: push
jobs:
  test:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@master
      - name: Install root dependencies
        uses: bahmutov/npm-install@v1

      - name: Start server in the background
        run: npm start &

      # Cypress has its own package.json in folder "e2e"
      - name: Install Cypress and run tests
        uses: cypress-io/github-action@4e415ee
        with:
          working-directory: e2e
```

See https://github.com/bahmutov/cypress-gh-action-subfolders