### PR TITLE
Resolve markdown-link-check forbidden with renovate app link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# cypress-io/github-action [![renovate-app badge][renovate-badge]][renovate-app] [![Action status](https://github.com/cypress-io/github-action/workflows/main/badge.svg?branch=master)](https://github.com/cypress-io/github-action/actions)
+# cypress-io/github-action [![renovate-app badge][renovate-badge]][renovate-bot] [![Action status](https://github.com/cypress-io/github-action/workflows/main/badge.svg?branch=master)](https://github.com/cypress-io/github-action/actions)
 
 > [GitHub Action](https://docs.github.com/en/actions) for running [Cypress](https://www.cypress.io) end-to-end tests. Includes NPM installation, custom caching and lots of configuration options.
 
@@ -1282,4 +1282,4 @@ This is noted as a breaking change ... but you should not see any changes. We ha
 [MIT License](./LICENSE.md)
 
 [renovate-badge]: https://img.shields.io/badge/renovate-app-blue.svg
-[renovate-app]: https://renovateapp.com/
+[renovate-bot]: https://github.com/renovatebot


### PR DESCRIPTION
This PR resolves a new issue that `npm run check:markdown` fails on GitHub when checking the link https://renovateapp.com/ in the [README](https://github.com/cypress-io/github-action/blob/master/README.md) file. The error is HTTP 403 forbidden.

When run locally there is no failure and https://renovateapp.com/ redirects to https://renovatebot.com/ and then to https://www.mend.io/free-developer-tools/renovate/.

I have replaced the link
https://renovateapp.com/
by
https://github.com/renovatebot
and this passes the `npm run check:markdown` check on GitHub.

## Problem analysis

CloudFront is blocking access to https://www.mend.io/free-developer-tools/renovate/ from GitHub by responding with 403 forbidden. A `cy.visit('https://www.mend.io/free-developer-tools/renovate/)` run on GitHub also fails.

`curl -v https://www.mend.io/free-developer-tools/renovate/ -o /dev/null` run on GitHub shows:
```
< HTTP/2 403 
< server: CloudFront
< content-type: text/html
< x-cache: Error from cloudfront
```