### PR TITLE
Change yarn --frozen-lockfile to --immutable

### DIFF
--- a/index.js
+++ b/index.js
@@ -239,7 +239,7 @@ const install = () => {
       debug(`yarn at "${yarnPath}"`)
       return exec.exec(
         quote(yarnPath),
-        ['--frozen-lockfile'],
+        ['--immutable'],
         cypressCommandOptions
       )
     })


### PR DESCRIPTION
Related: #591 

Yarn 2 has been out for about two years now, which deprecated this flag. The action should use the updated flag by default, with users of Yarn 1 using `install-command` to use the old flag