### PR TITLE
Update v12 examples to 12.4.1

### DIFF
--- a/.github/workflows/example-install-only.yml
+++ b/.github/workflows/example-install-only.yml
@@ -63,7 +63,7 @@ jobs:
           key: my-cache-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
 
       - name: Install Cypress 📥
-        run: npm i cypress@12.3.0
+        run: npm i cypress@12.4.1
 
       - name: Cypress tests 🧪
         uses: ./

--- a/examples/basic-pnpm/package.json
+++ b/examples/basic-pnpm/package.json
@@ -10,6 +10,6 @@
   "license": "ISC",
   "private": true,
   "devDependencies": {
-    "cypress": "^12.3.0"
+    "cypress": "^12.4.1"
   }
 }

--- a/examples/basic-pnpm/pnpm-lock.yaml
+++ b/examples/basic-pnpm/pnpm-lock.yaml
@@ -1,10 +1,10 @@
 lockfileVersion: 5.4
 
 specifiers:
-  cypress: ^12.3.0
+  cypress: ^12.4.1
 
 devDependencies:
-  cypress: 12.3.0
+  cypress: 12.4.1
 
 packages:
 
@@ -190,7 +190,7 @@ packages:
     resolution: {integrity: sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==}
     dependencies:
       function-bind: 1.1.1
-      get-intrinsic: 1.1.3
+      get-intrinsic: 1.2.0
     dev: true
 
   /caseless/0.12.0:
@@ -293,8 +293,8 @@ packages:
       which: 2.0.2
     dev: true
 
-  /cypress/12.3.0:
-    resolution: {integrity: sha512-ZQNebibi6NBt51TRxRMYKeFvIiQZ01t50HSy7z/JMgRVqBUey3cdjog5MYEbzG6Ktti5ckDt1tfcC47lmFwXkw==}
+  /cypress/12.4.1:
+    resolution: {integrity: sha512-IFMPzc1RJ22Fac+YbdqywtpcuqZXqQJh+JqZDXn+A15zG/dw99njfv8f0bTvD+WAHhP118+xWG/VwilkFg1rnA==}
     engines: {node: ^14.0.0 || ^16.0.0 || >=18.0.0}
     hasBin: true
     requiresBuild: true
@@ -506,8 +506,8 @@ packages:
     resolution: {integrity: sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==}
     dev: true
 
-  /get-intrinsic/1.1.3:
-    resolution: {integrity: sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==}
+  /get-intrinsic/1.2.0:
+    resolution: {integrity: sha512-L049y6nFOuom5wGyRc3/gdTLO94dySVKRACj1RmJZBQXlbTMhtNIgkWkUHq+jYmZvKf14EW1EoJnnjbmoHij0Q==}
     dependencies:
       function-bind: 1.1.1
       has: 1.0.3
@@ -792,8 +792,8 @@ packages:
       path-key: 3.1.1
     dev: true
 
-  /object-inspect/1.12.2:
-    resolution: {integrity: sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==}
+  /object-inspect/1.12.3:
+    resolution: {integrity: sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==}
     dev: true
 
   /once/1.4.0:
@@ -863,8 +863,8 @@ packages:
       once: 1.4.0
     dev: true
 
-  /punycode/2.2.0:
-    resolution: {integrity: sha512-LN6QV1IJ9ZhxWTNdktaPClrNfp8xdSAYS0Zk2ddX7XsXZAxckMHPCBcHRo0cTcEIgYPRiGEkmji3Idkh2yFtYw==}
+  /punycode/2.3.0:
+    resolution: {integrity: sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==}
     engines: {node: '>=6'}
     dev: true
 
@@ -903,7 +903,7 @@ packages:
   /rxjs/7.8.0:
     resolution: {integrity: sha512-F2+gxDshqmIub1KdvZkaEfGDwLNpPvk9Fs6LD/MyQxNgMds/WH9OdDDXOmxUZpME+iSK3rQCctkL0DYyytUqMg==}
     dependencies:
-      tslib: 2.4.1
+      tslib: 2.5.0
     dev: true
 
   /safe-buffer/5.2.1:
@@ -938,8 +938,8 @@ packages:
     resolution: {integrity: sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==}
     dependencies:
       call-bind: 1.0.2
-      get-intrinsic: 1.1.3
-      object-inspect: 1.12.2
+      get-intrinsic: 1.2.0
+      object-inspect: 1.12.3
     dev: true
 
   /signal-exit/3.0.7:
@@ -1035,11 +1035,11 @@ packages:
     engines: {node: '>=0.8'}
     dependencies:
       psl: 1.9.0
-      punycode: 2.2.0
+      punycode: 2.3.0
     dev: true
 
-  /tslib/2.4.1:
-    resolution: {integrity: sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==}
+  /tslib/2.5.0:
+    resolution: {integrity: sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==}
     dev: true
 
   /tunnel-agent/0.6.0:

--- a/examples/basic/package-lock.json
+++ b/examples/basic/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {
-        "cypress": "^12.3.0"
+        "cypress": "12.4.1"
       }
     },
     "node_modules/@cypress/request": {
@@ -511,9 +511,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "12.3.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.3.0.tgz",
-      "integrity": "sha512-ZQNebibi6NBt51TRxRMYKeFvIiQZ01t50HSy7z/JMgRVqBUey3cdjog5MYEbzG6Ktti5ckDt1tfcC47lmFwXkw==",
+      "version": "12.4.1",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.4.1.tgz",
+      "integrity": "sha512-IFMPzc1RJ22Fac+YbdqywtpcuqZXqQJh+JqZDXn+A15zG/dw99njfv8f0bTvD+WAHhP118+xWG/VwilkFg1rnA==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -2194,9 +2194,9 @@
       }
     },
     "cypress": {
-      "version": "12.3.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.3.0.tgz",
-      "integrity": "sha512-ZQNebibi6NBt51TRxRMYKeFvIiQZ01t50HSy7z/JMgRVqBUey3cdjog5MYEbzG6Ktti5ckDt1tfcC47lmFwXkw==",
+      "version": "12.4.1",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.4.1.tgz",
+      "integrity": "sha512-IFMPzc1RJ22Fac+YbdqywtpcuqZXqQJh+JqZDXn+A15zG/dw99njfv8f0bTvD+WAHhP118+xWG/VwilkFg1rnA==",
       "dev": true,
       "requires": {
         "@cypress/request": "^2.88.10",

--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -10,6 +10,6 @@
   "license": "ISC",
   "private": true,
   "devDependencies": {
-    "cypress": "^12.3.0"
+    "cypress": "12.4.1"
   }
 }

--- a/examples/chrome/package-lock.json
+++ b/examples/chrome/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {
-        "cypress": "^12.3.0",
+        "cypress": "12.4.1",
         "image-size": "0.8.3"
       }
     },
@@ -525,9 +525,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "12.3.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.3.0.tgz",
-      "integrity": "sha512-ZQNebibi6NBt51TRxRMYKeFvIiQZ01t50HSy7z/JMgRVqBUey3cdjog5MYEbzG6Ktti5ckDt1tfcC47lmFwXkw==",
+      "version": "12.4.1",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.4.1.tgz",
+      "integrity": "sha512-IFMPzc1RJ22Fac+YbdqywtpcuqZXqQJh+JqZDXn+A15zG/dw99njfv8f0bTvD+WAHhP118+xWG/VwilkFg1rnA==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -2228,9 +2228,9 @@
       }
     },
     "cypress": {
-      "version": "12.3.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.3.0.tgz",
-      "integrity": "sha512-ZQNebibi6NBt51TRxRMYKeFvIiQZ01t50HSy7z/JMgRVqBUey3cdjog5MYEbzG6Ktti5ckDt1tfcC47lmFwXkw==",
+      "version": "12.4.1",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.4.1.tgz",
+      "integrity": "sha512-IFMPzc1RJ22Fac+YbdqywtpcuqZXqQJh+JqZDXn+A15zG/dw99njfv8f0bTvD+WAHhP118+xWG/VwilkFg1rnA==",
       "dev": true,
       "requires": {
         "@cypress/request": "^2.88.10",

--- a/examples/chrome/package.json
+++ b/examples/chrome/package.json
@@ -11,7 +11,7 @@
   "license": "ISC",
   "private": true,
   "devDependencies": {
-    "cypress": "^12.3.0",
+    "cypress": "12.4.1",
     "image-size": "0.8.3"
   }
 }

--- a/examples/component-tests/package-lock.json
+++ b/examples/component-tests/package-lock.json
@@ -29,7 +29,7 @@
       "devDependencies": {
         "@cypress/react": "^5.12.0",
         "@cypress/webpack-dev-server": "^1.8.0",
-        "cypress": "^12.3.0",
+        "cypress": "12.4.1",
         "html-webpack-plugin": "^4.5.2"
       }
     },
@@ -6454,9 +6454,9 @@
       "license": "MIT"
     },
     "node_modules/cypress": {
-      "version": "12.3.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.3.0.tgz",
-      "integrity": "sha512-ZQNebibi6NBt51TRxRMYKeFvIiQZ01t50HSy7z/JMgRVqBUey3cdjog5MYEbzG6Ktti5ckDt1tfcC47lmFwXkw==",
+      "version": "12.4.1",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.4.1.tgz",
+      "integrity": "sha512-IFMPzc1RJ22Fac+YbdqywtpcuqZXqQJh+JqZDXn+A15zG/dw99njfv8f0bTvD+WAHhP118+xWG/VwilkFg1rnA==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -20750,9 +20750,9 @@
       "version": "3.0.10"
     },
     "cypress": {
-      "version": "12.3.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.3.0.tgz",
-      "integrity": "sha512-ZQNebibi6NBt51TRxRMYKeFvIiQZ01t50HSy7z/JMgRVqBUey3cdjog5MYEbzG6Ktti5ckDt1tfcC47lmFwXkw==",
+      "version": "12.4.1",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.4.1.tgz",
+      "integrity": "sha512-IFMPzc1RJ22Fac+YbdqywtpcuqZXqQJh+JqZDXn+A15zG/dw99njfv8f0bTvD+WAHhP118+xWG/VwilkFg1rnA==",
       "dev": true,
       "requires": {
         "@cypress/request": "^2.88.10",

--- a/examples/component-tests/package.json
+++ b/examples/component-tests/package.json
@@ -45,7 +45,7 @@
   "devDependencies": {
     "@cypress/react": "^5.12.0",
     "@cypress/webpack-dev-server": "^1.8.0",
-    "cypress": "^12.3.0",
+    "cypress": "12.4.1",
     "html-webpack-plugin": "^4.5.2"
   }
 }

--- a/examples/config/package-lock.json
+++ b/examples/config/package-lock.json
@@ -12,7 +12,7 @@
         "serve": "^14.1.2"
       },
       "devDependencies": {
-        "cypress": "^12.3.0",
+        "cypress": "12.4.1",
         "start-server-and-test": "1.11.5"
       }
     },
@@ -885,9 +885,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "12.3.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.3.0.tgz",
-      "integrity": "sha512-ZQNebibi6NBt51TRxRMYKeFvIiQZ01t50HSy7z/JMgRVqBUey3cdjog5MYEbzG6Ktti5ckDt1tfcC47lmFwXkw==",
+      "version": "12.4.1",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.4.1.tgz",
+      "integrity": "sha512-IFMPzc1RJ22Fac+YbdqywtpcuqZXqQJh+JqZDXn+A15zG/dw99njfv8f0bTvD+WAHhP118+xWG/VwilkFg1rnA==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -3311,9 +3311,9 @@
       }
     },
     "cypress": {
-      "version": "12.3.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.3.0.tgz",
-      "integrity": "sha512-ZQNebibi6NBt51TRxRMYKeFvIiQZ01t50HSy7z/JMgRVqBUey3cdjog5MYEbzG6Ktti5ckDt1tfcC47lmFwXkw==",
+      "version": "12.4.1",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.4.1.tgz",
+      "integrity": "sha512-IFMPzc1RJ22Fac+YbdqywtpcuqZXqQJh+JqZDXn+A15zG/dw99njfv8f0bTvD+WAHhP118+xWG/VwilkFg1rnA==",
       "dev": true,
       "requires": {
         "@cypress/request": "^2.88.10",

--- a/examples/config/package.json
+++ b/examples/config/package.json
@@ -14,7 +14,7 @@
   "license": "ISC",
   "private": true,
   "devDependencies": {
-    "cypress": "^12.3.0",
+    "cypress": "12.4.1",
     "start-server-and-test": "1.11.5"
   },
   "dependencies": {

--- a/examples/custom-command/package-lock.json
+++ b/examples/custom-command/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {
-        "cypress": "^12.3.0",
+        "cypress": "12.4.1",
         "lodash": "4.17.15"
       }
     },
@@ -525,9 +525,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "12.3.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.3.0.tgz",
-      "integrity": "sha512-ZQNebibi6NBt51TRxRMYKeFvIiQZ01t50HSy7z/JMgRVqBUey3cdjog5MYEbzG6Ktti5ckDt1tfcC47lmFwXkw==",
+      "version": "12.4.1",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.4.1.tgz",
+      "integrity": "sha512-IFMPzc1RJ22Fac+YbdqywtpcuqZXqQJh+JqZDXn+A15zG/dw99njfv8f0bTvD+WAHhP118+xWG/VwilkFg1rnA==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -2210,9 +2210,9 @@
       }
     },
     "cypress": {
-      "version": "12.3.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.3.0.tgz",
-      "integrity": "sha512-ZQNebibi6NBt51TRxRMYKeFvIiQZ01t50HSy7z/JMgRVqBUey3cdjog5MYEbzG6Ktti5ckDt1tfcC47lmFwXkw==",
+      "version": "12.4.1",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.4.1.tgz",
+      "integrity": "sha512-IFMPzc1RJ22Fac+YbdqywtpcuqZXqQJh+JqZDXn+A15zG/dw99njfv8f0bTvD+WAHhP118+xWG/VwilkFg1rnA==",
       "dev": true,
       "requires": {
         "@cypress/request": "^2.88.10",

--- a/examples/custom-command/package.json
+++ b/examples/custom-command/package.json
@@ -11,7 +11,7 @@
   "license": "ISC",
   "private": true,
   "devDependencies": {
-    "cypress": "^12.3.0",
+    "cypress": "12.4.1",
     "lodash": "4.17.15"
   }
 }

--- a/examples/env/package-lock.json
+++ b/examples/env/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {
-        "cypress": "^12.3.0"
+        "cypress": "12.4.1"
       }
     },
     "node_modules/@cypress/request": {
@@ -512,9 +512,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "12.3.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.3.0.tgz",
-      "integrity": "sha512-ZQNebibi6NBt51TRxRMYKeFvIiQZ01t50HSy7z/JMgRVqBUey3cdjog5MYEbzG6Ktti5ckDt1tfcC47lmFwXkw==",
+      "version": "12.4.1",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.4.1.tgz",
+      "integrity": "sha512-IFMPzc1RJ22Fac+YbdqywtpcuqZXqQJh+JqZDXn+A15zG/dw99njfv8f0bTvD+WAHhP118+xWG/VwilkFg1rnA==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -2173,9 +2173,9 @@
       }
     },
     "cypress": {
-      "version": "12.3.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.3.0.tgz",
-      "integrity": "sha512-ZQNebibi6NBt51TRxRMYKeFvIiQZ01t50HSy7z/JMgRVqBUey3cdjog5MYEbzG6Ktti5ckDt1tfcC47lmFwXkw==",
+      "version": "12.4.1",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.4.1.tgz",
+      "integrity": "sha512-IFMPzc1RJ22Fac+YbdqywtpcuqZXqQJh+JqZDXn+A15zG/dw99njfv8f0bTvD+WAHhP118+xWG/VwilkFg1rnA==",
       "dev": true,
       "requires": {
         "@cypress/request": "^2.88.10",

--- a/examples/env/package.json
+++ b/examples/env/package.json
@@ -10,6 +10,6 @@
   "license": "ISC",
   "private": true,
   "devDependencies": {
-    "cypress": "^12.3.0"
+    "cypress": "12.4.1"
   }
 }

--- a/examples/firefox/package-lock.json
+++ b/examples/firefox/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {
-        "cypress": "^12.3.0",
+        "cypress": "12.4.1",
         "image-size": "0.8.3"
       }
     },
@@ -512,9 +512,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "12.3.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.3.0.tgz",
-      "integrity": "sha512-ZQNebibi6NBt51TRxRMYKeFvIiQZ01t50HSy7z/JMgRVqBUey3cdjog5MYEbzG6Ktti5ckDt1tfcC47lmFwXkw==",
+      "version": "12.4.1",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.4.1.tgz",
+      "integrity": "sha512-IFMPzc1RJ22Fac+YbdqywtpcuqZXqQJh+JqZDXn+A15zG/dw99njfv8f0bTvD+WAHhP118+xWG/VwilkFg1rnA==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -2197,9 +2197,9 @@
       }
     },
     "cypress": {
-      "version": "12.3.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.3.0.tgz",
-      "integrity": "sha512-ZQNebibi6NBt51TRxRMYKeFvIiQZ01t50HSy7z/JMgRVqBUey3cdjog5MYEbzG6Ktti5ckDt1tfcC47lmFwXkw==",
+      "version": "12.4.1",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.4.1.tgz",
+      "integrity": "sha512-IFMPzc1RJ22Fac+YbdqywtpcuqZXqQJh+JqZDXn+A15zG/dw99njfv8f0bTvD+WAHhP118+xWG/VwilkFg1rnA==",
       "dev": true,
       "requires": {
         "@cypress/request": "^2.88.10",

--- a/examples/firefox/package.json
+++ b/examples/firefox/package.json
@@ -10,7 +10,7 @@
   "license": "ISC",
   "private": true,
   "devDependencies": {
-    "cypress": "^12.3.0",
+    "cypress": "12.4.1",
     "image-size": "0.8.3"
   }
 }

--- a/examples/install-command/package.json
+++ b/examples/install-command/package.json
@@ -9,7 +9,7 @@
   "license": "MIT",
   "private": true,
   "devDependencies": {
-    "cypress": "12.3.0"
+    "cypress": "12.4.1"
   },
   "dependencies": {
     "arg": "5.0.0",

--- a/examples/install-command/yarn.lock
+++ b/examples/install-command/yarn.lock
@@ -308,10 +308,10 @@ cross-spawn@^7.0.0:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
-cypress@12.3.0:
-  version "12.3.0"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-12.3.0.tgz#ae3fb0540aef4b5eab1ef2bcd0760caf2992b8bf"
-  integrity sha512-ZQNebibi6NBt51TRxRMYKeFvIiQZ01t50HSy7z/JMgRVqBUey3cdjog5MYEbzG6Ktti5ckDt1tfcC47lmFwXkw==
+cypress@12.4.1:
+  version "12.4.1"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-12.4.1.tgz#6121b49fd7d833d1f4a0f486034f063467f433af"
+  integrity sha512-IFMPzc1RJ22Fac+YbdqywtpcuqZXqQJh+JqZDXn+A15zG/dw99njfv8f0bTvD+WAHhP118+xWG/VwilkFg1rnA==
   dependencies:
     "@cypress/request" "^2.88.10"
     "@cypress/xvfb" "^1.2.4"

--- a/examples/install-only/package-lock.json
+++ b/examples/install-only/package-lock.json
@@ -13,7 +13,7 @@
         "debug": "4.2.0"
       },
       "devDependencies": {
-        "cypress": "^12.3.0"
+        "cypress": "12.4.1"
       }
     },
     "node_modules/@cypress/request": {
@@ -520,9 +520,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "12.3.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.3.0.tgz",
-      "integrity": "sha512-ZQNebibi6NBt51TRxRMYKeFvIiQZ01t50HSy7z/JMgRVqBUey3cdjog5MYEbzG6Ktti5ckDt1tfcC47lmFwXkw==",
+      "version": "12.4.1",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.4.1.tgz",
+      "integrity": "sha512-IFMPzc1RJ22Fac+YbdqywtpcuqZXqQJh+JqZDXn+A15zG/dw99njfv8f0bTvD+WAHhP118+xWG/VwilkFg1rnA==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -2202,9 +2202,9 @@
       }
     },
     "cypress": {
-      "version": "12.3.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.3.0.tgz",
-      "integrity": "sha512-ZQNebibi6NBt51TRxRMYKeFvIiQZ01t50HSy7z/JMgRVqBUey3cdjog5MYEbzG6Ktti5ckDt1tfcC47lmFwXkw==",
+      "version": "12.4.1",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.4.1.tgz",
+      "integrity": "sha512-IFMPzc1RJ22Fac+YbdqywtpcuqZXqQJh+JqZDXn+A15zG/dw99njfv8f0bTvD+WAHhP118+xWG/VwilkFg1rnA==",
       "dev": true,
       "requires": {
         "@cypress/request": "^2.88.10",

--- a/examples/install-only/package.json
+++ b/examples/install-only/package.json
@@ -9,7 +9,7 @@
   "license": "MIT",
   "private": true,
   "devDependencies": {
-    "cypress": "^12.3.0"
+    "cypress": "12.4.1"
   },
   "dependencies": {
     "arg": "5.0.0",

--- a/examples/node-versions/package-lock.json
+++ b/examples/node-versions/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {
-        "cypress": "^12.3.0"
+        "cypress": "12.4.1"
       }
     },
     "node_modules/@cypress/request": {
@@ -524,9 +524,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "12.3.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.3.0.tgz",
-      "integrity": "sha512-ZQNebibi6NBt51TRxRMYKeFvIiQZ01t50HSy7z/JMgRVqBUey3cdjog5MYEbzG6Ktti5ckDt1tfcC47lmFwXkw==",
+      "version": "12.4.1",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.4.1.tgz",
+      "integrity": "sha512-IFMPzc1RJ22Fac+YbdqywtpcuqZXqQJh+JqZDXn+A15zG/dw99njfv8f0bTvD+WAHhP118+xWG/VwilkFg1rnA==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -2203,9 +2203,9 @@
       }
     },
     "cypress": {
-      "version": "12.3.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.3.0.tgz",
-      "integrity": "sha512-ZQNebibi6NBt51TRxRMYKeFvIiQZ01t50HSy7z/JMgRVqBUey3cdjog5MYEbzG6Ktti5ckDt1tfcC47lmFwXkw==",
+      "version": "12.4.1",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.4.1.tgz",
+      "integrity": "sha512-IFMPzc1RJ22Fac+YbdqywtpcuqZXqQJh+JqZDXn+A15zG/dw99njfv8f0bTvD+WAHhP118+xWG/VwilkFg1rnA==",
       "dev": true,
       "requires": {
         "@cypress/request": "^2.88.10",

--- a/examples/node-versions/package.json
+++ b/examples/node-versions/package.json
@@ -10,6 +10,6 @@
   "license": "ISC",
   "private": true,
   "devDependencies": {
-    "cypress": "^12.3.0"
+    "cypress": "12.4.1"
   }
 }

--- a/examples/quiet/package-lock.json
+++ b/examples/quiet/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {
-        "cypress": "^12.3.0",
+        "cypress": "12.4.1",
         "image-size": "0.8.3"
       }
     },
@@ -525,9 +525,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "12.3.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.3.0.tgz",
-      "integrity": "sha512-ZQNebibi6NBt51TRxRMYKeFvIiQZ01t50HSy7z/JMgRVqBUey3cdjog5MYEbzG6Ktti5ckDt1tfcC47lmFwXkw==",
+      "version": "12.4.1",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.4.1.tgz",
+      "integrity": "sha512-IFMPzc1RJ22Fac+YbdqywtpcuqZXqQJh+JqZDXn+A15zG/dw99njfv8f0bTvD+WAHhP118+xWG/VwilkFg1rnA==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -2228,9 +2228,9 @@
       }
     },
     "cypress": {
-      "version": "12.3.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.3.0.tgz",
-      "integrity": "sha512-ZQNebibi6NBt51TRxRMYKeFvIiQZ01t50HSy7z/JMgRVqBUey3cdjog5MYEbzG6Ktti5ckDt1tfcC47lmFwXkw==",
+      "version": "12.4.1",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.4.1.tgz",
+      "integrity": "sha512-IFMPzc1RJ22Fac+YbdqywtpcuqZXqQJh+JqZDXn+A15zG/dw99njfv8f0bTvD+WAHhP118+xWG/VwilkFg1rnA==",
       "dev": true,
       "requires": {
         "@cypress/request": "^2.88.10",

--- a/examples/quiet/package.json
+++ b/examples/quiet/package.json
@@ -11,7 +11,7 @@
   "license": "ISC",
   "private": true,
   "devDependencies": {
-    "cypress": "^12.3.0",
+    "cypress": "12.4.1",
     "image-size": "0.8.3"
   }
 }

--- a/examples/react-scripts/package-lock.json
+++ b/examples/react-scripts/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {
-        "cypress": "^12.3.0",
+        "cypress": "12.4.1",
         "react": "16.14.0",
         "react-dom": "16.14.0",
         "react-scripts": "3.4.4"
@@ -5727,9 +5727,9 @@
       "dev": true
     },
     "node_modules/cypress": {
-      "version": "12.3.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.3.0.tgz",
-      "integrity": "sha512-ZQNebibi6NBt51TRxRMYKeFvIiQZ01t50HSy7z/JMgRVqBUey3cdjog5MYEbzG6Ktti5ckDt1tfcC47lmFwXkw==",
+      "version": "12.4.1",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.4.1.tgz",
+      "integrity": "sha512-IFMPzc1RJ22Fac+YbdqywtpcuqZXqQJh+JqZDXn+A15zG/dw99njfv8f0bTvD+WAHhP118+xWG/VwilkFg1rnA==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -24439,9 +24439,9 @@
       "dev": true
     },
     "cypress": {
-      "version": "12.3.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.3.0.tgz",
-      "integrity": "sha512-ZQNebibi6NBt51TRxRMYKeFvIiQZ01t50HSy7z/JMgRVqBUey3cdjog5MYEbzG6Ktti5ckDt1tfcC47lmFwXkw==",
+      "version": "12.4.1",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.4.1.tgz",
+      "integrity": "sha512-IFMPzc1RJ22Fac+YbdqywtpcuqZXqQJh+JqZDXn+A15zG/dw99njfv8f0bTvD+WAHhP118+xWG/VwilkFg1rnA==",
       "dev": true,
       "requires": {
         "@cypress/request": "^2.88.10",

--- a/examples/react-scripts/package.json
+++ b/examples/react-scripts/package.json
@@ -9,7 +9,7 @@
   "license": "ISC",
   "private": true,
   "devDependencies": {
-    "cypress": "^12.3.0",
+    "cypress": "12.4.1",
     "react": "16.14.0",
     "react-dom": "16.14.0",
     "react-scripts": "3.4.4"

--- a/examples/recording/package-lock.json
+++ b/examples/recording/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {
-        "cypress": "^12.3.0"
+        "cypress": "12.4.1"
       }
     },
     "node_modules/@cypress/request": {
@@ -511,9 +511,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "12.3.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.3.0.tgz",
-      "integrity": "sha512-ZQNebibi6NBt51TRxRMYKeFvIiQZ01t50HSy7z/JMgRVqBUey3cdjog5MYEbzG6Ktti5ckDt1tfcC47lmFwXkw==",
+      "version": "12.4.1",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.4.1.tgz",
+      "integrity": "sha512-IFMPzc1RJ22Fac+YbdqywtpcuqZXqQJh+JqZDXn+A15zG/dw99njfv8f0bTvD+WAHhP118+xWG/VwilkFg1rnA==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -2194,9 +2194,9 @@
       }
     },
     "cypress": {
-      "version": "12.3.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.3.0.tgz",
-      "integrity": "sha512-ZQNebibi6NBt51TRxRMYKeFvIiQZ01t50HSy7z/JMgRVqBUey3cdjog5MYEbzG6Ktti5ckDt1tfcC47lmFwXkw==",
+      "version": "12.4.1",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.4.1.tgz",
+      "integrity": "sha512-IFMPzc1RJ22Fac+YbdqywtpcuqZXqQJh+JqZDXn+A15zG/dw99njfv8f0bTvD+WAHhP118+xWG/VwilkFg1rnA==",
       "dev": true,
       "requires": {
         "@cypress/request": "^2.88.10",

--- a/examples/recording/package.json
+++ b/examples/recording/package.json
@@ -11,6 +11,6 @@
   "license": "ISC",
   "private": true,
   "devDependencies": {
-    "cypress": "^12.3.0"
+    "cypress": "12.4.1"
   }
 }

--- a/examples/start-and-yarn-workspaces/workspace-1/package.json
+++ b/examples/start-and-yarn-workspaces/workspace-1/package.json
@@ -12,7 +12,7 @@
   "license": "ISC",
   "private": true,
   "devDependencies": {
-    "cypress": "12.3.0"
+    "cypress": "12.4.1"
   },
   "dependencies": {
     "serve": "^14.1.2"

--- a/examples/start-and-yarn-workspaces/workspace-2/package.json
+++ b/examples/start-and-yarn-workspaces/workspace-2/package.json
@@ -12,7 +12,7 @@
   "license": "ISC",
   "private": true,
   "devDependencies": {
-    "cypress": "12.3.0"
+    "cypress": "12.4.1"
   },
   "dependencies": {
     "serve": "^14.1.2"

--- a/examples/start-and-yarn-workspaces/yarn.lock
+++ b/examples/start-and-yarn-workspaces/yarn.lock
@@ -438,10 +438,10 @@ cross-spawn@^7.0.3:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
-cypress@12.3.0:
-  version "12.3.0"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-12.3.0.tgz#ae3fb0540aef4b5eab1ef2bcd0760caf2992b8bf"
-  integrity sha512-ZQNebibi6NBt51TRxRMYKeFvIiQZ01t50HSy7z/JMgRVqBUey3cdjog5MYEbzG6Ktti5ckDt1tfcC47lmFwXkw==
+cypress@12.4.1:
+  version "12.4.1"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-12.4.1.tgz#6121b49fd7d833d1f4a0f486034f063467f433af"
+  integrity sha512-IFMPzc1RJ22Fac+YbdqywtpcuqZXqQJh+JqZDXn+A15zG/dw99njfv8f0bTvD+WAHhP118+xWG/VwilkFg1rnA==
   dependencies:
     "@cypress/request" "^2.88.10"
     "@cypress/xvfb" "^1.2.4"

--- a/examples/start/package-lock.json
+++ b/examples/start/package-lock.json
@@ -12,7 +12,7 @@
         "serve": "^14.1.2"
       },
       "devDependencies": {
-        "cypress": "^12.3.0"
+        "cypress": "12.4.1"
       }
     },
     "node_modules/@cypress/request": {
@@ -835,9 +835,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "12.3.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.3.0.tgz",
-      "integrity": "sha512-ZQNebibi6NBt51TRxRMYKeFvIiQZ01t50HSy7z/JMgRVqBUey3cdjog5MYEbzG6Ktti5ckDt1tfcC47lmFwXkw==",
+      "version": "12.4.1",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.4.1.tgz",
+      "integrity": "sha512-IFMPzc1RJ22Fac+YbdqywtpcuqZXqQJh+JqZDXn+A15zG/dw99njfv8f0bTvD+WAHhP118+xWG/VwilkFg1rnA==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -2998,9 +2998,9 @@
       }
     },
     "cypress": {
-      "version": "12.3.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.3.0.tgz",
-      "integrity": "sha512-ZQNebibi6NBt51TRxRMYKeFvIiQZ01t50HSy7z/JMgRVqBUey3cdjog5MYEbzG6Ktti5ckDt1tfcC47lmFwXkw==",
+      "version": "12.4.1",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.4.1.tgz",
+      "integrity": "sha512-IFMPzc1RJ22Fac+YbdqywtpcuqZXqQJh+JqZDXn+A15zG/dw99njfv8f0bTvD+WAHhP118+xWG/VwilkFg1rnA==",
       "dev": true,
       "requires": {
         "@cypress/request": "^2.88.10",

--- a/examples/start/package.json
+++ b/examples/start/package.json
@@ -13,7 +13,7 @@
   "license": "ISC",
   "private": true,
   "devDependencies": {
-    "cypress": "^12.3.0"
+    "cypress": "12.4.1"
   },
   "dependencies": {
     "serve": "^14.1.2"

--- a/examples/wait-on-vite/package-lock.json
+++ b/examples/wait-on-vite/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {
-        "cypress": "^12.3.0",
+        "cypress": "12.4.1",
         "vite": "^2.0.0-beta.65"
       }
     },
@@ -512,9 +512,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "12.3.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.3.0.tgz",
-      "integrity": "sha512-ZQNebibi6NBt51TRxRMYKeFvIiQZ01t50HSy7z/JMgRVqBUey3cdjog5MYEbzG6Ktti5ckDt1tfcC47lmFwXkw==",
+      "version": "12.4.1",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.4.1.tgz",
+      "integrity": "sha512-IFMPzc1RJ22Fac+YbdqywtpcuqZXqQJh+JqZDXn+A15zG/dw99njfv8f0bTvD+WAHhP118+xWG/VwilkFg1rnA==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -2348,9 +2348,9 @@
       }
     },
     "cypress": {
-      "version": "12.3.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.3.0.tgz",
-      "integrity": "sha512-ZQNebibi6NBt51TRxRMYKeFvIiQZ01t50HSy7z/JMgRVqBUey3cdjog5MYEbzG6Ktti5ckDt1tfcC47lmFwXkw==",
+      "version": "12.4.1",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.4.1.tgz",
+      "integrity": "sha512-IFMPzc1RJ22Fac+YbdqywtpcuqZXqQJh+JqZDXn+A15zG/dw99njfv8f0bTvD+WAHhP118+xWG/VwilkFg1rnA==",
       "dev": true,
       "requires": {
         "@cypress/request": "^2.88.10",

--- a/examples/wait-on-vite/package.json
+++ b/examples/wait-on-vite/package.json
@@ -12,7 +12,7 @@
   "license": "ISC",
   "private": true,
   "devDependencies": {
-    "cypress": "^12.3.0",
+    "cypress": "12.4.1",
     "vite": "^2.0.0-beta.65"
   }
 }

--- a/examples/wait-on/package-lock.json
+++ b/examples/wait-on/package-lock.json
@@ -13,7 +13,7 @@
         "debug": "4.2.0"
       },
       "devDependencies": {
-        "cypress": "^12.3.0"
+        "cypress": "12.4.1"
       }
     },
     "node_modules/@cypress/request": {
@@ -520,9 +520,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "12.3.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.3.0.tgz",
-      "integrity": "sha512-ZQNebibi6NBt51TRxRMYKeFvIiQZ01t50HSy7z/JMgRVqBUey3cdjog5MYEbzG6Ktti5ckDt1tfcC47lmFwXkw==",
+      "version": "12.4.1",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.4.1.tgz",
+      "integrity": "sha512-IFMPzc1RJ22Fac+YbdqywtpcuqZXqQJh+JqZDXn+A15zG/dw99njfv8f0bTvD+WAHhP118+xWG/VwilkFg1rnA==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -2218,9 +2218,9 @@
       }
     },
     "cypress": {
-      "version": "12.3.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.3.0.tgz",
-      "integrity": "sha512-ZQNebibi6NBt51TRxRMYKeFvIiQZ01t50HSy7z/JMgRVqBUey3cdjog5MYEbzG6Ktti5ckDt1tfcC47lmFwXkw==",
+      "version": "12.4.1",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.4.1.tgz",
+      "integrity": "sha512-IFMPzc1RJ22Fac+YbdqywtpcuqZXqQJh+JqZDXn+A15zG/dw99njfv8f0bTvD+WAHhP118+xWG/VwilkFg1rnA==",
       "dev": true,
       "requires": {
         "@cypress/request": "^2.88.10",

--- a/examples/wait-on/package.json
+++ b/examples/wait-on/package.json
@@ -18,7 +18,7 @@
   "license": "ISC",
   "private": true,
   "devDependencies": {
-    "cypress": "^12.3.0"
+    "cypress": "12.4.1"
   },
   "dependencies": {
     "arg": "5.0.0",

--- a/examples/webpack/package-lock.json
+++ b/examples/webpack/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {
-        "cypress": "^12.3.0",
+        "cypress": "12.4.1",
         "webpack": "4",
         "webpack-cli": "3",
         "webpack-dev-server": "3.11.0"
@@ -1866,9 +1866,9 @@
       "dev": true
     },
     "node_modules/cypress": {
-      "version": "12.3.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.3.0.tgz",
-      "integrity": "sha512-ZQNebibi6NBt51TRxRMYKeFvIiQZ01t50HSy7z/JMgRVqBUey3cdjog5MYEbzG6Ktti5ckDt1tfcC47lmFwXkw==",
+      "version": "12.4.1",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.4.1.tgz",
+      "integrity": "sha512-IFMPzc1RJ22Fac+YbdqywtpcuqZXqQJh+JqZDXn+A15zG/dw99njfv8f0bTvD+WAHhP118+xWG/VwilkFg1rnA==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -9699,9 +9699,9 @@
       "dev": true
     },
     "cypress": {
-      "version": "12.3.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.3.0.tgz",
-      "integrity": "sha512-ZQNebibi6NBt51TRxRMYKeFvIiQZ01t50HSy7z/JMgRVqBUey3cdjog5MYEbzG6Ktti5ckDt1tfcC47lmFwXkw==",
+      "version": "12.4.1",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.4.1.tgz",
+      "integrity": "sha512-IFMPzc1RJ22Fac+YbdqywtpcuqZXqQJh+JqZDXn+A15zG/dw99njfv8f0bTvD+WAHhP118+xWG/VwilkFg1rnA==",
       "dev": true,
       "requires": {
         "@cypress/request": "^2.88.10",

--- a/examples/webpack/package.json
+++ b/examples/webpack/package.json
@@ -9,7 +9,7 @@
   "license": "ISC",
   "private": true,
   "devDependencies": {
-    "cypress": "^12.3.0",
+    "cypress": "12.4.1",
     "webpack": "4",
     "webpack-cli": "3",
     "webpack-dev-server": "3.11.0"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "build": "ncc build -o dist index.js",
     "format": "prettier --write index.js",
     "check:markdown": "find *.md -print0 | xargs -0 -n1 markdown-link-check -c md-linkcheck.json",
-    "install-v10-deps": "./scripts/npm-install-v10-examples.sh"
+    "install-deps": "./scripts/npm-install-examples.sh"
   },
   "repository": {
     "type": "git",

--- a/scripts/npm-install-examples.sh
+++ b/scripts/npm-install-examples.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-cd ./examples/v10/basic && npm install cypress@latest
+cd ./examples/basic && npm install cypress@latest
 cd ../chrome && npm install cypress@latest
 cd ../component-tests && npm install cypress@latest
 cd ../config && npm install cypress@latest


### PR DESCRIPTION
This PR updates [examples](https://github.com/cypress-io/github-action/tree/master/examples) to use the latest Cypress version 
~~[12.4.0](https://docs.cypress.io/guides/references/changelog#12-4-0) released on Jan 24, 2023.~~
[12.4.1](https://docs.cypress.io/guides/references/changelog#12-4-1) released on Jan 27, 2023.

Each of the test directories in [examples](https://github.com/cypress-io/github-action/tree/master/examples), apart from [examples/v9](https://github.com/cypress-io/github-action/tree/master/examples/v9), is upgraded to use [Cypress 12.4.1](https://docs.cypress.io/guides/references/changelog#12-4-1).

1. An issue caused by PR https://github.com/cypress-io/github-action/pull/727 concerning renaming of the script [scripts/npm-install-examples.sh](https://github.com/cypress-io/github-action/blob/master/scripts/npm-install-examples.sh) is corrected.

2. The npm-based examples are updated using:
`npm run install-deps`
This updates `package.json` to include `"cypress": "12.4.1"` with exact version number as determined by [.npmrc](https://github.com/cypress-io/github-action/blob/master/.npmrc).

3. [examples/start-and-yarn-workspaces](https://github.com/cypress-io/github-action/tree/master/examples/start-and-yarn-workspaces) is updated using:
`yarn upgrade-interactive --latest`

4. [examples/install-command](https://github.com/cypress-io/github-action/tree/master/examples/install-command) is updated using:
`yarn add cypress -D`

5. [examples/basic-pnpm](https://github.com/cypress-io/github-action/tree/master/examples/basic-pnpm) is updated using:
`pnpm update --latest`

6. Edit the run command in [.github/workflows/example-install-only.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-install-only.yml) `run: npm i cypress@12.x.x`
