### PR TITLE
fix: move ping logs to debug mode

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ const ping = (url, timeout) => {
     retry: {
       retries(retry, error) {
         const now = +new Date()
-        console.error(
+        core.debug(
           now - start,
           'ms',
           error.method,

--- a/index.js
+++ b/index.js
@@ -25,11 +25,9 @@ const ping = (url, timeout) => {
       retries(retry, error) {
         const now = +new Date()
         core.debug(
-          now - start,
-          'ms',
-          error.method,
-          error.host,
-          error.code
+          `${now - start}ms ${error.method} ${error.host} ${
+            error.code
+          }`
         )
         if (now - start > timeout) {
           console.error('%s timed out', url)


### PR DESCRIPTION
This only moves the pinging to debug, otherwise leaves the timeout and the initialisation of `wait-on` as console outputs.

Also, instead of adding a flag to `wait-on` I figured it made more sense to use the default debug variable.

Fixes #45 