### PR TITLE
Remove ffprobe and mplayer from chrome test

### DIFF
--- a/.github/workflows/example-chrome.yml
+++ b/.github/workflows/example-chrome.yml
@@ -56,11 +56,6 @@ jobs:
       - run: npx image-size cypress/screenshots/**/*.png
         working-directory: examples/v9/chrome
 
-      # I wonder if GH Actions VM includes any of the tools that
-      # can tell us the resolution of a video file
-      - run: ffprobe cypress/videos/*.mp4 || true
-      - run: mplayer -really-quiet -ao null -vo null -identify -frames 0 cypress/videos/*.mp4 || true
-
       - name: Chrome headed
         uses: ./
         with:
@@ -130,11 +125,6 @@ jobs:
 
       - run: npx image-size cypress/screenshots/**/*.png
         working-directory: examples/chrome
-
-      # I wonder if GH Actions VM includes any of the tools that
-      # can tell us the resolution of a video file
-      - run: ffprobe cypress/videos/*.mp4 || true
-      - run: mplayer -really-quiet -ao null -vo null -identify -frames 0 cypress/videos/*.mp4 || true
 
       - name: Chrome headless
         uses: ./


### PR DESCRIPTION
This PR resolves issue https://github.com/cypress-io/github-action/issues/734 "Chrome example contains failing jobs (ffprobe and mplayer)"

It removes the test steps `ffprobe` and `mplayer` from [.github/workflows/example-chrome.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-chrome.yml).

The utilities are not loaded, the tests are therefore failing. Since these tests are not necessary, they are removed.

## Verification

View a workflow run in https://github.com/cypress-io/github-action/actions/workflows/example-chrome.yml, select:

- tests-v9 or
- tests

Ensure that there is no occurrence of:

- "Run ffprobe cypress/videos/*.mp4 || true" or
- "Run mplayer -really-quiet -ao null -vo null -identify -frames 0 cypress/videos/*.mp4 || true"
