### PR TITLE
fix: use longer ping timeout for wait-on pings

### DIFF
--- a/.github/workflows/example-wait-on.yml
+++ b/.github/workflows/example-wait-on.yml
@@ -39,6 +39,18 @@ jobs:
           start: npm run start3
           wait-on: 'http://localhost:3050'
 
+  wait4:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: Cypress tests
+        uses: ./
+        with:
+          working-directory: examples/wait-on
+          start: npm run start4
+          wait-on: 'http://localhost:3050'
+
   wait-multiple:
     runs-on: ubuntu-latest
     steps:

--- a/dist/index.js
+++ b/dist/index.js
@@ -84684,12 +84684,15 @@ const ping = (url, timeout) => {
   const errorCodes = [...got.defaults.options.retry.errorCodes]
   errorCodes.push('ESOCKETTIMEDOUT')
 
+  // we expect the server to respond within a time limit
+  // and if it does not - retry up to total "timeout" duration
+  const individualPingTimeout = Math.min(timeout, 30000)
   const start = +new Date()
   return got(url, {
-    timeout: 1000,
+    timeout: individualPingTimeout,
     errorCodes,
     retry: {
-      limit: Math.ceil(timeout / 1000),
+      limit: Math.ceil(timeout / individualPingTimeout),
       calculateDelay({ error }) {
         const now = +new Date()
         core.debug(

--- a/dist/index.js
+++ b/dist/index.js
@@ -84699,18 +84699,17 @@ const ping = (url, timeout) => {
     errorCodes,
     retry: {
       limit,
-      calculateDelay({ error, retryCount }) {
+      calculateDelay({ error, attemptCount }) {
         const now = +new Date()
+        const elapsed = now - start
         core.debug(
-          `${now - start}ms ${error.method} ${error.host} ${
-            error.code
-          }`
+          `${elapsed}ms ${error.method} ${error.host} ${error.code} try ${attemptCount} of ${limit}`
         )
-        if (retryCount > limit) {
+        if (elapsed > timeout) {
           console.error(
             '%s timed out on retry %d of %d',
             url,
-            retryCount,
+            attemptCount,
             limit
           )
           return 0
@@ -84719,7 +84718,9 @@ const ping = (url, timeout) => {
       }
     }
   }).then(() => {
-    core.debug(`pinging ${url} has finished ok`)
+    const now = +new Date()
+    const elapsed = now - start
+    core.debug(`pinging ${url} has finished ok after ${elapsed}ms`)
   })
 }
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -84703,7 +84703,7 @@ const ping = (url, timeout) => {
         const now = +new Date()
         const elapsed = now - start
         core.debug(
-          `${elapsed}ms ${error.method} ${error.host} ${error.code} try ${attemptCount} of ${limit}`
+          `${elapsed}ms ${error.method} ${error.host} ${error.code} attempt ${attemptCount}`
         )
         if (elapsed > timeout) {
           console.error(
@@ -84714,6 +84714,14 @@ const ping = (url, timeout) => {
           )
           return 0
         }
+
+        // if the error code is ECONNREFUSED use shorter timeout
+        // because the server is probably starting
+        if (error.code === 'ECONNREFUSED') {
+          return 1000
+        }
+
+        // default "long" timeout
         return individualPingTimeout
       }
     }

--- a/examples/wait-on/README.md
+++ b/examples/wait-on/README.md
@@ -11,3 +11,7 @@ Server responds for the first 10 seconds with an error
 ## start3
 
 Server keeps the connection without response for the first period
+
+## start4
+
+Server takes 5 seconds to respond to each request

--- a/examples/wait-on/index4.js
+++ b/examples/wait-on/index4.js
@@ -1,0 +1,29 @@
+// this server starts listening right away
+// but every response takes 6 seconds
+
+// always log messages
+// useful because shows timestamps
+const log = require('debug')('*')
+const http = require('http')
+const arg = require('arg')
+
+const args = arg({
+  '--port': Number
+})
+const port = args['--port'] || 3050
+
+log('creating the server on port %d', port)
+
+const server = http.createServer((req, res) => {
+  const reqTimestamp = +new Date()
+  log('request at %d: %s %s', reqTimestamp, req.method, req.url)
+  setTimeout(function() {
+    log('responding to request from %d', reqTimestamp)
+    res.writeHead(200)
+    res.end('all good')
+  }, 6000)
+})
+
+server.listen(port, () => {
+  log('server is listening')
+})

--- a/examples/wait-on/package.json
+++ b/examples/wait-on/package.json
@@ -7,7 +7,8 @@
     "test": "cypress run",
     "start": "node .",
     "start2": "node ./index2",
-    "start3": "node ./index3"
+    "start3": "node ./index3",
+    "start4": "node ./index4"
   },
   "author": "",
   "license": "ISC",

--- a/src/ping-cli.js
+++ b/src/ping-cli.js
@@ -1,5 +1,5 @@
 const { ping } = require('./ping')
-const timeoutSeconds = 30
+const timeoutSeconds = 60
 const url = process.argv[2]
 console.log('pinging url %s for %d seconds', url, timeoutSeconds)
 if (!url) {

--- a/src/ping.js
+++ b/src/ping.js
@@ -15,12 +15,15 @@ const ping = (url, timeout) => {
   const errorCodes = [...got.defaults.options.retry.errorCodes]
   errorCodes.push('ESOCKETTIMEDOUT')
 
+  // we expect the server to respond within a time limit
+  // and if it does not - retry up to total "timeout" duration
+  const individualPingTimeout = Math.min(timeout, 30000)
   const start = +new Date()
   return got(url, {
-    timeout: 1000,
+    timeout: individualPingTimeout,
     errorCodes,
     retry: {
-      limit: Math.ceil(timeout / 1000),
+      limit: Math.ceil(timeout / individualPingTimeout),
       calculateDelay({ error }) {
         const now = +new Date()
         core.debug(

--- a/src/ping.js
+++ b/src/ping.js
@@ -30,18 +30,17 @@ const ping = (url, timeout) => {
     errorCodes,
     retry: {
       limit,
-      calculateDelay({ error, retryCount }) {
+      calculateDelay({ error, attemptCount }) {
         const now = +new Date()
+        const elapsed = now - start
         core.debug(
-          `${now - start}ms ${error.method} ${error.host} ${
-            error.code
-          }`
+          `${elapsed}ms ${error.method} ${error.host} ${error.code} try ${attemptCount} of ${limit}`
         )
-        if (retryCount > limit) {
+        if (elapsed > timeout) {
           console.error(
             '%s timed out on retry %d of %d',
             url,
-            retryCount,
+            attemptCount,
             limit
           )
           return 0
@@ -50,7 +49,9 @@ const ping = (url, timeout) => {
       }
     }
   }).then(() => {
-    core.debug(`pinging ${url} has finished ok`)
+    const now = +new Date()
+    const elapsed = now - start
+    core.debug(`pinging ${url} has finished ok after ${elapsed}ms`)
   })
 }
 

--- a/src/ping.js
+++ b/src/ping.js
@@ -18,24 +18,35 @@ const ping = (url, timeout) => {
   // we expect the server to respond within a time limit
   // and if it does not - retry up to total "timeout" duration
   const individualPingTimeout = Math.min(timeout, 30000)
+  const limit = Math.ceil(timeout / individualPingTimeout)
+
+  core.debug(`total ping timeout ${timeout}`)
+  core.debug(`individual ping timeout ${individualPingTimeout}ms`)
+  core.debug(`retries limit ${limit}`)
+
   const start = +new Date()
   return got(url, {
     timeout: individualPingTimeout,
     errorCodes,
     retry: {
-      limit: Math.ceil(timeout / individualPingTimeout),
-      calculateDelay({ error }) {
+      limit,
+      calculateDelay({ error, retryCount }) {
         const now = +new Date()
         core.debug(
           `${now - start}ms ${error.method} ${error.host} ${
             error.code
           }`
         )
-        if (now - start > timeout) {
-          console.error('%s timed out', url)
+        if (retryCount > limit) {
+          console.error(
+            '%s timed out on retry %d of %d',
+            url,
+            retryCount,
+            limit
+          )
           return 0
         }
-        return 1000
+        return individualPingTimeout
       }
     }
   }).then(() => {

--- a/src/ping.js
+++ b/src/ping.js
@@ -34,7 +34,7 @@ const ping = (url, timeout) => {
         const now = +new Date()
         const elapsed = now - start
         core.debug(
-          `${elapsed}ms ${error.method} ${error.host} ${error.code} try ${attemptCount} of ${limit}`
+          `${elapsed}ms ${error.method} ${error.host} ${error.code} attempt ${attemptCount}`
         )
         if (elapsed > timeout) {
           console.error(
@@ -45,6 +45,14 @@ const ping = (url, timeout) => {
           )
           return 0
         }
+
+        // if the error code is ECONNREFUSED use shorter timeout
+        // because the server is probably starting
+        if (error.code === 'ECONNREFUSED') {
+          return 1000
+        }
+
+        // default "long" timeout
         return individualPingTimeout
       }
     }


### PR DESCRIPTION
closes #235 

Adding a test where the server takes 5 seconds to respond to every request, shows our `ping` logic timing out. Reworked ping to quickly retry on `ECONNREFUSED` but use long timeout (30 seconds) for other errors.