### PR TITLE
fix: respect the CYPRESS_CACHE_FOLDER environment variable

### DIFF
--- a/index.js
+++ b/index.js
@@ -120,7 +120,7 @@ const getNpmCache = () => {
 
 // custom Cypress binary cache folder
 // see https://on.cypress.io/caching
-const CYPRESS_CACHE_FOLDER = path.join(
+const CYPRESS_CACHE_FOLDER = process.env.CYPRESS_CACHE_FOLDER || path.join(
   homeDirectory,
   '.cache',
   'Cypress'


### PR DESCRIPTION
When using `install: false`, the Cypress binary needs to be installed manually. If this is done a separate job, the caching gets complicated if the binary is in the home directory. Setting the env var `CYPRESS_CACHE_FOLDER: ${{ github.workspace }}/node_modules/.cache/Cypress` makes this trivial, but is currently not supported by this action as the cache folder path is hard-coded. This change adds support for overriding the path with the environment var.