### PR TITLE
feat(polish): warn about input that have no effect when using a custom command

### DIFF
--- a/index.js
+++ b/index.js
@@ -590,6 +590,21 @@ const runTestsUsingCommandLine = async () => {
   return exec.exec(quote(npxPath), cmd, opts)
 }
 
+const warnAboutIrrelevantInputs = (potentiallyIrrelevantInputs) => {
+  const irrelevantInputs = potentiallyIrrelevantInputs.filter(
+    (inputName) => core.getInput(inputName)
+  )
+  if (irrelevantInputs.length > 0) {
+    console.warn(
+      `Those inputs don't have any effect on this run: ${irrelevantInputs.join(
+        ', '
+      )}.`
+    )
+  }
+}
+
+const compact = (obj) => {}
+
 /**
  * Run Cypress tests by collecting input parameters
  * and using Cypress module API to run tests.
@@ -609,6 +624,22 @@ const runTests = async () => {
   const customCommand = core.getInput('command')
   if (customCommand) {
     console.log('Using custom test command: %s', customCommand)
+    warnAboutIrrelevantInputs([
+      'browser',
+      'ci-build-id',
+      'command-prefix',
+      'config',
+      'config-file',
+      'env',
+      'group',
+      'headless',
+      'parallel',
+      'project',
+      'quie',
+      'record',
+      'spec',
+      'tag'
+    ])
     return execCommand(customCommand, true, 'run tests')
   }
 


### PR DESCRIPTION
The same could probably be done in some other places but this is the one that was the most relevant for me - since I've not realized that those inputs won't be forwarded to the custom command.