### PR TITLE
feat: wait on multiple urls

### DIFF
--- a/.github/workflows/example-wait-on.yml
+++ b/.github/workflows/example-wait-on.yml
@@ -50,5 +50,5 @@ jobs:
           working-directory: examples/wait-on
           # use different command formats
           start: npm start -- --port 3050, npm run start2 -- --port 3060, node ./index3 --port 3070
-          # wait for the last server to respond
-          wait-on: 'http://localhost:3070'
+          # wait for all services to respond
+          wait-on: 'http://localhost:3050, http://localhost:3060, http://localhost:3070'

--- a/README.md
+++ b/README.md
@@ -580,6 +580,20 @@ By default, `wait-on` will retry for 60 seconds. You can pass a custom timeout i
 
 See also [![Webpack Dev Server example](https://github.com/cypress-io/github-action/workflows/example-webpack/badge.svg?branch=master)](.github/workflows/example-webpack.yml)
 
+You can wait for multiple URLs to respond by separating urls with a comma
+
+```yml
+- uses: cypress-io/github-action@v2
+  with:
+    # API runs on port 3050
+    # Web server runs on port 8080
+    start: npm run api, npm run web
+    # wait for all services to respond
+    wait-on: 'http://localhost:3050, http://localhost:8080'
+```
+
+The action will wait for the first url to respond, then will check the second url, and so on.
+
 ### Command prefix
 
 You can prefix the default test command using the `command-prefix` option. This is useful for example when running [Percy](https://docs.percy.io/docs/cypress), which requires the test command to be wrapped with `percy exec --`.

--- a/dist/index.js
+++ b/dist/index.js
@@ -8834,7 +8834,16 @@ const waitOnMaybe = () => {
 
   const waitTimeoutMs = parseFloat(waitOnTimeout) * 1000
 
-  return ping(waitOn, waitTimeoutMs)
+  const waitUrls = waitOn
+    .split(',')
+    .map(s => s.trim())
+    .filter(Boolean)
+  core.debug(`Waiting for urls ${waitUrls.join(', ')}`)
+
+  return waitUrls.reduce((prevPromise, url) => {
+    core.debug(`Waiting for url ${url}`)
+    return prevPromise.then(() => ping(url, waitTimeoutMs))
+  }, Promise.resolve())
 }
 
 const I = x => x

--- a/dist/index.js
+++ b/dist/index.js
@@ -8840,9 +8840,13 @@ const waitOnMaybe = () => {
     .filter(Boolean)
   core.debug(`Waiting for urls ${waitUrls.join(', ')}`)
 
+  // run every wait promise after the previous has finished
+  // to avoid "noise" of debug messages
   return waitUrls.reduce((prevPromise, url) => {
-    core.debug(`Waiting for url ${url}`)
-    return prevPromise.then(() => ping(url, waitTimeoutMs))
+    return prevPromise.then(() => {
+      core.debug(`Waiting for url ${url}`)
+      return ping(url, waitTimeoutMs)
+    })
   }, Promise.resolve())
 }
 

--- a/index.js
+++ b/index.js
@@ -318,7 +318,16 @@ const waitOnMaybe = () => {
 
   const waitTimeoutMs = parseFloat(waitOnTimeout) * 1000
 
-  return ping(waitOn, waitTimeoutMs)
+  const waitUrls = waitOn
+    .split(',')
+    .map(s => s.trim())
+    .filter(Boolean)
+  core.debug(`Waiting for urls ${waitUrls.join(', ')}`)
+
+  return waitUrls.reduce((prevPromise, url) => {
+    core.debug(`Waiting for url ${url}`)
+    return prevPromise.then(() => ping(url, waitTimeoutMs))
+  }, Promise.resolve())
 }
 
 const I = x => x

--- a/index.js
+++ b/index.js
@@ -324,9 +324,13 @@ const waitOnMaybe = () => {
     .filter(Boolean)
   core.debug(`Waiting for urls ${waitUrls.join(', ')}`)
 
+  // run every wait promise after the previous has finished
+  // to avoid "noise" of debug messages
   return waitUrls.reduce((prevPromise, url) => {
-    core.debug(`Waiting for url ${url}`)
-    return prevPromise.then(() => ping(url, waitTimeoutMs))
+    return prevPromise.then(() => {
+      core.debug(`Waiting for url ${url}`)
+      return ping(url, waitTimeoutMs)
+    })
   }, Promise.resolve())
 }
 


### PR DESCRIPTION
- closes #152 
- closes #128

Separate urls with a comma

```yml
with:
  working-directory: examples/wait-on
  start: npm start -- --port 3050, npm run start2 -- --port 3060, node ./index3 --port 3070
  # wait for all services to respond
  wait-on: 'http://localhost:3050, http://localhost:3060, http://localhost:3070'
```