### PR TITLE
Correct ubuntu versions for basic example

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ jobs:
 
 [![Basic example](https://github.com/cypress-io/github-action/workflows/example-basic/badge.svg?branch=master)](.github/workflows/example-basic.yml)
 
-The workflow file [.github/workflows/example-basic.yml](.github/workflows/example-basic.yml) shows how Cypress runs on GH Actions using Ubuntu (16, 18, or 20), on Windows, and on Mac without additional OS dependencies necessary.
+The workflow file [.github/workflows/example-basic.yml](.github/workflows/example-basic.yml) shows how Cypress runs on GH Actions using Ubuntu (20 and 22), on Windows, and on Mac without additional OS dependencies necessary.
 
 **Note:** this package assumes that `cypress` is declared as a development dependency in the `package.json` file. The `cypress` NPM module is required to run Cypress via its [NPM module API](https://on.cypress.io/module-api).
 


### PR DESCRIPTION
This PR corrects the reference to the Ubuntu versions used by the [example-basic.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-basic.yml) workflow described in README section [Basic](https://github.com/cypress-io/github-action/blob/master/README.md#basic).

The currently used versions are:

- `runs-on: ubuntu-20.04`
- `runs-on: ubuntu-22.04`
