### PR TITLE
Use npm i, instead of npm ci

### DIFF
--- a/index.js
+++ b/index.js
@@ -212,7 +212,7 @@ const install = () => {
 
     return io.which('npm', true).then(npmPath => {
       core.debug(`npm at "${npmPath}"`)
-      return exec.exec(quote(npmPath), ['ci'], cypressCommandOptions)
+      return exec.exec(quote(npmPath), ['i'], cypressCommandOptions)
     })
   }
 }


### PR DESCRIPTION
Fixes https://github.com/cypress-io/github-action/issues/136

According to https://github.com/npm/cli/issues/558#issuecomment-586452997 it should be safe to utilize `npm i` in place of `npm ci` nowadays. Also, if you don't, and you're using `fsevents` (so anyone developing on a mac), you will get random failures by using `npm ci`.

I do believe that `npm ci` is the correct thing for this action to use, but until npm and/or fsevents fixes this, replacing `npm ci` with `npm i` is the only way to ensure this action runs properly.