### PR TITLE
Make check:markdown successful for github domain checks

### DIFF
--- a/md-linkcheck.json
+++ b/md-linkcheck.json
@@ -1,0 +1,16 @@
+{
+    "httpHeaders": [
+        {
+            "urls": [
+                "https://github.com/",
+                "https://guides.github.com/",
+                "https://docs.github.com/",
+                "https://help.github.com/",
+                "https://support.github.com"
+            ],
+            "headers": {
+                "Accept-Encoding": "zstd, br, gzip, deflate"
+            }
+        }
+    ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "@types/node": "18.11.9",
         "@vercel/ncc": "0.34.0",
         "husky": "7.0.4",
-        "markdown-link-check": "3.10.2",
+        "markdown-link-check": "3.10.3",
         "prettier": "2.6.2",
         "stop-build": "1.1.0"
       }
@@ -1466,17 +1466,17 @@
       }
     },
     "node_modules/markdown-link-check": {
-      "version": "3.10.2",
-      "resolved": "https://registry.npmjs.org/markdown-link-check/-/markdown-link-check-3.10.2.tgz",
-      "integrity": "sha512-5yQEVtjLxAjxWy82+iTgxrekr1tuD4sKGgwXiyLrCep8RERFH3yCdpZdeA12em2S2SEwXGxp6qHI73jVhuScKA==",
+      "version": "3.10.3",
+      "resolved": "https://registry.npmjs.org/markdown-link-check/-/markdown-link-check-3.10.3.tgz",
+      "integrity": "sha512-uGdJiZOy1CVWlRe7CyBSJ0Gz80Xm4vt++xjX9sNFjB7qcAxLinaMmzFQ5xOwERaXC9mK770BhnqnsyJT1gTr9w==",
       "dev": true,
       "dependencies": {
-        "async": "^3.2.3",
+        "async": "^3.2.4",
         "chalk": "^4.1.2",
         "commander": "^6.2.0",
-        "link-check": "^5.1.0",
+        "link-check": "^5.2.0",
         "lodash": "^4.17.21",
-        "markdown-link-extractor": "^3.0.2",
+        "markdown-link-extractor": "^3.1.0",
         "needle": "^3.1.0",
         "progress": "^2.0.3"
       },
@@ -3290,17 +3290,17 @@
       "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA=="
     },
     "markdown-link-check": {
-      "version": "3.10.2",
-      "resolved": "https://registry.npmjs.org/markdown-link-check/-/markdown-link-check-3.10.2.tgz",
-      "integrity": "sha512-5yQEVtjLxAjxWy82+iTgxrekr1tuD4sKGgwXiyLrCep8RERFH3yCdpZdeA12em2S2SEwXGxp6qHI73jVhuScKA==",
+      "version": "3.10.3",
+      "resolved": "https://registry.npmjs.org/markdown-link-check/-/markdown-link-check-3.10.3.tgz",
+      "integrity": "sha512-uGdJiZOy1CVWlRe7CyBSJ0Gz80Xm4vt++xjX9sNFjB7qcAxLinaMmzFQ5xOwERaXC9mK770BhnqnsyJT1gTr9w==",
       "dev": true,
       "requires": {
-        "async": "^3.2.3",
+        "async": "^3.2.4",
         "chalk": "^4.1.2",
         "commander": "^6.2.0",
-        "link-check": "^5.1.0",
+        "link-check": "^5.2.0",
         "lodash": "^4.17.21",
-        "markdown-link-extractor": "^3.0.2",
+        "markdown-link-extractor": "^3.1.0",
         "needle": "^3.1.0",
         "progress": "^2.0.3"
       }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test": "echo \"There are no tests :(\"",
     "build": "ncc build -o dist index.js",
     "format": "prettier --write index.js",
-    "check:markdown": "find *.md -exec npx markdown-link-check {} \\;",
+    "check:markdown": "find *.md -print0 | xargs -0 -n1 markdown-link-check -c md-linkcheck.json",
     "install-v10-deps": "./scripts/npm-install-v10-examples.sh"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@types/node": "18.11.9",
     "@vercel/ncc": "0.34.0",
     "husky": "7.0.4",
-    "markdown-link-check": "3.10.2",
+    "markdown-link-check": "3.10.3",
     "prettier": "2.6.2",
     "stop-build": "1.1.0"
   },


### PR DESCRIPTION
This PR resolves issue https://github.com/cypress-io/github-action/issues/664 "markdown-link-check produces wrong results and exit status"

1. To resolve the issue that link checking on the domain [github.com](https://github.com/) results in 403 Forbidden errors, the new markdown-link-check configuration file `md-linkcheck.json` is added and it is referred to by the script `check:markdown`. After adding this config file, checks on links to github.com no longer produce a 403 error.

2. To resolve the issue that the action [main.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/main.yml) is successful, even when the markdown link check fails, the check:markdown script is converted to use `xargs` instead of `exec` as suggested in https://github.com/tcort/markdown-link-check#check-links-from-a-local-markdown-folder-recursive. 

The new check:markdown script, which is invoked by npm run check:markdown is now defined as:

```shell
find *.md -print0 | xargs -0 -n1 markdown-link-check -c md-linkcheck.json
```

Changing the script ensures that no 403 (forbidden) errors are produced for otherwise correctly working links on github.com. Also if there are genuine link errors found, then the [main.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/main.yml) action will show failure, which should alert to one or more links which need correcting. In the past, link check failures went (apparently) unnoticed. 

## Verification

### Verification with bad links

When there are known bad links in `*.md` files e.g. when `npm run check:markdown` finds 400 or 404 errors for links on the branch to be tested.

After [main.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/main.yml) has completed its run, examine the logs.

"Test on Node v14" has a red X. "Run npm run check:markdown" shows no 403 errors and completes with the message "Error: Process completed with exit code 123."

![link failure no 403](https://user-images.githubusercontent.com/66998419/207293543-1059f1a2-55db-4a87-a9c4-859b9b456e83.jpg)

### Verification with no bad links

When there are no known bad links in `*.md` files e.g. when `npm run check:markdown` finds no 400 or 404 errors for links on the branch to be tested.

After [main.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/main.yml) has completed its run, examine the logs of main.yml.

Look for success (green tick).

Matrix build-and-test shows 3 jobs completed.

![main matrix](https://user-images.githubusercontent.com/66998419/207293647-cdea4ba9-2675-4ff4-ad19-c6333717e514.jpg)

Look at details of any of Test on Node v14 / v16 / v18. Drill down into "Run npm run check:markdown" which should end with no errors and a line similar to "134 links checked."

![links checked](https://user-images.githubusercontent.com/66998419/207293726-7020a3e4-f8f0-4d30-bd61-7c1f48f5267d.jpg)
