### PR TITLE
Record to Cypress Cloud in fork

### DIFF
--- a/.github/workflows/example-custom-ci-build-id.yml
+++ b/.github/workflows/example-custom-ci-build-id.yml
@@ -1,3 +1,15 @@
+name: example-custom-ci-build-id
+#
+# If this workflow is failing and you do not want to use it
+# then you can disable it individually.
+# See GitHub help: Disabling and enabling a workflow
+# https://docs.github.com/en/actions/managing-workflow-runs/disabling-and-enabling-a-workflow).
+#
+# To set it up to work with your own Cypress Cloud refer to the README
+# in the example directory examples/v10/recording.
+#
+# ---
+#
 # Typically you would let this action
 # determine a unique build id to tie multiple parallel
 # test jobs together into a single logical Cypress Cloud run.
@@ -13,12 +25,22 @@
 # in 2019 so this is replaced by GitHub Environment files, see
 # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#environment-files
 #
-name: example-custom-ci-build-id
+
 on:
   push:
     branches:
       - 'master'
   pull_request:
+
+env:
+  # Set up the Cypress Cloud project ID and record key as environment variables
+  # If the Actions variable EXAMPLE_PROJECT_ID is not defined then
+  # the projectId is taken from cypress.json (Legacy configuration)
+  # or cypress.config.js (v10 and later).
+  CYPRESS_PROJECT_ID: ${{ vars.EXAMPLE_PROJECT_ID }}
+  CYPRESS_RECORD_KEY: ${{ secrets.EXAMPLE_RECORDING_KEY }}
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
 jobs:
   # single job that generates and outputs a common id
   prepare:
@@ -59,9 +81,6 @@ jobs:
           ci-build-id: ${{ needs.prepare.outputs.uuid }}
           spec: 'cypress/e2e/spec-a.cy.js'
           working-directory: examples/recording
-        env:
-          # pass the Cypress Cloud record key as an environment variable
-          CYPRESS_RECORD_KEY: ${{ secrets.EXAMPLE_RECORDING_KEY }}
 
   # if smoke tests pass, run all tests, splitting them in parallel
   # because we record with the same build id, smoke and these
@@ -92,6 +111,3 @@ jobs:
               --ci-build-id ${{ needs.prepare.outputs.uuid }} \
               --group "2 - all tests"
           working-directory: examples/recording
-        env:
-          # pass the Cypress Cloud record key as an environment variable
-          CYPRESS_RECORD_KEY: ${{ secrets.EXAMPLE_RECORDING_KEY }}

--- a/.github/workflows/example-recording.yml
+++ b/.github/workflows/example-recording.yml
@@ -1,9 +1,27 @@
 name: example-recording
+#
+# If this workflow is failing and you do not want to use it
+# then you can disable it individually.
+# See GitHub help: Disabling and enabling a workflow
+# https://docs.github.com/en/actions/managing-workflow-runs/disabling-and-enabling-a-workflow).
+#
+# To set it up to work with your own Cypress Cloud refer to the README
+# in the corresponding example directory examples/*/recording.
+#
 on:
   push:
     branches:
       - 'master'
   pull_request:
+
+env:
+  # Set up the Cypress Cloud project ID and record key as environment variables
+  # If the Actions variable EXAMPLE_PROJECT_ID is not defined then
+  # the projectId is taken from cypress.json (v9) or cypress.config.js (v10 and later).
+  CYPRESS_PROJECT_ID: ${{ vars.EXAMPLE_PROJECT_ID }}
+  CYPRESS_RECORD_KEY: ${{ secrets.EXAMPLE_RECORDING_KEY }}
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
 jobs:
 
   # ~~~~~~~~~~~~~~~~~~ Cypress v9 and below (using Legacy configuration) ~~~~~~~~~~~~~~~~~~~ #
@@ -30,10 +48,6 @@ jobs:
           parallel: true
           group: Recording example v9
           tag: action
-        env:
-          # pass the Dashboard record key as an environment variable
-          CYPRESS_RECORD_KEY: ${{ secrets.EXAMPLE_RECORDING_KEY }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # see "outcome" and "conclusion" of a step doc
       # https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#steps-context
@@ -58,10 +72,6 @@ jobs:
           record: true
           # no parallel flag, just the group name
           group: Recording group v9
-        env:
-          # pass the Dashboard record key as an environment variable
-          CYPRESS_RECORD_KEY: ${{ secrets.EXAMPLE_RECORDING_KEY }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Cypress v10 and higher ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ #
 
@@ -87,10 +97,6 @@ jobs:
           parallel: true
           group: Recording example
           tag: action
-        env:
-          # pass the Dashboard record key as an environment variable
-          CYPRESS_RECORD_KEY: ${{ secrets.EXAMPLE_RECORDING_KEY }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # see "outcome" and "conclusion" of a step doc
       # https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#steps-context
@@ -115,7 +121,3 @@ jobs:
           record: true
           # no parallel flag, just the group name
           group: Recording group
-        env:
-          # pass the Dashboard record key as an environment variable
-          CYPRESS_RECORD_KEY: ${{ secrets.EXAMPLE_RECORDING_KEY }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -331,12 +331,12 @@ jobs:
         with:
           record: true
         env:
-          # pass the Cypress Cloud record key as an environment variable
+          # pass the Cypress Cloud record key as an environment variable (Actions secret)
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
           # pass GitHub token to allow accurately detecting a build vs a re-run build
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # pass the project ID from the secrets through environment variable
-          CYPRESS_PROJECT_ID: ${{ secrets.PROJECT_ID }}
+          # pass the project ID as an environment variable (Actions variable)
+          CYPRESS_PROJECT_ID: ${{ vars.PROJECT_ID }}
 ```
 
 ### Quiet flag

--- a/examples/recording/README.md
+++ b/examples/recording/README.md
@@ -1,0 +1,26 @@
+# example: recording
+
+The recording example uses [Cypress Cloud](https://docs.cypress.io/guides/cloud/introduction) to record results using the Cypress Cloud `projectId` as defined in the [cypress.config.js](cypress.config.js) configuration file.
+
+## Using your own Cypress Cloud project
+
+In order to use the recording example with your own Cypress Cloud project, you need to replace the `projectId` and `record key` with your own values.
+
+Follow the [Cypress Cloud](https://docs.cypress.io/guides/cloud/introduction) documentation to sign up, if you do not already have an account, or to [sign in](https://cloud.cypress.io/) if you have an account.
+
+Create a new project if one does not exist.
+
+Access "Project settings" in Cypress Cloud and copy the contents of each of the following parameters for the project into the Security settings of your GitHub fork, using "Secrets and variables" > "Actions", then "Variables" for the "Project ID" and "Secrets" for the "Record Key" as in the table below:
+
+| Cypress Cloud name | Actions name in fork | Variable type     |
+| ------------------ | -------------------- | ----------------- |
+| Project ID         | EXAMPLE_PROJECT_ID   | Actions variables |
+| Record Keys        | EXAMPLE_RECORD_KEY   | Actions secrets   |
+
+Refer to the GitHub documentation
+- [Defining configuration variables for multiple workflows](https://docs.github.com/en/actions/learn-github-actions/variables#defining-configuration-variables-for-multiple-workflows)
+- [Creating encrypted secrets for a repository](https://docs.github.com/en/actions/security-guides/encrypted-secrets#creating-encrypted-secrets-for-a-repository).
+
+When you have done this, the example recording will take the `projectId` from the `EXAMPLE_PROJECT_ID` variable instead of from the [cypress.config.js](cypress.config.js) configuration file.
+
+This setup allows the example recording to run in your own Cypress Cloud project, whilst leaving the same example for use in the parent repository [cypress-io/github-action](https://github.com/cypress-io/github-action) unchanged. The parent repository has its own `EXAMPLE_RECORD_KEY` defined as a secret and it uses the `projectId` as defined in the [cypress.config.js](cypress.config.js) configuration file.

--- a/examples/v9/recording/README.md
+++ b/examples/v9/recording/README.md
@@ -1,0 +1,26 @@
+# example: recording
+
+The recording example uses [Cypress Cloud](https://docs.cypress.io/guides/cloud/introduction) to record results using the Cypress Cloud `projectId` as defined in the [cypress.json](cypress.json) configuration file.
+
+## Using your own Cypress Cloud project
+
+In order to use the recording example with your own Cypress Cloud project, you need to replace the `projectId` and `record key` with your own values.
+
+Follow the [Cypress Cloud](https://docs.cypress.io/guides/cloud/introduction) documentation to sign up, if you do not already have an account, or to [sign in](https://cloud.cypress.io/) if you have an account.
+
+Create a new project if one does not exist.
+
+Access "Project settings" in Cypress Cloud and copy the contents of each of the following parameters for the project into the Security settings of your GitHub fork, using "Secrets and variables" > "Actions", then "Variables" for the "Project ID" and "Secrets" for the "Record Key" as in the table below:
+
+| Cypress Cloud name | Actions name in fork | Variable type     |
+| ------------------ | -------------------- | ----------------- |
+| Project ID         | EXAMPLE_PROJECT_ID   | Actions variables |
+| Record Keys        | EXAMPLE_RECORD_KEY   | Actions secrets   |
+
+Refer to the GitHub documentation
+- [Defining configuration variables for multiple workflows](https://docs.github.com/en/actions/learn-github-actions/variables#defining-configuration-variables-for-multiple-workflows)
+- [Creating encrypted secrets for a repository](https://docs.github.com/en/actions/security-guides/encrypted-secrets#creating-encrypted-secrets-for-a-repository).
+
+When you have done this, the example recording will take the `projectId` from the `EXAMPLE_PROJECT_ID` variable instead of from the [cypress.json](cypress.json) configuration file.
+
+This setup allows the example recording to run in your own Cypress Cloud project, whilst leaving the same example for use in the parent repository [cypress-io/github-action](https://github.com/cypress-io/github-action) unchanged. The parent repository has its own `EXAMPLE_RECORD_KEY` defined as a secret and it uses the `projectId` as defined in the [cypress.json](cypress.json) configuration file.


### PR DESCRIPTION
This PR resolves the issue https://github.com/cypress-io/github-action/issues/693 "Workflows using Cypress Cloud fail in fork".

It follows the recommendation in the [README: Record test results on Cypress Cloud](https://github.com/cypress-io/github-action/blob/master/README.md#record-test-results-on-cypress-cloud) documentation, Tip 4, to pass the project id using an environment variable.

The two examples are modified so that they accept and use a new GitHub Actions variable `EXAMPLE_PROJECT_ID` in addition to the existing `EXAMPLE_RECORDING_KEY` which is an Actions secret:

- [example-custom-ci-build-id](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-custom-ci-build-id.yml)
- [example-recording](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-recording.yml)

This is backward compatible to the current workflows.

In the parent repository [cypress-io/github-action](https://github.com/cypress-io/github-action) the Actions secret `EXAMPLE_RECORDING_KEY` is defined for the Project ID `3tb7jn`. Runs are publicly viewable via the Cypress Cloud on https://cloud.cypress.io/projects/3tb7jn.

If fork users define `EXAMPLE_PROJECT_ID` as Actions variable and `EXAMPLE_RECORDING_KEY` as Actions secret in their forked repository then the workflows record into the user's own project. If this step is not taken, then the workflows will simply continue to report failures if they are triggered in a fork, exactly as happens before this PR was introduced.

README files have been added as:

- examples/v9/recording/README.md
- examples/recording/README.md

to explain how to obtain and add a user's own `EXAMPLE_PROJECT_ID` and `EXAMPLE_RECORDING_KEY`.

The README files are reviewable in

- https://github.com/MikeMcC399/github-action/blob/feat/record-in-fork/examples/v9/recording/README.md
- https://github.com/MikeMcC399/github-action/blob/feat/record-in-fork/examples/recording/README.md

## Verification

### Backwards compatibility

Ensure that the workflows for the parent repository [cypress-io/github-action](https://github.com/cypress-io/github-action) continue to report success:

- https://github.com/cypress-io/github-action/actions/workflows/example-custom-ci-build-id.yml?query=branch%3Amaster
- https://github.com/cypress-io/github-action/actions/workflows/example-recording.yml?query=branch%3Amaster

### New functionality

Follow the instructions to create new `EXAMPLE_PROJECT_ID` Actions variable and `EXAMPLE_RECORDING_KEY` Actions secret and check that the results are published on Cypress Cloud.