### PR TITLE
docs: remove outdated README reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 
 ## Examples
 
-- [Cypress 10](#cypress-10)
 - [Basic](#basic)
 - [Explicit version](#explicit-version)
 - Run tests in a given [browser](#browser)


### PR DESCRIPTION
The readme references a "Cypress 10" section that doesn't exist anymore since all the examples have been updated.