### PR TITLE
feat: export dashboard url from the action

### DIFF
--- a/.github/workflows/example-recording.yml
+++ b/.github/workflows/example-recording.yml
@@ -30,5 +30,5 @@ jobs:
 
       - name: Print Dashboard URL
         run: |
-          echo Cypress finished with ${{ steps.cypress.outcome }}
-          echo See results at ${{ steps.cypress.dashboardUrl }}
+          echo Cypress finished with: ${{ steps.cypress.outcome }}
+          echo See results at ${{ steps.cypress.outputs.dashboardUrl }}

--- a/.github/workflows/example-recording.yml
+++ b/.github/workflows/example-recording.yml
@@ -11,6 +11,12 @@ jobs:
         # normally you would write
         # uses: cypress-io/github-action@v2
         uses: ./
+        # let's give this action an ID so we can refer
+        # to its output values later
+        id: cypress
+        # Continue the build in case of an error, as we need to set the
+        # commit status in the next step, both in case of success and failure
+        continue-on-error: true
         with:
           working-directory: examples/recording
           record: true
@@ -21,3 +27,8 @@ jobs:
           # pass the Dashboard record key as an environment variable
           CYPRESS_RECORD_KEY: ${{ secrets.EXAMPLE_RECORDING_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Print Dashboard URL
+        run: |
+          echo Cypress finished with ${{ steps.cypress.outcome }}
+          echo See results at ${{ steps.cypress.dashboardUrl }}

--- a/README.md
+++ b/README.md
@@ -781,6 +781,33 @@ Read [DEVELOPMENT.md](DEVELOPMENT.md)
 
 ## Extras
 
+### Outputs
+
+This GH Action sets an output `dashboardUrl` if the run was recorded on [Cypress Dashboard](https://on.cypress.io/dashboard-introduction), see [action.yml](action.yml). To use this output:
+
+```yml
+- name: Cypress tests
+  uses: cypress-io/github-action@v2
+  # let's give this action an ID so we can refer
+  # to its output values later
+  id: cypress
+  # Continue the build in case of an error, as we need to set the
+  # commit status in the next step, both in case of success and failure
+  continue-on-error: true
+  with:
+    record: true
+  env:
+    CYPRESS_RECORD_KEY: ${{ secrets.RECORDING_KEY }}
+- name: Print Dashboard URL
+  run: |
+    echo Cypress finished with: ${{ steps.cypress.outcome }}
+    echo See results at ${{ steps.cypress.outputs.dashboardUrl }}
+```
+
+[![recording example](https://github.com/cypress-io/github-action/workflows/example-recording/badge.svg?branch=master)](.github/workflows/example-recording.yml)
+
+### Docker image
+
 If your repository does not have `package.json` or `yarn.json` (maybe it contains a static site and does not need any dependencies), you can run Cypress tests using `cypress/included:...` [Cypress Docker images](https://github.com/cypress-io/cypress-docker-images/tree/master/included). In that case you don't even need this GH Action, instead use the Docker container and write `cypress run` command like this example from [cypress-gh-action-included](https://github.com/bahmutov/cypress-gh-action-included)
 
 ```yml

--- a/action.yml
+++ b/action.yml
@@ -74,6 +74,9 @@ inputs:
   cache-key:
     description: 'Custom cache key'
     required: false
+outputs:
+  dashboardUrl:
+    description: 'Cypress Dashboard URL if the run was recorded'
 runs:
   using: 'node12'
   main: 'dist/index.js'

--- a/dist/index.js
+++ b/dist/index.js
@@ -6141,6 +6141,11 @@ const runTests = async () => {
     }
 
     core.debug(`Cypress tests: ${testResults.totalFailed} failed`)
+
+    const dashboardUrl = testResults.runUrl
+    core.debug(`Dashboard url ${dashboardUrl}`)
+    core.setOutput('dashboardUrl', dashboardUrl)
+
     return testResults.totalFailed
   }
 

--- a/index.js
+++ b/index.js
@@ -564,6 +564,11 @@ const runTests = async () => {
     }
 
     core.debug(`Cypress tests: ${testResults.totalFailed} failed`)
+
+    const dashboardUrl = testResults.runUrl
+    core.debug(`Dashboard url ${dashboardUrl}`)
+    core.setOutput('dashboardUrl', dashboardUrl)
+
     return testResults.totalFailed
   }
 


### PR DESCRIPTION
- closes #150 
setting output via https://github.com/actions/toolkit/tree/master/packages/core#inputsoutputs

Typical use case

```yml
- name: Cypress tests
  uses: cypress-io/github-action@v2
  # let's give this action an ID so we can refer
  # to its output values later
  id: cypress
  # Continue the build in case of an error, as we need to set the
  # commit status in the next step, both in case of success and failure
  continue-on-error: true
  with:
    record: true
  env:
    CYPRESS_RECORD_KEY: ${{ secrets.RECORDING_KEY }}
- name: Print Dashboard URL
  run: |
    echo Cypress finished with: ${{ steps.cypress.outcome }}
    echo See results at ${{ steps.cypress.outputs.dashboardUrl }}
```
