### PR TITLE
feat: always provide ci-build-id so actions can be re-run

### DIFF
--- a/index.js
+++ b/index.js
@@ -413,7 +413,7 @@ const getCiBuildId = async () => {
 
   const [owner, repo] = GITHUB_REPOSITORY.split('/')
   let branch
-  let parallelId = `${GITHUB_WORKFLOW} - ${GITHUB_SHA}`
+  let buildId = `${GITHUB_WORKFLOW} - ${GITHUB_SHA}`
 
   if (GITHUB_TOKEN) {
     core.debug(
@@ -461,16 +461,14 @@ const getCiBuildId = async () => {
     ) {
       const jobId = runsList.data.jobs[0].id
       core.debug(`fetched run list with jobId ${jobId}`)
-      parallelId = `${GITHUB_RUN_ID}-${jobId}`
+      buildId = `${GITHUB_RUN_ID}-${jobId}`
     } else {
       core.debug('could not get run list data')
     }
   }
 
-  core.debug(
-    `determined branch ${branch} and parallel id ${parallelId}`
-  )
-  return { branch, parallelId }
+  core.debug(`determined branch ${branch} and build id ${buildId}`)
+  return { branch, buildId }
 }
 
 /**
@@ -542,16 +540,13 @@ const runTestsUsingCommandLine = async () => {
     cmd.push(quoteArgument(configFileInput))
   }
 
-  if (parallel || group) {
-    const { branch, parallelId } = await getCiBuildId()
-    if (branch) {
-      core.exportVariable('GH_BRANCH', branch)
-    }
-
-    const customCiBuildId = core.getInput('ci-build-id') || parallelId
-    cmd.push('--ci-build-id')
-    cmd.push(quoteArgument(customCiBuildId))
+  const { branch, buildId } = await getCiBuildId()
+  if (branch) {
+    core.exportVariable('GH_BRANCH', branch)
   }
+
+  cmd.push('--ci-build-id')
+  cmd.push(quoteArgument(core.getInput('ci-build-id') || buildId))
 
   const browser = core.getInput('browser')
   if (browser) {
@@ -663,17 +658,12 @@ const runTests = async () => {
     cypressOptions.env = core.getInput('env')
   }
 
-  if (cypressOptions.parallel || cypressOptions.group) {
-    const { branch, parallelId } = await getCiBuildId()
-    if (branch) {
-      core.exportVariable('GH_BRANCH', branch)
-    }
-
-    const customCiBuildId = core.getInput('ci-build-id') || parallelId
-    if (customCiBuildId) {
-      cypressOptions.ciBuildId = customCiBuildId
-    }
+  const { branch, buildId } = await getCiBuildId()
+  if (branch) {
+    core.exportVariable('GH_BRANCH', branch)
   }
+
+  cypressOptions.ciBuildId = core.getInput('ci-build-id') || buildId
 
   core.debug(`Cypress options ${JSON.stringify(cypressOptions)}`)
 


### PR DESCRIPTION
closes #363 

I know that there are known workarounds for this, mentioned both in the [README](https://github.com/cypress-io/github-action#parallel) and some [issue comments](https://github.com/cypress-io/github-action/issues/177).

Since this is relevant not only for parallel runs I think that adding this at all times would improve the DX and provide this improvement out of the box for all users. The expected result is that a GitHub action should be able to re-run the workflow and create a new test run in the Cypress dashboard.