### PR TITLE
Add "component tests" to action description

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # cypress-io/github-action [![renovate-app badge][renovate-badge]][renovate-bot] [![Action status](https://github.com/cypress-io/github-action/workflows/main/badge.svg?branch=master)](https://github.com/cypress-io/github-action/actions)
 
-> [GitHub Action](https://docs.github.com/en/actions) for running [Cypress](https://www.cypress.io) end-to-end tests. Includes NPM installation, custom caching and lots of configuration options.
+> [GitHub Action](https://docs.github.com/en/actions) for running [Cypress](https://www.cypress.io) end-to-end and component tests. Includes NPM installation, custom caching and lots of configuration options.
 
 ## Examples
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cypress/github-action",
   "version": "0.0.0-development",
-  "description": "GitHub Action for running Cypress end-to-end tests",
+  "description": "GitHub Action for running Cypress end-to-end and component tests",
   "private": false,
   "main": "dist/index.js",
   "files": [


### PR DESCRIPTION
This PR resolves issue https://github.com/cypress-io/github-action/issues/744 "Package description lacks 'component test'"

It adds the text "component tests" to the descriptions in

- [README.md](https://github.com/cypress-io/github-action/blob/master/README.md) and
- [package.json](https://github.com/cypress-io/github-action/blob/master/package.json)
