### PR TITLE
Remove non-working archived example links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1069,13 +1069,10 @@ Name | Description
 [cypress-gh-action-monorepo](https://github.com/bahmutov/cypress-gh-action-monorepo) | splits install and running tests commands, runs Cypress from sub-folder
 [cypress-gh-action-subfolders](https://github.com/bahmutov/cypress-gh-action-subfolders) | separate folder for Cypress dependencies
 [cypress-gh-action-split-install](https://github.com/bahmutov/cypress-gh-action-split-install) | only install NPM dependencies, then install and cache Cypress binary yourself
-[cypress-gh-action-vue-example](https://github.com/cypress-io/cypress-gh-action-vue-example) | project was scaffolded using Vue CLI
-[gh-action-and-gh-integration](https://github.com/cypress-io/gh-action-and-gh-integration) | records to the dashboard and has [Cypress GH Integration](https://on.cypress.io/github-integration) app installed
 [test-personal-site](https://github.com/bahmutov/test-personal-site) | Testing an external website every night and by manually clicking a button.
 [cypress-gh-action-changed-files](https://github.com/bahmutov/cypress-gh-action-changed-files) | Shows how to run different Cypress projects depending on changed files
 [cypress-examples](https://github.com/bahmutov/cypress-examples) | Shows separate install job from parallel test jobs
 [cypress-gh-action-split-jobs](https://github.com/bahmutov/cypress-gh-action-split-jobs) | Shows a separate install job with the build step, and another job that runs the tests
-[cypress-and-jest-typescript-example](https://github.com/cypress-io/cypress-and-jest-typescript-example) | Run E2E and Jest unit tests in parallel
 [cypress-react-component-example](https://github.com/bahmutov/cypress-react-component-example) | Run E2E and component tests using this action
 <!-- prettier-ignore-end -->
 


### PR DESCRIPTION
This PR resolves issue https://github.com/cypress-io/github-action/issues/709 "Linked archived 'More examples' in README using @v1 fail"

The archived and failing example repositories as follows are removed from the README section [More examples](https://github.com/cypress-io/github-action#more-examples):

| Failing examples using GHA @v1                                                                           |
| -------------------------------------------------------------------------------------------------------- |
| [cypress-io/cypress-and-jest-typescript-example](https://github.com/cypress-io/cypress-and-jest-typescript-example) |
| [cypress-io/cypress-gh-action-vue-example](https://github.com/cypress-io/cypress-gh-action-vue-example)             |
| [cypress-io/gh-action-and-gh-integration](https://github.com/cypress-io/gh-action-and-gh-integration)               |
