### PR TITLE
Clear Annotations warnings from example-chrome workflow

### DIFF
--- a/.github/workflows/example-chrome.yml
+++ b/.github/workflows/example-chrome.yml
@@ -8,7 +8,7 @@ jobs:
 
   # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Cypress v9 and lower ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ #
 
-  tests:
+  tests-v9:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout
@@ -31,8 +31,8 @@ jobs:
       # store screenshot captured during the test
       - uses: actions/upload-artifact@v3
         with:
-          name: screenshots-in-electron
-          path: examples/chrome/cypress/screenshots
+          name: screenshots-in-electron-v9
+          path: examples/v9/chrome/cypress/screenshots
 
       - run: npx image-size cypress/screenshots/**/*.png
         working-directory: examples/v9/chrome
@@ -45,13 +45,13 @@ jobs:
 
       - uses: actions/upload-artifact@v3
         with:
-          name: screenshots-in-chrome
-          path: examples/chrome/cypress/screenshots
+          name: screenshots-in-chrome-v9
+          path: examples/v9/chrome/cypress/screenshots
 
       - uses: actions/upload-artifact@v3
         with:
-          name: video-in-chrome
-          path: examples/chrome/cypress/videos
+          name: video-in-chrome-v9
+          path: examples/v9/chrome/cypress/videos
 
       - run: npx image-size cypress/screenshots/**/*.png
         working-directory: examples/v9/chrome
@@ -70,13 +70,13 @@ jobs:
 
       - uses: actions/upload-artifact@v3
         with:
-          name: screenshots-in-headed-chrome
-          path: examples/chrome/cypress/screenshots
+          name: screenshots-in-headed-chrome-v9
+          path: examples/v9/chrome/cypress/screenshots
 
       - uses: actions/upload-artifact@v3
         with:
-          name: video-in-headed-chrome
-          path: examples/chrome/cypress/videos
+          name: video-in-headed-chrome-v9
+          path: examples/v9/chrome/cypress/videos
 
       - run: npx image-size cypress/screenshots/**/*.png
         working-directory: examples/v9/chrome
@@ -106,7 +106,7 @@ jobs:
       # store screenshot captured during the test
       - uses: actions/upload-artifact@v3
         with:
-          name: screenshots-in-electron
+          name: screenshots-in-electron-v10
           path: examples/v10/chrome/cypress/screenshots
 
       - run: npx image-size cypress/screenshots/**/*.png
@@ -120,12 +120,12 @@ jobs:
 
       - uses: actions/upload-artifact@v3
         with:
-          name: screenshots-in-chrome
+          name: screenshots-in-chrome-v10
           path: examples/v10/chrome/cypress/screenshots
 
       - uses: actions/upload-artifact@v3
         with:
-          name: video-in-chrome
+          name: video-in-chrome-v10
           path: examples/v10/chrome/cypress/videos
 
       - run: npx image-size cypress/screenshots/**/*.png
@@ -141,16 +141,16 @@ jobs:
         with:
           working-directory: examples/v10/chrome
           browser: chrome
-          headless: true
+          headed: false
 
       - uses: actions/upload-artifact@v3
         with:
-          name: screenshots-in-headless-chrome
+          name: screenshots-in-headless-chrome-v10
           path: examples/v10/chrome/cypress/screenshots
 
       - uses: actions/upload-artifact@v3
         with:
-          name: video-in-headless-chrome
+          name: video-in-headless-chrome-v10
           path: examples/v10/chrome/cypress/videos
 
       - run: npx image-size cypress/screenshots/**/*.png


### PR DESCRIPTION
This PR resolves issue https://github.com/cypress-io/github-action/issues/669 "CI: Workflow chrome shows Annotations warnings".

It updates the example workflow [.github/workflows/example-chrome.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-chrome.yml) by

1. correcting the paths for artifact uploads. Adds `v9` for v9 tests. 
2. ensuring that the artifact names are unique. Appends `-v10` to v10 tests.
3. converting the incorrect parameter `headless: true` to `headed: false`

Edit: In addition, as requested, the v9 test, and artifacts produced by it, have `-v9` added to their labels.

## Verification

View the action logs for https://github.com/cypress-io/github-action/actions/workflows/example-chrome.yml and check that there are no longer any Annotations warnings.

The count of Artifacts should show 10.