### PR TITLE
Correct Firefox example artifacts and video

### DIFF
--- a/.github/workflows/example-firefox.yml
+++ b/.github/workflows/example-firefox.yml
@@ -32,8 +32,8 @@ jobs:
       # report screenshot size and store the screenshots as test artifacts
       - uses: actions/upload-artifact@v3
         with:
-          name: screenshots-in-firefox
-          path: examples/firefox/cypress/screenshots
+          name: screenshots-in-firefox-v9
+          path: examples/v9/firefox/cypress/screenshots
 
       - run: npx image-size cypress/screenshots/**/*.png
         working-directory: examples/v9/firefox
@@ -60,7 +60,7 @@ jobs:
       # report screenshot size and store the screenshots as test artifacts
       - uses: actions/upload-artifact@v3
         with:
-          name: screenshots-in-firefox
+          name: screenshots-in-firefox-v10
           path: examples/v10/firefox/cypress/screenshots
 
       - run: npx image-size cypress/screenshots/**/*.png

--- a/examples/v10/firefox/cypress.config.js
+++ b/examples/v10/firefox/cypress.config.js
@@ -7,5 +7,6 @@ module.exports = defineConfig({
       return require('./cypress/plugins/index.js')(on, config)
     },
     supportFile: false,
+    video: false
   },
 })

--- a/examples/v9/firefox/cypress.json
+++ b/examples/v9/firefox/cypress.json
@@ -1,4 +1,5 @@
 {
   "fixturesFolder": false,
-  "supportFile": false
+  "supportFile": false,
+  "video": false
 }


### PR DESCRIPTION
This PR resolves the issue https://github.com/cypress-io/github-action/issues/661 "CI: Artifact and video warnings in example-firefox".

1. It corrects [.github/workflows/example-firefox.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-firefox.yml) by selecting the right directory to upload the screenshots captured by the Cypress v9 test and makes the name unique under which the artifacts are stored on GitHub.

2. It disables videos to prevent a video warning message appearing which is a known problem under Firefox (see https://github.com/cypress-io/cypress/issues/18415).

3. ~~`.gitignore` files are created for both v9 and v10 Firefox tests in case the tests are used locally (rather than in the workflow).~~ Edit: removed.

## Verification

Find a successful run of the workflow [example-firefox](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-firefox.yml) by searching on https://github.com/cypress-io/github-action/actions/workflows/example-firefox.yml?query=branch%3Amaster

1. In the "Artifacts" section check that `screenshots-in-firefox-v9` and `screenshots-in-firefox-v10` have both been uploaded. Download each artifact file and examine the contents.

2. In the logs from `firefox-v9` and `firefox-v10` select and expand "Firefox". Check that there are no warnings regarding videos.

*Note: Since PR https://github.com/cypress-io/github-action/pull/660 has now been merged, the `v9` test is skipped, and therefore there is no `screenshots-in-firefox-v9` artifact uploaded and no detailed logs for `firefox-v9` available.*