### PR TITLE
Fix confusing start command label

### DIFF
--- a/index.js
+++ b/index.js
@@ -354,7 +354,7 @@ const startServersMaybe = () => {
     return execCommand(
       startCommand,
       false,
-      `start server "${startCommand}`
+      `start server`
     )
   })
 }


### PR DESCRIPTION
Removed extra comma

Remove command from the label since the command is logged
afterwards