### PR TITLE
chore: confirm Cypress v6 runs on ubuntu 16

### DIFF
--- a/.github/workflows/example-basic.yml
+++ b/.github/workflows/example-basic.yml
@@ -1,6 +1,25 @@
 name: example-basic
 on: [push]
 jobs:
+  basic-ubuntu-16:
+    runs-on: ubuntu-16.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+
+      - name: Cypress tests
+        # normally you would write
+        # uses: cypress-io/github-action@v2
+        uses: ./
+        # the parameters below are only necessary
+        # because we are running these examples in a monorepo
+        with:
+          working-directory: examples/basic
+          # just for full picture after installing Cypress
+          # print information about detected browsers, etc
+          # see https://on.cypress.io/command-line#cypress-info
+          build: npx cypress info
+
   basic-ubuntu-18:
     runs-on: ubuntu-18.04
     steps:


### PR DESCRIPTION
closes https://github.com/cypress-io/github-action/issues/251

the .github/workflows/example-basic.yml tests Cypress on Ubuntu 16, 18, and 20. Shows that no additional OS dependencies are necessary, GH virtual environments already have everything we need