### PR TITLE
Run Firefox example without using Docker containers

### DIFF
--- a/.github/workflows/example-firefox.yml
+++ b/.github/workflows/example-firefox.yml
@@ -12,8 +12,6 @@ jobs:
       - name: Firefox
         uses: ./
         timeout-minutes: 3
-        env:
-          DEBUG: 'cypress:*'
         with:
           # let's show browser and system info
           build: npx cypress info

--- a/.github/workflows/example-firefox.yml
+++ b/.github/workflows/example-firefox.yml
@@ -2,24 +2,12 @@ name: example-firefox
 on: push
 jobs:
   firefox:
-    runs-on: ubuntu-latest
-    # https://github.com/cypress-io/cypress-docker-images
-    container:
-      image: cypress/browsers:node12.18.0-chrome83-ff77
-      # "magical" user id that matches id for created home folder
-      # https://github.com/cypress-io/github-action/issues/104
-      options: --user 1001
+    # should include Firefox browser install
+    # https://github.com/actions/virtual-environments
+    runs-on: ubuntu-18.04
     steps:
       - name: Checkout
         uses: actions/checkout@v1
-
-      # for debugging permission problems
-      - run: id
-      # the home folder is set by the GH docker start
-      # -e "HOME=/github/home"
-      # and has permissions (user 1001)
-      # drwxr-xr-x 2 1001  115
-      - run: ls -la ~
 
       - name: Firefox
         uses: ./
@@ -27,6 +15,8 @@ jobs:
         env:
           DEBUG: 'cypress:*'
         with:
+          # let's show browser and system info
+          build: npx cypress info
           working-directory: examples/firefox
           browser: firefox
 


### PR DESCRIPTION
Seems the Docker container is just making everything flaky, and Ubuntu GH Action environments have Firefox 82 pre-installed