### PR TITLE
chore: update upload-artifact version in readme doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -426,13 +426,13 @@ jobs:
       # thus we store screenshots only on failures
       # Alternative: create and commit an empty cypress/screenshots folder
       # to always have something to upload
-      - uses: actions/upload-artifact@v1
+      - uses: actions/upload-artifact@v2
         if: failure()
         with:
           name: cypress-screenshots
           path: cypress/screenshots
       # Test run video was always captured, so this action uses "always()" condition
-      - uses: actions/upload-artifact@v1
+      - uses: actions/upload-artifact@v2
         if: always()
         with:
           name: cypress-videos


### PR DESCRIPTION
Update README doc file upgrading the upload-artifact Github actions to v2 as it is in the example workflows.