### PR TITLE
Skip Firefox test using Cypress v9 to resolve flaky tests

### DIFF
--- a/.github/workflows/example-firefox.yml
+++ b/.github/workflows/example-firefox.yml
@@ -11,6 +11,10 @@ jobs:
   firefox:
     # should include Firefox browser install
     # https://github.com/actions/virtual-environments
+    #
+    # skip Firefox test on Cypress v9 due to Cypress issue
+    # https://github.com/cypress-io/cypress/issues/23215
+    if: false 
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout


### PR DESCRIPTION
This PR resolves the issue https://github.com/cypress-io/github-action/issues/659 "CI: Sporadic failures in example-firefox".

The Firefox test under Cypress v9 in [.github/workflows/example-firefox.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-firefox.yml) is disabled, since it is unreliable and the issue has been shown to be reproducible on a local machine independently of github-action.

This allows the Cypress v10 test to then run reliably.