### PR TITLE
Resolve deprecation warnings for example-basic-pnpm

### DIFF
--- a/.github/workflows/example-basic-pnpm.yml
+++ b/.github/workflows/example-basic-pnpm.yml
@@ -1,4 +1,4 @@
-name: example-basic
+name: example-basic-pnpm
 on:
   push:
     branches:
@@ -7,8 +7,8 @@ on:
 jobs:
   # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Cypress v9 and lower ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ #
 
-  basic-pnpm-ubuntu-18:
-    runs-on: ubuntu-18.04
+  basic-pnpm-ubuntu-20:
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -20,7 +20,7 @@ jobs:
 
       - name: Cypress tests
         # normally you would write
-        # uses: cypress-io/github-action@v2
+        # uses: cypress-io/github-action@v5
         uses: ./
         # the parameters below are only necessary
         # because we are running these examples in a monorepo
@@ -31,8 +31,8 @@ jobs:
           # see https://on.cypress.io/command-line#cypress-info
           build: npx cypress info
 
-  basic-pnpm-ubuntu-20:
-    runs-on: ubuntu-20.04
+  basic-pnpm-ubuntu-22:
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -109,8 +109,8 @@ jobs:
 
   # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Cypress v10 and higher ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ #
 
-  basic-pnpm-ubuntu-18-v10:
-    runs-on: ubuntu-18.04
+  basic-pnpm-ubuntu-20-v10:
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -122,7 +122,7 @@ jobs:
 
       - name: Cypress tests
         # normally you would write
-        # uses: cypress-io/github-action@v2
+        # uses: cypress-io/github-action@v5
         uses: ./
         # the parameters below are only necessary
         # because we are running these examples in a monorepo
@@ -133,8 +133,8 @@ jobs:
           # see https://on.cypress.io/command-line#cypress-info
           build: npx cypress info
 
-  basic-pnpm-ubuntu-20-v10:
-    runs-on: ubuntu-20.04
+  basic-pnpm-ubuntu-22-v10:
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
This PR resolves the deprecation warnings produced by running [.github/workflows/example-basic-pnpm.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-basic-pnpm.ym). It solves one item of issue https://github.com/cypress-io/github-action/issues/648 "Deprecated Ubuntu 18.04 used in example workflows".

## Previous deprecation warnings

The previous deprecation warnings, for instance in run [3643305664](https://github.com/cypress-io/github-action/actions/runs/3643305664), were:

"Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/checkout@v2"

and

"The ubuntu-18.04 environment is deprecated, consider switching to ubuntu-20.04(ubuntu-latest), or ubuntu-22.04 instead. For more details see https://github.com/actions/virtual-environments/issues/6002"

## Remaining warning

The remaining warning is:

"macOS-latest pipelines will use macOS-12 soon. For more details, see https://github.com/actions/runner-images/issues/6384"

There is nothing which needs to be done about this warning as the action is already successfully running macOS 12.6.1 through macOS-latest. It can be considered as a pure info message.

## Name correction

In addition, since the workflow duplicated the name "example-basic" as it shows on the list https://github.com/cypress-io/github-action/actions, the name in the workflow has been extended to "example-basic-pnpm" which aligns with the filename "example-basic-pnpm.yml" of the action.
