### PR TITLE
Correct README for "Start multiple servers" to use ubuntu-22.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -623,7 +623,7 @@ name: With servers
 on: [push]
 jobs:
   cypress-run:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
This corrects the example https://github.com/cypress-io/github-action/blob/master/README.md#start-multiple-servers

`runs-on: ubuntu-18.04`

now reads

`runs-on: ubuntu-22.04`

It was overlooked, as the only example still specifying `ubuntu-18.04` and it should have been handled by PR https://github.com/cypress-io/github-action/pull/720. ([ubuntu-18.04](https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu1804-Readme.md) is deprecated.)
