### PR TITLE
feat: support different working directory for server

### DIFF
--- a/README.md
+++ b/README.md
@@ -610,6 +610,29 @@ jobs:
           start-windows: npm run start:windows:server
 ```
 
+**Note:** you might need the server command to be ran from a different directory. You can use `start-working-directory` for this
+```yml
+name: With server
+on: [push]
+jobs:
+  cypress-run:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup Java
+        uses: actions/setup-java@v1
+        with:
+          java-version: '11'
+          architecture: x64
+      - name: Cypress run
+        uses: cypress-io/github-action@v2
+        with:
+          start: ./gradlew run :server:run
+          # The server executable lives in a different directory
+          start-working-directory: '../backend/
+```
+
 [![start example](https://github.com/cypress-io/github-action/workflows/example-start/badge.svg?branch=master)](.github/workflows/example-start.yml)
 
 **Note:** GitHub cleans up the running server processes automatically. This action does not stop them.

--- a/action.yml
+++ b/action.yml
@@ -29,6 +29,9 @@ inputs:
   start-windows:
     description: 'A different start command on Windows'
     required: false
+  start-working-directory:
+    description: 'A different working directory for the local server start command'
+    required: false
   build:
     description: 'Command to run in build step before starting tests'
     required: false


### PR DESCRIPTION
fixes #368 

This PR adds a `start-working-directory` that allows setting a different dir for running the server `start` command. Useful for when you have a non-node server living in a different working directory than the one used for `npm i`, etc.