### PR TITLE
Upgrade `setup-node` action to `v2`

### DIFF
--- a/.github/workflows/example-node-versions.yml
+++ b/.github/workflows/example-node-versions.yml
@@ -10,7 +10,7 @@ jobs:
     name: E2E on Node v${{ matrix.node }}
     steps:
       - name: Setup Node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node }}
       - run: node -v

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
         with:
           node-version: '12'
       - uses: bahmutov/npm-install@v1
@@ -23,7 +23,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
         with:
           node-version: '14'
       - uses: bahmutov/npm-install@v1

--- a/README.md
+++ b/README.md
@@ -382,7 +382,7 @@ jobs:
     name: E2E on Node v${{ matrix.node }}
     steps:
       - name: Setup Node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node }}
       - run: node -v
@@ -940,7 +940,7 @@ jobs:
     name: E2E on Node v${{ matrix.node }}
     steps:
       - name: Setup Node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node }}
       - name: Checkout
@@ -973,7 +973,7 @@ jobs:
         node: [10, 12]
     name: E2E on Node v${{ matrix.node }}
     steps:
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node }}
       - uses: actions/checkout@v2


### PR DESCRIPTION
This PR upgrades GitHub Actions workflows and documentation to use `actions/setup-node@v2`.