### PR TITLE
fix: add extra period to handle ETIMEDOUT error

### DIFF
--- a/.github/workflows/example-wait-on.yml
+++ b/.github/workflows/example-wait-on.yml
@@ -78,9 +78,26 @@ jobs:
       - name: Cypress tests
         uses: ./
         with:
+          # in this situation the server does not respond
+          # for the first period causing ETIMEDOUT errors
           working-directory: examples/wait-on
           start: npm run start3
           wait-on: 'http://localhost:3050'
+
+  wait3-for-200-seconds:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Cypress tests
+        uses: ./
+        with:
+          # in this situation the server does not respond
+          # for the first period causing ETIMEDOUT errors
+          working-directory: examples/wait-on
+          start: npm run start3-after-200-seconds
+          wait-on: 'http://localhost:3050'
+          wait-on-timeout: 210
 
   wait4:
     runs-on: ubuntu-20.04

--- a/dist/index.js
+++ b/dist/index.js
@@ -66190,7 +66190,7 @@ const ping = (url, timeout) => {
   // we expect the server to respond within a time limit
   // and if it does not - retry up to total "timeout" duration
   const individualPingTimeout = Math.min(timeout, 30000)
-  const limit = Math.ceil(timeout / individualPingTimeout)
+  const limit = Math.ceil(timeout / individualPingTimeout) + 1
 
   core.debug(`total ping timeout ${timeout}`)
   core.debug(`individual ping timeout ${individualPingTimeout}ms`)
@@ -66216,10 +66216,12 @@ const ping = (url, timeout) => {
         )
         if (elapsed > timeout) {
           console.error(
-            '%s timed out on retry %d of %d',
+            '%s timed out on retry %d of %d, elapsed %dms, limit %dms',
             url,
             attemptCount,
-            limit
+            limit,
+            elapsed,
+            timeout
           )
           return 0
         }

--- a/dist/index.js
+++ b/dist/index.js
@@ -66190,7 +66190,12 @@ const ping = (url, timeout) => {
   // we expect the server to respond within a time limit
   // and if it does not - retry up to total "timeout" duration
   const individualPingTimeout = Math.min(timeout, 30000)
-  const limit = Math.ceil(timeout / individualPingTimeout) + 1
+
+  // add to the timeout max individual ping timeout
+  // to avoid long-waiting ping from "rolling" over the end
+  // and preventing pinging the last time
+  timeout += individualPingTimeout
+  const limit = Math.ceil(timeout / individualPingTimeout)
 
   core.debug(`total ping timeout ${timeout}`)
   core.debug(`individual ping timeout ${individualPingTimeout}ms`)

--- a/examples/wait-on/index3.js
+++ b/examples/wait-on/index3.js
@@ -8,18 +8,19 @@ const http = require('http')
 const arg = require('arg')
 
 const args = arg({
-  '--port': Number
+  '--port': Number,
+  '--delay': Number
 })
 const port = args['--port'] || 3050
+const errorPeriodSeconds = args['--delay'] || 40
 
-const errorPeriodSeconds = 40
 const endErrorsAt = +new Date() + errorPeriodSeconds * 1000
 
 log('creating the server on port %d', port)
 log('will not respond for the first %d seconds', errorPeriodSeconds)
 
-setTimeout(function() {
-  log('from now on will answer all good')
+setTimeout(function () {
+  log('the server will now answer ok')
 }, errorPeriodSeconds * 1000)
 
 const server = http.createServer((req, res) => {

--- a/examples/wait-on/index3.js
+++ b/examples/wait-on/index3.js
@@ -25,8 +25,9 @@ setTimeout(function () {
 
 const server = http.createServer((req, res) => {
   log('request %s %s', req.method, req.url)
-  if (new Date() < endErrorsAt) {
-    log('not responding')
+  const now = +new Date()
+  if (now < endErrorsAt) {
+    log('not responding, %d ms left', endErrorsAt - now)
     return
   }
 

--- a/examples/wait-on/package.json
+++ b/examples/wait-on/package.json
@@ -11,6 +11,7 @@
     "start-after-50-seconds": "node ./index2 --delay 50",
     "start-after-120-seconds": "node ./index2 --delay 120",
     "start3": "node ./index3",
+    "start3-after-200-seconds": "node ./index3 --delay 200",
     "start4": "node ./index4"
   },
   "author": "",

--- a/src/ping-cli.js
+++ b/src/ping-cli.js
@@ -2,7 +2,7 @@
 // node ./src/ping-cli <url>
 
 const { ping } = require('./ping')
-const timeoutSeconds = 60
+const timeoutSeconds = 30
 const url = process.argv[2]
 console.log('pinging url %s for %d seconds', url, timeoutSeconds)
 if (!url) {

--- a/src/ping.js
+++ b/src/ping.js
@@ -18,7 +18,7 @@ const ping = (url, timeout) => {
   // we expect the server to respond within a time limit
   // and if it does not - retry up to total "timeout" duration
   const individualPingTimeout = Math.min(timeout, 30000)
-  const limit = Math.ceil(timeout / individualPingTimeout)
+  const limit = Math.ceil(timeout / individualPingTimeout) + 1
 
   core.debug(`total ping timeout ${timeout}`)
   core.debug(`individual ping timeout ${individualPingTimeout}ms`)
@@ -44,10 +44,12 @@ const ping = (url, timeout) => {
         )
         if (elapsed > timeout) {
           console.error(
-            '%s timed out on retry %d of %d',
+            '%s timed out on retry %d of %d, elapsed %dms, limit %dms',
             url,
             attemptCount,
-            limit
+            limit,
+            elapsed,
+            timeout
           )
           return 0
         }

--- a/src/ping.js
+++ b/src/ping.js
@@ -18,7 +18,12 @@ const ping = (url, timeout) => {
   // we expect the server to respond within a time limit
   // and if it does not - retry up to total "timeout" duration
   const individualPingTimeout = Math.min(timeout, 30000)
-  const limit = Math.ceil(timeout / individualPingTimeout) + 1
+
+  // add to the timeout max individual ping timeout
+  // to avoid long-waiting ping from "rolling" over the end
+  // and preventing pinging the last time
+  timeout += individualPingTimeout
+  const limit = Math.ceil(timeout / individualPingTimeout)
 
   core.debug(`total ping timeout ${timeout}`)
   core.debug(`individual ping timeout ${individualPingTimeout}ms`)


### PR DESCRIPTION
when the last timed out error pushes the time beyond the time limit (and we have no chance to ask again, even if the server would respond within the time limit)

closes #286 

