### PR TITLE
use Chrome window size 1920,1080

### DIFF
--- a/.github/workflows/example-chrome.yml
+++ b/.github/workflows/example-chrome.yml
@@ -32,6 +32,11 @@ jobs:
           name: screenshots-in-chrome
           path: examples/chrome/cypress/screenshots
 
+      - uses: actions/upload-artifact@v1
+        with:
+          name: video-in-chrome
+          path: examples/chrome/cypress/video
+
       - run: npx image-size cypress/screenshots/**/*.png
         working-directory: examples/chrome
 
@@ -46,6 +51,11 @@ jobs:
         with:
           name: screenshots-in-headless-chrome
           path: examples/chrome/cypress/screenshots
+
+      - uses: actions/upload-artifact@v1
+        with:
+          name: video-in-headless-chrome
+          path: examples/chrome/cypress/video
 
       - run: npx image-size cypress/screenshots/**/*.png
         working-directory: examples/chrome

--- a/.github/workflows/example-chrome.yml
+++ b/.github/workflows/example-chrome.yml
@@ -35,10 +35,15 @@ jobs:
       - uses: actions/upload-artifact@v1
         with:
           name: video-in-chrome
-          path: examples/chrome/cypress/video
+          path: examples/chrome/cypress/videos
 
       - run: npx image-size cypress/screenshots/**/*.png
         working-directory: examples/chrome
+
+      # I wonder if GH Actions VM includes any of the tools that
+      # can tell us the resolution of a video file
+      - run: ffprobe cypress/videos/*.mp4 || true
+      - run: mplayer -really-quiet -ao null -vo null -identify -frames 0 cypress/videos/*.mp4 || true
 
       - name: Chrome headless
         uses: ./
@@ -55,7 +60,7 @@ jobs:
       - uses: actions/upload-artifact@v1
         with:
           name: video-in-headless-chrome
-          path: examples/chrome/cypress/video
+          path: examples/chrome/cypress/videos
 
       - run: npx image-size cypress/screenshots/**/*.png
         working-directory: examples/chrome

--- a/examples/chrome/cypress/integration/spec.js
+++ b/examples/chrome/cypress/integration/spec.js
@@ -9,4 +9,14 @@ it('works', () => {
   // you can take the screenshot of the entire page
   // which will be stitched into one tall image
   cy.screenshot('fullPage', { capture: 'fullPage' })
+
+  // log the top window's dimensions
+  const resolution = Cypress._.pick(top, [
+    'innerWidth',
+    'innerHeight'
+  ])
+  cy.task(
+    'log',
+    `top window inner w, h is ${resolution.innerWidth}x${resolution.innerHeight}`
+  )
 })

--- a/examples/chrome/cypress/plugins/index.js
+++ b/examples/chrome/cypress/plugins/index.js
@@ -13,4 +13,11 @@ module.exports = on => {
       return launchOptions
     }
   })
+
+  on('task', {
+    log(message) {
+      console.log(message)
+      return null
+    }
+  })
 }

--- a/examples/chrome/cypress/plugins/index.js
+++ b/examples/chrome/cypress/plugins/index.js
@@ -6,7 +6,7 @@ module.exports = on => {
 
     if (browser.name === 'chrome') {
       // https://www.ghacks.net/2013/10/06/list-useful-google-chrome-command-line-switches/
-      launchOptions.args.push('--window-size=1280,1024')
+      launchOptions.args.push('--window-size=1920,1080')
 
       console.log('chrome launch args:')
       console.log(launchOptions.args.join(os.EOL))


### PR DESCRIPTION
- closes #88 

Hmm, for a while I thought the user would need to spin their own Xvfb server with custom parameters like this to get higher resolution screen

```
xvfb-run --server-args="-screen 0 1920x1080x24" cypress run --browser chrome --headless
```

But when I tried the simplest solution it worked: run Cypress as before and just pass the flag in the plugin to tell Chrome to use the larger resolution
```js
module.exports = on => {
  on('before:browser:launch', (browser, launchOptions) => {
    if (browser.name === 'chrome') {
      // https://www.ghacks.net/2013/10/06/list-useful-google-chrome-command-line-switches/
      launchOptions.args.push('--window-size=1920,1080')
      return launchOptions
    }
  })
}
```

The produced images are 1920x1020 (or similar without the top bar) for the runner, see https://github.com/cypress-io/github-action/actions/runs/42146060

```
Run npx image-size cypress/screenshots/**/*.png
1000x4823 - cypress/screenshots/spec.js/fullPage.png (png)
1920x1080 - cypress/screenshots/spec.js/runner.png (png)
1000x660 - cypress/screenshots/spec.js/viewport.png (png)
```

![runner](https://user-images.githubusercontent.com/2212006/74896398-2d4ad200-5362-11ea-9f4f-de9cb3dcc97c.png)
