### PR TITLE
fix: make headed execution available again

### DIFF
--- a/.github/workflows/example-chrome.yml
+++ b/.github/workflows/example-chrome.yml
@@ -61,21 +61,21 @@ jobs:
       - run: ffprobe cypress/videos/*.mp4 || true
       - run: mplayer -really-quiet -ao null -vo null -identify -frames 0 cypress/videos/*.mp4 || true
 
-      - name: Chrome headless
+      - name: Chrome headed
         uses: ./
         with:
           working-directory: examples/v9/chrome
           browser: chrome
-          headless: true
+          headed: true
 
       - uses: actions/upload-artifact@v2
         with:
-          name: screenshots-in-headless-chrome
+          name: screenshots-in-headed-chrome
           path: examples/chrome/cypress/screenshots
 
       - uses: actions/upload-artifact@v2
         with:
-          name: video-in-headless-chrome
+          name: video-in-headed-chrome
           path: examples/chrome/cypress/videos
 
       - run: npx image-size cypress/screenshots/**/*.png

--- a/.github/workflows/example-chrome.yml
+++ b/.github/workflows/example-chrome.yml
@@ -66,7 +66,7 @@ jobs:
         with:
           working-directory: examples/v9/chrome
           browser: chrome
-          headless: false
+          headed: true
 
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/example-chrome.yml
+++ b/.github/workflows/example-chrome.yml
@@ -66,7 +66,7 @@ jobs:
         with:
           working-directory: examples/v9/chrome
           browser: chrome
-          headed: true
+          headless: false
 
       - uses: actions/upload-artifact@v2
         with:

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 - Run tests in a given [browser](#browser)
   - using [Firefox](#firefox)
   - using [Edge](#edge)
-  - using [headless mode](#headless)
+  - using [headed mode](#headed)
 - Using [Docker image](#docker-image)
 - Specify [environment variables](#env)
 - Run only some [spec files](#specs)
@@ -149,12 +149,12 @@ jobs:
 
 **Note:** Microsoft has not released Edge for Linux yet, thus you need to run these tests on Windows or Mac runners with Edge preinstalled. You can use [`cypress info`](https://on.cypress.io/command-line#cypress-info) command to see the browsers installed on the machine.
 
-### Headless
+### Headed
 
-Run the browser in headless mode
+Run the browser in headed mode - as of Cypress v8.0 the `cypress run` executes tests in `headless` mode by default
 
 ```yml
-name: Chrome headless
+name: Chrome headed
 on: [push]
 jobs:
   cypress-run:
@@ -164,7 +164,7 @@ jobs:
       - uses: cypress-io/github-action@v4
         with:
           browser: chrome
-          headless: true
+          headed: true
 ```
 
 ### Docker image

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ jobs:
 
 ### Headed
 
-Run the browser in headed mode - as of Cypress v8.0 the `cypress run` executes tests in `headless` mode by default
+Run the browser in headed or headless mode - as of Cypress v8.0 the `cypress run` command executes tests in `headless` mode by default
 
 ```yml
 name: Chrome headed
@@ -164,7 +164,7 @@ jobs:
       - uses: cypress-io/github-action@v4
         with:
           browser: chrome
-          headed: true
+          headless: false
 ```
 
 ### Docker image

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ jobs:
 
 ### Headed
 
-Run the browser in headed or headless mode - as of Cypress v8.0 the `cypress run` command executes tests in `headless` mode by default
+Run the browser in headed mode - as of Cypress v8.0 the `cypress run` command executes tests in `headless` mode by default
 
 ```yml
 name: Chrome headed
@@ -164,7 +164,7 @@ jobs:
       - uses: cypress-io/github-action@v4
         with:
           browser: chrome
-          headless: false
+          headed: true
 ```
 
 ### Docker image

--- a/action.yml
+++ b/action.yml
@@ -59,8 +59,8 @@ inputs:
   working-directory:
     description: 'Working directory containing Cypress folder'
     required: false
-  headless:
-    description: 'Whether or not to use headless mode'
+  headed:
+    description: 'Whether or not to use headed mode'
     required: false
   spec:
     description: 'Provide a specific specs to run'

--- a/action.yml
+++ b/action.yml
@@ -59,7 +59,7 @@ inputs:
   working-directory:
     description: 'Working directory containing Cypress folder'
     required: false
-  headed:
+  headless:
     description: 'Whether or not to use headless mode'
     required: false
   spec:

--- a/action.yml
+++ b/action.yml
@@ -59,7 +59,7 @@ inputs:
   working-directory:
     description: 'Working directory containing Cypress folder'
     required: false
-  headless:
+  headed:
     description: 'Whether or not to use headless mode'
     required: false
   spec:

--- a/dist/index.js
+++ b/dist/index.js
@@ -75105,8 +75105,8 @@ const runTestsUsingCommandLine = async () => {
 
   const record = getInputBool('record')
   const parallel = getInputBool('parallel')
-  const headless = getInputBool('headless')
   const component = getInputBool('component')
+  const headed = getInputBool('headed')
 
   // TODO using yarn to run cypress when yarn is used for install
   // split potentially long command?
@@ -75125,8 +75125,8 @@ const runTestsUsingCommandLine = async () => {
   if (component) {
     cmd.push('--component')
   }
-  if (headless) {
-    cmd.push('--headless')
+  if (headed) {
+    cmd.push('--headed')
   }
   if (record) {
     cmd.push('--record')
@@ -75226,7 +75226,7 @@ const runTests = async () => {
   const commandPrefix = core.getInput('command-prefix')
   const customCommand = core.getInput('command')
   const cypressOptions = {
-    headless: getInputBool('headless'),
+    headed: getInputBool('headed'),
     record: getInputBool('record'),
     parallel: getInputBool('parallel'),
     quiet: getInputBool('quiet'),

--- a/index.js
+++ b/index.js
@@ -495,8 +495,8 @@ const runTestsUsingCommandLine = async () => {
 
   const record = getInputBool('record')
   const parallel = getInputBool('parallel')
-  const headless = getInputBool('headless')
   const component = getInputBool('component')
+  const headed = getInputBool('headed')
 
   // TODO using yarn to run cypress when yarn is used for install
   // split potentially long command?
@@ -515,8 +515,8 @@ const runTestsUsingCommandLine = async () => {
   if (component) {
     cmd.push('--component')
   }
-  if (headless) {
-    cmd.push('--headless')
+  if (headed) {
+    cmd.push('--headed')
   }
   if (record) {
     cmd.push('--record')
@@ -616,7 +616,7 @@ const runTests = async () => {
   const commandPrefix = core.getInput('command-prefix')
   const customCommand = core.getInput('command')
   const cypressOptions = {
-    headless: getInputBool('headless'),
+    headed: getInputBool('headed'),
     record: getInputBool('record'),
     parallel: getInputBool('parallel'),
     quiet: getInputBool('quiet'),


### PR DESCRIPTION
- Addresses issue [#403](https://github.com/cypress-io/github-action/issues/403);
- Because `cypress run` executes tests in `headless` mode by default we need to bring back the flag which toggles `headed` vs `headless` execution in CI;