### PR TITLE
Use modern Node.js version

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -84,7 +84,7 @@ outputs:
   dashboardUrl:
     description: 'Cypress Dashboard URL if the run was recorded'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'
 branding:
   color: 'green'


### PR DESCRIPTION
The current Node.js version (12) doesn't support code used by newer parts of Cypress.
Specifically the `nullish` operator `??`, which is used in `@cypress/react/plugins/utils/get-transpile-folders.js`, since May 2021, see [PR](https://github.com/cypress-io/cypress/pull/16453) for [@cypress/react v5.7.0](https://github.com/cypress-io/cypress/blob/5d1dce61e0641ceaaf1fd0b8153182869459715f/npm/react/CHANGELOG.md#cypressreact-v570-2021-05-12)