### PR TITLE
fix: list Cypress cached versions after install

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -7332,8 +7332,24 @@ const install = () => {
   }
 }
 
+const listCypressBinaries = () => {
+  core.debug(
+    `Cypress versions in the cache folder ${CYPRESS_CACHE_FOLDER}`
+  )
+  core.exportVariable('CYPRESS_CACHE_FOLDER', CYPRESS_CACHE_FOLDER)
+  return io.which('npx', true).then(npxPath => {
+    return exec.exec(
+      quote(npxPath),
+      ['cypress', 'cache', 'list'],
+      cypressCommandOptions
+    )
+  })
+}
+
 const verifyCypressBinary = () => {
-  core.debug('Verifying Cypress')
+  core.debug(
+    `Verifying Cypress using cache folder ${CYPRESS_CACHE_FOLDER}`
+  )
   core.exportVariable('CYPRESS_CACHE_FOLDER', CYPRESS_CACHE_FOLDER)
   return io.which('npx', true).then(npxPath => {
     return exec.exec(
@@ -7750,14 +7766,18 @@ const installMaybe = () => {
     core.debug(`cypress cache hit ${cypressCacheHit}`)
 
     return install().then(() => {
-      if (npmCacheHit && cypressCacheHit) {
-        core.debug('no need to verify Cypress binary or save caches')
-        return Promise.resolve(undefined)
-      }
+      return listCypressBinaries().then(() => {
+        if (npmCacheHit && cypressCacheHit) {
+          core.debug(
+            'no need to verify Cypress binary or save caches'
+          )
+          return Promise.resolve(undefined)
+        }
 
-      return verifyCypressBinary()
-        .then(saveCachedNpm)
-        .then(saveCachedCypressBinary)
+        return verifyCypressBinary()
+          .then(saveCachedNpm)
+          .then(saveCachedCypressBinary)
+      })
     })
   })
 }


### PR DESCRIPTION
prints the list of binaries in the global cache after the install

<img width="591" alt="Screen Shot 2020-10-28 at 12 22 41 PM" src="https://user-images.githubusercontent.com/2212006/97465773-c631e400-1918-11eb-87d4-0f8aee771245.png">
