### PR TITLE
Remove scripted npm update for yarn-based install-command

### DIFF
--- a/scripts/npm-install-v10-examples.sh
+++ b/scripts/npm-install-v10-examples.sh
@@ -7,7 +7,6 @@ cd ../config && npm install cypress@latest
 cd ../custom-command && npm install cypress@latest
 cd ../env && npm install cypress@latest
 cd ../firefox && npm install cypress@latest
-cd ../install-command && npm install cypress@latest
 cd ../install-only && npm install cypress@latest
 cd ../node-versions && npm install cypress@latest
 cd ../quiet && npm install cypress@latest


### PR DESCRIPTION
This PR resolves issue https://github.com/cypress-io/github-action/issues/699 "npm-install-v10-examples script targets yarn example-install-command".

It removes the incorrect instruction

```bash
cd ../install-command && npm install cypress@latest
```
 from [npm-install-v10-examples.sh](https://github.com/cypress-io/github-action/blob/master/scripts/npm-install-v10-examples.sh).

 Since [examples/v10/install-command](https://github.com/cypress-io/github-action/tree/master/examples/v10/install-command) is based on `yarn` it must only be updated using `yarn` rather than `npm`.

 ## Verification

 Execute [npm-install-v10-examples.sh](https://github.com/cypress-io/github-action/blob/master/scripts/npm-install-v10-examples.sh) locally and ensure that there is no change to the files in the directory [examples/v10/install-command](https://github.com/cypress-io/github-action/tree/master/examples/v10/install-command).