### PR TITLE
Update Docker examples in README to Node.js 18

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ jobs:
   firefox:
     runs-on: ubuntu-22.04
     container:
-      image: cypress/browsers:node12.16.1-chrome80-ff73
+      image: cypress/browsers:node18.12.0-chrome106-ff106
       options: --user 1001
     steps:
       - uses: actions/checkout@v3
@@ -175,9 +175,9 @@ on: [push]
 jobs:
   cypress-run:
     runs-on: ubuntu-22.04
-    # Cypress Docker image with Chrome v78
-    # and Firefox v70 pre-installed
-    container: cypress/browsers:node12.13.0-chrome78-ff70
+    # Cypress Docker image with Chrome v106
+    # and Firefox v106 pre-installed
+    container: cypress/browsers:node18.12.0-chrome106-ff106
     steps:
       - uses: actions/checkout@v3
       - uses: cypress-io/github-action@v5


### PR DESCRIPTION
This PR resolves the documentation issue https://github.com/cypress-io/github-action/issues/680 "Example uses Docker image with end-of-life Node.js 12".

In the documentation examples

- [Docker image](https://github.com/cypress-io/github-action#docker-image) 
- [Firefox](https://github.com/cypress-io/github-action#firefox)

the Cypress Docker image

- [cypress/browsers:node18.12.0-chrome106-ff106](https://github.com/cypress-io/cypress-docker-images/tree/master/browsers/node18.12.0-chrome106-ff106) is substituted for the 

- [cypress/browsers:node12.13.0-chrome78-ff70](https://github.com/cypress-io/cypress-docker-images/tree/master/browsers/node12.13.0-chrome78-ff70) Docker image,

since Node.js 12 already passed End-of-Life last year on 2022-04-30 according to the [End-of-Life Releases](https://github.com/nodejs/release#end-of-life-releases) list.

## Verification

Create a new workflow `example-docker.yml` in the `.github/workflows` directory of a local copy of a fork of this repository as below:

```yml
name: E2E in custom container
on: [push]
jobs:
  cypress-run:
    runs-on: ubuntu-20.04
    # Cypress Docker image with Chrome v106
    # and Firefox v106 pre-installed
    container: cypress/browsers:node18.12.0-chrome106-ff106
    steps:
      - uses: actions/checkout@v3
      - uses: cypress-io/github-action@v5
        with:
          browser: chrome
          working-directory: examples/basic
```

Push the example to the repository and ensure that the action log shows that it ran successfully.

Similarly for the Firefox example.