### PR TITLE
fix: resolve working-directory if specified

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -7187,8 +7187,12 @@ const homeDirectory = os.homedir()
 const platformAndArch = `${process.platform}-${process.arch}`
 
 const startWorkingDirectory = process.cwd()
-const workingDirectory =
-  core.getInput('working-directory') || process.cwd()
+// seems the working directory should be absolute to work correctly
+// https://github.com/cypress-io/github-action/issues/211
+const workingDirectory = core.getInput('working-directory')
+  ? path.resolve(core.getInput('working-directory'))
+  : startWorkingDirectory
+core.debug(`working directory ${workingDirectory}`)
 
 /**
  * When running "npm install" or any other Cypress-related commands,

--- a/index.js
+++ b/index.js
@@ -81,8 +81,12 @@ const homeDirectory = os.homedir()
 const platformAndArch = `${process.platform}-${process.arch}`
 
 const startWorkingDirectory = process.cwd()
-const workingDirectory =
-  core.getInput('working-directory') || process.cwd()
+// seems the working directory should be absolute to work correctly
+// https://github.com/cypress-io/github-action/issues/211
+const workingDirectory = core.getInput('working-directory')
+  ? path.resolve(core.getInput('working-directory'))
+  : startWorkingDirectory
+core.debug(`working directory ${workingDirectory}`)
 
 /**
  * When running "npm install" or any other Cypress-related commands,


### PR DESCRIPTION
in situations when the job specified `working-directory` parameter, `actions/exec` would fail to run `yarn` or `npm` if the working directory was not absolute.

- closes #211 
