### PR TITLE
fix: add missing spec input to action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -50,6 +50,9 @@ inputs:
   headless:
     description: 'Whether or not to use headless mode'
     required: false
+  spec:
+    description: 'Provide a specific specs to run'
+    required: false
 runs:
   using: 'node12'
   main: 'dist/index.js'


### PR DESCRIPTION
Add missing spec input to action.yml to prevent warnings in console log as on screenshot below: 

<img width="847" alt="Screenshot 2020-05-27 at 09 31 47" src="https://user-images.githubusercontent.com/34001198/82991550-23d6a300-9ffe-11ea-83d1-080936dde193.png">
