### PR TITLE
fix: ignore restore cache error

### DIFF
--- a/index.js
+++ b/index.js
@@ -159,7 +159,9 @@ const restoreCachedNpm = () => {
   const NPM_CACHE = getNpmCache()
   return restoreCache([NPM_CACHE.inputPath], NPM_CACHE.primaryKey, [
     NPM_CACHE.restoreKeys
-  ])
+  ]).catch(e => {
+    console.warn('Restoring NPM cache error: %s', e.message)
+  })
 }
 
 const saveCachedNpm = () => {
@@ -179,7 +181,9 @@ const restoreCachedCypressBinary = () => {
     [CYPRESS_BINARY_CACHE.inputPath],
     CYPRESS_BINARY_CACHE.primaryKey,
     [CYPRESS_BINARY_CACHE.restoreKeys]
-  )
+  ).catch(e => {
+    console.warn('Restoring Cypress cache error: %s', e.message)
+  })
 }
 
 const saveCachedCypressBinary = () => {


### PR DESCRIPTION
- closes #212

Catches cache restore errors and just prints a warning, rather than failing the job. Tested in https://github.com/bahmutov/eleventy-example/pull/10