### PR TITLE
Update semantic-release-action to v3

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,7 +1,7 @@
 name: main
 on:
   push:
-    branches:    
+    branches:
       - 'master'
   pull_request:
 jobs:
@@ -37,7 +37,7 @@ jobs:
       - uses: bahmutov/npm-install@v1
       # https://github.com/cycjimmy/semantic-release-action
       - name: Semantic Release
-        uses: cycjimmy/semantic-release-action@v2
+        uses: cycjimmy/semantic-release-action@v3
         id: semantic
         with:
           branch: master


### PR DESCRIPTION
This PR resolves the show-stopper issue https://github.com/cypress-io/github-action/issues/711 "main / release fails with Error [ERR_REQUIRE_ESM]" which was caused by the [semantic-release v20.0.0](https://github.com/semantic-release/semantic-release/releases/tag/v20.0.0) on Jan 6, 2023. The new semantic-release v20 contains breaking changes related to ESM-only and minimum Node.js 18 and it is currently used by default by [main.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/main.yml), since no version is specified.

In this PR [main.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/main.yml) is updated to use [cycjimmy/semantic-release-action](https://github.com/cycjimmy/semantic-release-action) v3 instead of v2.

This resolves the issue because [cycjimmy/semantic-release-action](https://github.com/cycjimmy/semantic-release-action) v3 defaults to using the compatible [semantic-release v19.0.5](https://github.com/semantic-release/semantic-release/releases/tag/v19.0.5). The v3 version of this action specifies a working default, whereas the previous v2 version did not do this.

Until this PR is merged, it will not be possible to release any new versions of GHA.