### PR TITLE
Fix: Disable summary when it is not available

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -74623,6 +74623,7 @@ const cliParser = __nccwpck_require__(8604)()
 const findYarnWorkspaceRoot = __nccwpck_require__(6748)
 const debug = __nccwpck_require__(8237)('@cypress/github-action')
 const { ping } = __nccwpck_require__(9390)
+const { SUMMARY_ENV_VAR } = __nccwpck_require__(1327)
 
 /**
  * Parses input command, finds the tool and
@@ -75359,7 +75360,16 @@ const runTests = async () => {
     .then(onTestsFinished, onTestsError)
 }
 
+// Summary is not available for GitHub Enterprise at the moment
+const isSummaryEnabled = () => {
+  return process.env[SUMMARY_ENV_VAR] !== undefined
+}
+
 const generateSummary = async (testResults) => {
+  if (!isSummaryEnabled()) {
+    return testResults
+  }
+
   const headers = [
     { data: 'Result', header: true },
     { data: 'Passed :white_check_mark:', header: true },

--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ const cliParser = require('argument-vector')()
 const findYarnWorkspaceRoot = require('find-yarn-workspace-root')
 const debug = require('debug')('@cypress/github-action')
 const { ping } = require('./src/ping')
+const { SUMMARY_ENV_VAR } = require('@actions/core/lib/summary')
 
 /**
  * Parses input command, finds the tool and
@@ -749,7 +750,16 @@ const runTests = async () => {
     .then(onTestsFinished, onTestsError)
 }
 
+// Summary is not available for GitHub Enterprise at the moment
+const isSummaryEnabled = () => {
+  return process.env[SUMMARY_ENV_VAR] !== undefined
+}
+
 const generateSummary = async (testResults) => {
+  if (!isSummaryEnabled()) {
+    return testResults
+  }
+
   const headers = [
     { data: 'Result', header: true },
     { data: 'Passed :white_check_mark:', header: true },


### PR DESCRIPTION
# Fix for unsupported step summary on GHE

The workflow summary is currently not available on GitHub Enterprise.

When trying to use the API it will result in the following error:
```
Error: Unable to find environment variable for $GITHUB_STEP_SUMMARY. Check if your runtime environment supports job summaries.
    at Summary.<anonymous> (/runner/_work/_actions/philipparndt/cy-github-action/disable-summary-on-ghe/dist/index.js:1810:23)
Error: Unable to find environment variable for $GITHUB_STEP_SUMMARY. Check if your runtime environment supports job summaries.
    at Generator.next (<anonymous>)
    at /runner/_work/_actions/philipparndt/cy-github-action/disable-summary-on-ghe/dist/index.js:1783:71
    at new Promise (<anonymous>)
    at __webpack_modules__.1327.__awaiter (/runner/_work/_actions/philipparndt/cy-github-action/disable-summary-on-ghe/dist/index.js:1779:12)
    at Summary.filePath (/runner/_work/_actions/philipparndt/cy-github-action/disable-summary-on-ghe/dist/index.js:1804:16)
    at Summary.<anonymous> (/runner/_work/_actions/philipparndt/cy-github-action/disable-summary-on-ghe/dist/index.js:1850:41)
    at Generator.next (<anonymous>)
    at /runner/_work/_actions/philipparndt/cy-github-action/disable-summary-on-ghe/dist/index.js:1783:71
    at new Promise (<anonymous>)
    at __webpack_modules__.1327.__awaiter (/runner/_work/_actions/philipparndt/cy-github-action/disable-summary-on-ghe/dist/index.js:1779:12)
    at Summary.write (/runner/_work/_actions/philipparndt/cy-github-action/disable-summary-on-ghe/dist/index.js:1848:16)
    at generateSummary (/runner/_work/_actions/philipparndt/cy-github-action/disable-summary-on-ghe/dist/index.js:75393:6)
    at tryCatcher (/runner/_work/vehub-frontend/vehub-frontend/vehub/node_modules/bluebird/js/release/util.js:16:23)
    at Promise._settlePromiseFromHandler (/runner/_work/vehub-frontend/vehub-frontend/vehub/node_modules/bluebird/js/release/promise.js:547:31)
    at Promise._settlePromise (/runner/_work/vehub-frontend/vehub-frontend/vehub/node_modules/bluebird/js/release/promise.js:604:18)
```

This change checks whether or not the feature is available.
It will help to 
- get this great feature as soon as GHE supports the feature 
- and stay up-to-date with the latest `cypress-io/github-action` version

fixes https://github.com/cypress-io/github-action/issues/570