### PR TITLE
Update README.md for Specs section 

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ jobs:
           spec: cypress/integration/spec1.js
 ```
 
-You can pass multiple multiple specs and wild card patterns using multi-line parameter, see [example-config.yml](./.github/workflows/example-config.yml):
+You can pass multiple specs and wild card patterns using multi-line parameter, see [example-config.yml](./.github/workflows/example-config.yml):
 
 ```yml
 spec: |


### PR DESCRIPTION
This correct the typo in Specs section.

Previously it was like that:

`You can pass multiple multiple specs and wild card patterns using multi-line parameter, see [example-config.yml](https://file+.vscode-resource.vscode-cdn.net/Users/uzairkhan/Repos/github-action/.github/workflows/example-config.yml):`

Now it will show like that:

`You can pass multiple specs and wild card patterns using multi-line parameter, see [example-config.yml](https://file+.vscode-resource.vscode-cdn.net/Users/uzairkhan/Repos/github-action/.github/workflows/example-config.yml):`