### PR TITLE
Use latest version of @semantic-release/git to re-enable semantic releases

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,7 +49,7 @@ jobs:
         with:
           branch: master
           extra_plugins: |
-            @semantic-release/git@v9
+            @semantic-release/git
             @semantic-release/changelog
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Fixes #491