### PR TITLE
Update supported Node.js versions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,7 +378,7 @@ jobs:
     # let's make sure our "app" works on several versions of Node
     strategy:
       matrix:
-        node: [10, 12]
+        node: [14, 16, 18]
     name: E2E on Node v${{ matrix.node }}
     steps:
       - name: Setup Node
@@ -936,7 +936,7 @@ jobs:
     # let's make sure our "app" works on several versions of Node
     strategy:
       matrix:
-        node: [10, 12]
+        node: [14, 16, 18]
     name: E2E on Node v${{ matrix.node }}
     steps:
       - name: Setup Node
@@ -970,7 +970,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [10, 12]
+        node: [14, 16, 18]
     name: E2E on Node v${{ matrix.node }}
     steps:
       - uses: actions/setup-node@v3


### PR DESCRIPTION
This PR resolves issue https://github.com/cypress-io/github-action/issues/691 "README lists unsupported Node.js versions 10 and 12".

Instances in [README.md](https://github.com/cypress-io/github-action/blob/master/README.md) with examples using `node: [10, 12]` are updated to use the current set of supported Node.js versions `node: [14, 16, 18]` instead.