### PR TITLE
feat: add project input

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,28 @@ jobs:
 
 For more information, visit [the Cypress command-line docs](https://on.cypress.io/command-line#cypress-run-env-lt-env-gt).
 
+### Project
+
+Specify the [project to run](https://docs.cypress.io/guides/guides/command-line.html#cypress-run-project-lt-project-path-gt) with `project` parameter
+
+```yml
+name: Cypress tests
+on: [push]
+jobs:
+  cypress-run:
+    name: Cypress run
+    runs-on: ubuntu-16.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: Cypress run
+        uses: cypress-io/github-action@v1
+        with:
+          project: ./some/nested/folder
+```
+
+For more information, visit [the Cypress command-line docs](https://on.cypress.io/command-line#cypress-run-project-lt-project-path-gt).
+
 ### Record test results on Cypress Dashboard
 
 ```yml

--- a/action.yml
+++ b/action.yml
@@ -53,6 +53,9 @@ inputs:
   spec:
     description: 'Provide a specific specs to run'
     required: false
+  project:
+    description: 'Path of project to run'
+    required: false
 runs:
   using: 'node12'
   main: 'dist/index.js'

--- a/dist/index.js
+++ b/dist/index.js
@@ -6648,6 +6648,11 @@ const runTests = async () => {
     cmd.push('--spec')
     cmd.push(quoteArgument(spec))
   }
+  const project = core.getInput('project')
+  if (project) {
+    cmd.push('--project')
+    cmd.push(quoteArgument(project))
+  }
   const configFileInput = core.getInput('config-file')
   if (configFileInput) {
     cmd.push('--config-file')

--- a/index.js
+++ b/index.js
@@ -365,6 +365,11 @@ const runTests = async () => {
     cmd.push('--spec')
     cmd.push(quoteArgument(spec))
   }
+  const project = core.getInput('project')
+  if (project) {
+    cmd.push('--project')
+    cmd.push(quoteArgument(project))
+  }
   const configFileInput = core.getInput('config-file')
   if (configFileInput) {
     cmd.push('--config-file')


### PR DESCRIPTION
* Adds input for `project` cli option [documented here](https://docs.cypress.io/guides/guides/command-line.html#cypress-run-project-lt-project-path-gt) to allow for running tests within a project folder