### PR TITLE
Logging: add folding sections for each stage

### DIFF
--- a/index.js
+++ b/index.js
@@ -858,7 +858,7 @@ const logGroup = (name, fn) => {
    }
 }
 
-logGroup("Restore cache and install", installMaybe)
+logGroup("Restore cache and install", installMaybe)()
   .then(logGroup("Build", buildAppMaybe))
   .then(logGroup("Start Servers", startServersMaybe))
   .then(logGroup("Wait...", waitOnMaybe))


### PR DESCRIPTION
Github actions supports creating folding and collapsing sections of
the log via specially formatted log lines. They provide functions to
spt these out.

Here, we wrap each major stage in a folding log section. This enables
a viewer to more easily skip (collapse) sections that aren't currently
of interest. This is especially helpful if the build command is
verbose for instance.