### PR TITLE
Remove outdated comment on Edge availability on Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,8 +147,6 @@ jobs:
 
 [![Edge example](https://github.com/cypress-io/github-action/workflows/example-edge/badge.svg?branch=master)](.github/workflows/example-edge.yml)
 
-**Note:** Microsoft has not released Edge for Linux yet, thus you need to run these tests on Windows or Mac runners with Edge preinstalled. You can use [`cypress info`](https://on.cypress.io/command-line#cypress-info) command to see the browsers installed on the machine.
-
 ### Headed
 
 Run the browser in headed mode - as of Cypress v8.0 the `cypress run` command executes tests in `headless` mode by default


### PR DESCRIPTION
This PR resolves issue https://github.com/cypress-io/github-action/issues/713 "Microsoft Edge browser available on Linux".

The statement:

"**Note:** Microsoft has not released Edge for Linux yet, thus you need to run these tests on Windows or Mac runners with Edge preinstalled."

in the README file section [Edge](https://github.com/cypress-io/github-action/blob/master/README.md#edge) is no longer correct. The paragraph is removed.

*Edge for Linux became generally available in November 2021 and the current GitHub runners [ubuntu-20.04](https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2004-Readme.md#browsers-and-drivers) and [ubuntu-22.04](https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2204-Readme.md#browsers-and-drivers) contain Edge pre-installed.*