### PR TITLE
fix: send ci-build-id only in parallel or group mode

### DIFF
--- a/.github/workflows/example-recording.yml
+++ b/.github/workflows/example-recording.yml
@@ -1,7 +1,7 @@
 name: example-recording
 on: [push]
 jobs:
-  basic:
+  parallel:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout
@@ -32,3 +32,23 @@ jobs:
         run: |
           echo Cypress finished with: ${{ steps.cypress.outcome }}
           echo See results at ${{ steps.cypress.outputs.dashboardUrl }}
+
+  group:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Cypress tests
+        # normally you would write
+        # uses: cypress-io/github-action@v2
+        uses: ./
+        with:
+          working-directory: examples/recording
+          record: true
+          # no parallel flag, just the group name
+          group: Recording group
+        env:
+          # pass the Dashboard record key as an environment variable
+          CYPRESS_RECORD_KEY: ${{ secrets.EXAMPLE_RECORDING_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/dist/index.js
+++ b/dist/index.js
@@ -6994,8 +6994,7 @@ const runTestsUsingCommandLine = async () => {
     cmd.push(quoteArgument(configFileInput))
   }
 
-  if (record) {
-    // only include the ci-build-id if recording
+  if (parallel || group) {
     const { branch, buildId } = await getCiBuildId()
     if (branch) {
       core.exportVariable('GH_BRANCH', branch)
@@ -7116,7 +7115,7 @@ const runTests = async () => {
     cypressOptions.env = core.getInput('env')
   }
 
-  if (cypressOptions.record) {
+  if (cypressOptions.parallel || cypressOptions.group) {
     const { branch, buildId } = await getCiBuildId()
     if (branch) {
       core.exportVariable('GH_BRANCH', branch)

--- a/index.js
+++ b/index.js
@@ -540,8 +540,7 @@ const runTestsUsingCommandLine = async () => {
     cmd.push(quoteArgument(configFileInput))
   }
 
-  if (record) {
-    // only include the ci-build-id if recording
+  if (parallel || group) {
     const { branch, buildId } = await getCiBuildId()
     if (branch) {
       core.exportVariable('GH_BRANCH', branch)
@@ -662,7 +661,7 @@ const runTests = async () => {
     cypressOptions.env = core.getInput('env')
   }
 
-  if (cypressOptions.record) {
+  if (cypressOptions.parallel || cypressOptions.group) {
     const { branch, buildId } = await getCiBuildId()
     if (branch) {
       core.exportVariable('GH_BRANCH', branch)


### PR DESCRIPTION
closes #365 

added a workflow with recording with just group name