### PR TITLE
Remove outdated angular-pizza-creator from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -741,8 +741,6 @@ jobs:
           command-prefix: 'percy exec -- npx'
 ```
 
-See live example [angular-pizza-creator](https://github.com/cypress-io/angular-pizza-creator).
-
 ### Custom test command
 
 You can overwrite the Cypress run command with your own


### PR DESCRIPTION
This PR resolves issue https://github.com/cypress-io/github-action/issues/733 "Command prefix example angular-pizza-creator outdated by" removing the reference to the archived repository https://github.com/cypress-io/angular-pizza-creator:

"See live example [angular-pizza-creator](https://github.com/cypress-io/angular-pizza-creator)."

from the [README: Command prefix](https://github.com/cypress-io/github-action#command-prefix) section.

The example is archived, read-only, with no further development expected and it relies on Node.js 12 which has reached end-of-life. It will finally fail in Summer 2023 as GitHub plans to remove support for Node.js 12.
