### PR TITLE
feat: start several services in parallel

### DIFF
--- a/.github/workflows/example-wait-on.yml
+++ b/.github/workflows/example-wait-on.yml
@@ -48,6 +48,7 @@ jobs:
         uses: ./
         with:
           working-directory: examples/wait-on
-          start: npm start -- --port 3050, npm run start2 -- --port 3060, npx run start3 --port 3070
+          # use different command formats
+          start: npm start -- --port 3050, npm run start2 -- --port 3060, node ./index3 --port 3070
           # wait for the last server to respond
           wait-on: 'http://localhost:3070'

--- a/.github/workflows/example-wait-on.yml
+++ b/.github/workflows/example-wait-on.yml
@@ -38,3 +38,15 @@ jobs:
           working-directory: examples/wait-on
           start: npm run start3
           wait-on: 'http://localhost:3050'
+
+  wait-multiple:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: Cypress tests
+        uses: ./
+        with:
+          working-directory: examples/wait-on
+          start: npm start, npm run start2, npm run start3
+          wait-on: 'http://localhost:3050'

--- a/.github/workflows/example-wait-on.yml
+++ b/.github/workflows/example-wait-on.yml
@@ -48,5 +48,6 @@ jobs:
         uses: ./
         with:
           working-directory: examples/wait-on
-          start: npm start, npm run start2, npm run start3
-          wait-on: 'http://localhost:3050'
+          start: npm start -- --port 3050, npm run start2 -- --port 3060, npx run start3 --port 3070
+          # wait for the last server to respond
+          wait-on: 'http://localhost:3070'

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@
 - Run tests in [parallel](#parallel)
 - [Build app](#build-app) before running the tests
 - [Start server](#start-server) before running the tests
+- [Start multiple servers](#start-multiple-servers) before running the tests
 - [Wait for server](#wait-on) before running the tests
 - use [command prefix](#command-prefix)
 - use [own custom test command](#custom-test-command)
@@ -521,6 +522,27 @@ jobs:
 ```
 
 [![start example](https://github.com/cypress-io/github-action/workflows/example-start/badge.svg?branch=master)](.github/workflows/example-start.yml)
+
+**Note:** GitHub cleans up the running server processes automatically. This action does not stop them.
+
+### Start multiple servers
+
+You can start multiple server processes. For example, if you have an API to start using `npm run api` and the web server to start using `npm run web` you can put those commands in `start` using comma separation.
+
+```yml
+name: With servers
+on: [push]
+jobs:
+  cypress-run:
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: Cypress run
+        uses: cypress-io/github-action@v2
+        with:
+          start: npm run api, npm run web
+```
 
 ### Wait-on
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -8786,7 +8786,7 @@ const buildAppMaybe = () => {
   return execCommand(buildApp, true, 'build app')
 }
 
-const startServerMaybe = () => {
+const startServersMaybe = () => {
   let startCommand
 
   if (isWindows()) {
@@ -8801,7 +8801,21 @@ const startServerMaybe = () => {
     return
   }
 
-  return execCommand(startCommand, false, 'start server')
+  const separateStartCommands = startCommand
+    .split(',')
+    .map(s => s.trim())
+    .filter(Boolean)
+  core.debug(
+    `Separated start commands ${separateStartCommands.join(', ')}`
+  )
+
+  return separateStartCommands.map(startCommand => {
+    return execCommand(
+      startCommand,
+      false,
+      `start server "${startCommand}`
+    )
+  })
 }
 
 const waitOnMaybe = () => {
@@ -9181,7 +9195,7 @@ const installMaybe = () => {
 
 installMaybe()
   .then(buildAppMaybe)
-  .then(startServerMaybe)
+  .then(startServersMaybe)
   .then(waitOnMaybe)
   .then(runTests)
   .then(() => {

--- a/examples/wait-on/index.js
+++ b/examples/wait-on/index.js
@@ -5,10 +5,15 @@
 // useful because shows timestamps
 const log = require('debug')('*')
 const http = require('http')
+const arg = require('arg')
 
-log('starting the server...')
+const args = arg({
+  '--port': Number
+})
+const port = args['--port'] || 3050
+
+log('starting the server at port %d', port)
 setTimeout(function() {
-  const port = 3050
   log('creating the server on port %d', port)
   const server = http.createServer((req, res) => {
     log('request %s %s', req.method, req.url)
@@ -16,6 +21,6 @@ setTimeout(function() {
     res.end('all good')
   })
   server.listen(port, () => {
-    log('server is listening')
+    log('server is listening at port %d', port)
   })
 }, 7000)

--- a/examples/wait-on/index2.js
+++ b/examples/wait-on/index2.js
@@ -5,10 +5,15 @@
 // useful because shows timestamps
 const log = require('debug')('*')
 const http = require('http')
+const arg = require('arg')
+
+const args = arg({
+  '--port': Number
+})
+const port = args['--port'] || 3050
 
 const errorPeriodSeconds = 10
 const endErrorsAt = +new Date() + errorPeriodSeconds * 1000
-const port = 3050
 
 log('creating the server on port %d', port)
 log('will respond with errors for %d seconds', errorPeriodSeconds)

--- a/examples/wait-on/index3.js
+++ b/examples/wait-on/index3.js
@@ -5,10 +5,15 @@
 // useful because shows timestamps
 const log = require('debug')('*')
 const http = require('http')
+const arg = require('arg')
+
+const args = arg({
+  '--port': Number
+})
+const port = args['--port'] || 3050
 
 const errorPeriodSeconds = 40
 const endErrorsAt = +new Date() + errorPeriodSeconds * 1000
-const port = 3050
 
 log('creating the server on port %d', port)
 log('will not respond for the first %d seconds', errorPeriodSeconds)

--- a/examples/wait-on/package-lock.json
+++ b/examples/wait-on/package-lock.json
@@ -149,6 +149,11 @@
       "integrity": "sha512-Of/R0wqp83cgHozfIYLbBMnej79U/SVGOOyuB3VVFv1NRM/PSFMK12x9KVtiYzJqmnU5WR2qp0Z5rHb7sWGnFQ==",
       "dev": true
     },
+    "arg": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.0.tgz",
+      "integrity": "sha512-4P8Zm2H+BRS+c/xX1LrHw0qKpEhdlZjLCgWy+d78T9vqa2Z2SiD2wMrYuWIAFy5IZUD7nnNXroRttz+0RzlrzQ=="
+    },
     "asn1": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",

--- a/examples/wait-on/package.json
+++ b/examples/wait-on/package.json
@@ -16,6 +16,7 @@
     "cypress": "5.2.0"
   },
   "dependencies": {
+    "arg": "5.0.0",
     "debug": "4.2.0"
   }
 }

--- a/index.js
+++ b/index.js
@@ -270,7 +270,7 @@ const buildAppMaybe = () => {
   return execCommand(buildApp, true, 'build app')
 }
 
-const startServerMaybe = () => {
+const startServersMaybe = () => {
   let startCommand
 
   if (isWindows()) {
@@ -285,7 +285,21 @@ const startServerMaybe = () => {
     return
   }
 
-  return execCommand(startCommand, false, 'start server')
+  const separateStartCommands = startCommand
+    .split(',')
+    .map(s => s.trim())
+    .filter(Boolean)
+  core.debug(
+    `Separated start commands ${separateStartCommands.join(', ')}`
+  )
+
+  return separateStartCommands.map(startCommand => {
+    return execCommand(
+      startCommand,
+      false,
+      `start server "${startCommand}`
+    )
+  })
 }
 
 const waitOnMaybe = () => {
@@ -665,7 +679,7 @@ const installMaybe = () => {
 
 installMaybe()
   .then(buildAppMaybe)
-  .then(startServerMaybe)
+  .then(startServersMaybe)
   .then(waitOnMaybe)
   .then(runTests)
   .then(() => {


### PR DESCRIPTION
When you need to start webserver and API for example. Separate commands with comma

```yml
- name: Cypress tests
  uses: cypress-io/github-action@v2
  with:
    start: npm run api, npm run web
    # for now only a single URL can be waited on
    wait-on: 'http://localhost:3050' 
```

- for #128

For now wait for the longest starting process