### PR TITLE
fix: 🐛 action not working in windows or with pnpm 

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -38,6 +38,9 @@ inputs:
   install-command:
     description: 'Custom install command to use'
     required: false
+  hash-file:
+    description: 'Path to the file for cypress cache key generation'
+    required: false
   runTests:
     description: 'Whether or not to run tests'
     required: false


### PR DESCRIPTION
## why not working with windows when install == false

action export the CYPRESS_CACHE_FOLDER env variable, so cli can not find the binary to execute; but binary is already installed by package manager in another cache folder( (ref)[https://docs.cypress.io/guides/references/advanced-installation#Binary-cache],  so according the link,  it will ethier not  working on mac os)

### solution
don't  export  the env variable, if cypress bin is not installted by the action

## why not working with pnpm when install == true
after install action will generate hash from yarn.lock or npm-lock.json, but pnpm dont generate these two files.

### solution

user specify the hash file,  it will be flexiable to working with new locking files.


