### PR TITLE
feat: upgrade to use Node v18, remove v12

### DIFF
--- a/.github/workflows/example-node-versions.yml
+++ b/.github/workflows/example-node-versions.yml
@@ -13,18 +13,18 @@ jobs:
     # let's make sure Cypress works on several versions of Node
     strategy:
       matrix:
-        node: [12, 14, 16]
-    name: E2E on Node v${{ matrix.node }}
+        node: [14, 16, 18]
+    name: Cypress v9 E2E on Node v${{ matrix.node }}
     steps:
       - name: Setup Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node }}
       - run: node -v
       - run: npm -v
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       # Hmm, should we rebuild the "dist" before using the action?
 
@@ -39,18 +39,18 @@ jobs:
     # let's make sure Cypress works on several versions of Node
     strategy:
       matrix:
-        node: [12, 14, 16]
-    name: E2E on Node v${{ matrix.node }}
+        node: [14, 16, 18]
+    name: Cypress v10 E2E on Node v${{ matrix.node }}
     steps:
       - name: Setup Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node }}
       - run: node -v
       - run: npm -v
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       # Hmm, should we rebuild the "dist" before using the action?
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,13 +9,13 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        node: [12, 14, 16]
+        node: [14, 16, 18]
     name: Test on Node v${{ matrix.node }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node }}
       - uses: bahmutov/npm-install@v1
@@ -33,7 +33,7 @@ jobs:
     if: github.ref == 'refs/heads/master'
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - uses: bahmutov/npm-install@v1
       # https://github.com/cycjimmy/semantic-release-action
       - name: Semantic Release

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,8 +23,8 @@
         "quote": "0.4.0"
       },
       "devDependencies": {
-        "@types/node": "16.11.35",
-        "@vercel/ncc": "0.33.1",
+        "@types/node": "18.11.9",
+        "@vercel/ncc": "0.34.0",
         "husky": "7.0.4",
         "markdown-link-check": "3.10.2",
         "prettier": "2.6.2",
@@ -479,9 +479,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "16.11.35",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.35.tgz",
-      "integrity": "sha512-QXu45LyepgnhUfnIAj/FyT4uM87ug5KpIrgXfQtUPNAlx8w5hmd8z8emqCLNvG11QkpRSCG9Qg2buMxvqfjfsQ=="
+      "version": "18.11.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.9.tgz",
+      "integrity": "sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg=="
     },
     "node_modules/@types/node-fetch": {
       "version": "2.5.12",
@@ -522,9 +522,9 @@
       }
     },
     "node_modules/@vercel/ncc": {
-      "version": "0.33.1",
-      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.33.1.tgz",
-      "integrity": "sha512-Mlsps/P0PLZwsCFtSol23FGqT3FhBGb4B1AuGQ52JTAtXhak+b0Fh/4T55r0/SVQPeRiX9pNItOEHwakGPmZYA==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.34.0.tgz",
+      "integrity": "sha512-G9h5ZLBJ/V57Ou9vz5hI8pda/YQX5HQszCs3AmIus3XzsmRn/0Ptic5otD3xVST8QLKk7AMk7AqpsyQGN7MZ9A==",
       "dev": true,
       "bin": {
         "ncc": "dist/ncc/cli.js"
@@ -2550,9 +2550,9 @@
       }
     },
     "@types/node": {
-      "version": "16.11.35",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.35.tgz",
-      "integrity": "sha512-QXu45LyepgnhUfnIAj/FyT4uM87ug5KpIrgXfQtUPNAlx8w5hmd8z8emqCLNvG11QkpRSCG9Qg2buMxvqfjfsQ=="
+      "version": "18.11.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.9.tgz",
+      "integrity": "sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg=="
     },
     "@types/node-fetch": {
       "version": "2.5.12",
@@ -2592,9 +2592,9 @@
       }
     },
     "@vercel/ncc": {
-      "version": "0.33.1",
-      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.33.1.tgz",
-      "integrity": "sha512-Mlsps/P0PLZwsCFtSol23FGqT3FhBGb4B1AuGQ52JTAtXhak+b0Fh/4T55r0/SVQPeRiX9pNItOEHwakGPmZYA==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.34.0.tgz",
+      "integrity": "sha512-G9h5ZLBJ/V57Ou9vz5hI8pda/YQX5HQszCs3AmIus3XzsmRn/0Ptic5otD3xVST8QLKk7AMk7AqpsyQGN7MZ9A==",
       "dev": true
     },
     "abort-controller": {

--- a/package.json
+++ b/package.json
@@ -45,8 +45,8 @@
     "quote": "0.4.0"
   },
   "devDependencies": {
-    "@types/node": "16.11.35",
-    "@vercel/ncc": "0.33.1",
+    "@types/node": "18.11.9",
+    "@vercel/ncc": "0.34.0",
     "husky": "7.0.4",
     "markdown-link-check": "3.10.2",
     "prettier": "2.6.2",


### PR DESCRIPTION
BREAKING CHANGE:

Add node v18 support & remove deprecated v12.

- add node v18, remove deprecated v12 in `example-node-versions.yml` test matrix
- add node v18, remove v12 in `main.yml`
- bump `ncc` pkg to fix `ERR_OSSL_EVP_UNSUPPORTED` errors intruduced in node > node v16 (https://github.com/vercel/ncc/pull/868)
- bump `@types/node` to latest
- bump `actions/setup-node`, `actions/checkout` to v3 to prevent  < v16 deprecation warnings
- rename tests for clarity