### PR TITLE
Allow all example workflows to be triggered manually

### DIFF
--- a/.github/workflows/example-basic-pnpm.yml
+++ b/.github/workflows/example-basic-pnpm.yml
@@ -4,6 +4,8 @@ on:
     branches:
       - 'master'
   pull_request:
+  workflow_dispatch:
+
 jobs:
   # ~~~~~~~~~~~~~~~~~~ Cypress v9 and below (using Legacy configuration) ~~~~~~~~~~~~~~~~~~~ #
 

--- a/.github/workflows/example-basic.yml
+++ b/.github/workflows/example-basic.yml
@@ -4,6 +4,8 @@ on:
     branches:
       - 'master'
   pull_request:
+  workflow_dispatch:
+
 jobs:
   # ~~~~~~~~~~~~~~~~~~ Cypress v9 and below (using Legacy configuration) ~~~~~~~~~~~~~~~~~~~ #
 

--- a/.github/workflows/example-chrome.yml
+++ b/.github/workflows/example-chrome.yml
@@ -4,6 +4,8 @@ on:
     branches:
       - 'master'
   pull_request:
+  workflow_dispatch:
+
 jobs:
 
   # ~~~~~~~~~~~~~~~~~~ Cypress v9 and below (using Legacy configuration) ~~~~~~~~~~~~~~~~~~~ #

--- a/.github/workflows/example-component-test.yml
+++ b/.github/workflows/example-component-test.yml
@@ -1,5 +1,5 @@
 name: Component Tests
-on: [push]
+on: [push, workflow_dispatch]
 jobs:
   cypress-run:
     runs-on: ubuntu-latest

--- a/.github/workflows/example-config.yml
+++ b/.github/workflows/example-config.yml
@@ -4,6 +4,8 @@ on:
     branches:
       - 'master'
   pull_request:
+  workflow_dispatch:
+
 jobs:
 
   # ~~~~~~~~~~~~~~~~~~ Cypress v9 and below (using Legacy configuration) ~~~~~~~~~~~~~~~~~~~ #

--- a/.github/workflows/example-cron.yml
+++ b/.github/workflows/example-cron.yml
@@ -3,6 +3,8 @@ on:
   schedule:
     # runs tests every day at 4am
     - cron: '0 4 * * *'
+  workflow_dispatch:
+
 jobs:
   nightly:
     runs-on: ubuntu-22.04

--- a/.github/workflows/example-custom-ci-build-id.yml
+++ b/.github/workflows/example-custom-ci-build-id.yml
@@ -19,6 +19,8 @@ on:
     branches:
       - 'master'
   pull_request:
+  workflow_dispatch:
+
 jobs:
   # single job that generates and outputs a common id
   prepare:

--- a/.github/workflows/example-custom-command.yml
+++ b/.github/workflows/example-custom-command.yml
@@ -4,6 +4,8 @@ on:
     branches:
       - 'master'
   pull_request:
+  workflow_dispatch:
+
 jobs:
 
   # ~~~~~~~~~~~~~~~~~~ Cypress v9 and below (using Legacy configuration) ~~~~~~~~~~~~~~~~~~~ #

--- a/.github/workflows/example-debug.yml
+++ b/.github/workflows/example-debug.yml
@@ -4,6 +4,8 @@ on:
     branches:
       - 'master'
   pull_request:
+  workflow_dispatch:
+
 jobs:
   nightly:
     runs-on: ubuntu-22.04

--- a/.github/workflows/example-edge.yml
+++ b/.github/workflows/example-edge.yml
@@ -4,6 +4,8 @@ on:
     branches:
       - 'master'
   pull_request:
+  workflow_dispatch:
+
 jobs:
   tests:
     runs-on: windows-latest

--- a/.github/workflows/example-env.yml
+++ b/.github/workflows/example-env.yml
@@ -4,6 +4,8 @@ on:
     branches:
       - 'master'
   pull_request:
+  workflow_dispatch:
+
 env:
   # pass an environment variable to Cypress
   # a test can get its value like this

--- a/.github/workflows/example-firefox.yml
+++ b/.github/workflows/example-firefox.yml
@@ -4,6 +4,8 @@ on:
     branches:
       - 'master'
   pull_request:
+  workflow_dispatch:
+
 jobs:
 
   # ~~~~~~~~~~~~~~~~~~ Cypress v9 and below (using Legacy configuration) ~~~~~~~~~~~~~~~~~~~ #

--- a/.github/workflows/example-install-command.yml
+++ b/.github/workflows/example-install-command.yml
@@ -4,6 +4,8 @@ on:
     branches:
       - 'master'
   pull_request:
+  workflow_dispatch:
+
 jobs:
 
   # ~~~~~~~~~~~~~~~~~~ Cypress v9 and below (using Legacy configuration) ~~~~~~~~~~~~~~~~~~~ #

--- a/.github/workflows/example-install-only.yml
+++ b/.github/workflows/example-install-only.yml
@@ -4,6 +4,8 @@ on:
     branches:
       - 'master'
   pull_request:
+  workflow_dispatch:
+
 jobs:
   # ~~~~~~~~~~~~~~~~~~ Cypress v9 and below (using Legacy configuration) ~~~~~~~~~~~~~~~~~~~ #
 

--- a/.github/workflows/example-node-versions.yml
+++ b/.github/workflows/example-node-versions.yml
@@ -4,6 +4,8 @@ on:
     branches:
       - 'master'
   pull_request:
+  workflow_dispatch:
+
 jobs:
 
   # ~~~~~~~~~~~~~~~~~~ Cypress v9 and below (using Legacy configuration) ~~~~~~~~~~~~~~~~~~~ #

--- a/.github/workflows/example-quiet.yml
+++ b/.github/workflows/example-quiet.yml
@@ -4,6 +4,8 @@ on:
     branches:
       - 'master'
   pull_request:
+  workflow_dispatch:
+
 jobs:
 
   # ~~~~~~~~~~~~~~~~~~ Cypress v9 and below (using Legacy configuration) ~~~~~~~~~~~~~~~~~~~ #

--- a/.github/workflows/example-recording.yml
+++ b/.github/workflows/example-recording.yml
@@ -4,6 +4,8 @@ on:
     branches:
       - 'master'
   pull_request:
+  workflow_dispatch:
+
 jobs:
 
   # ~~~~~~~~~~~~~~~~~~ Cypress v9 and below (using Legacy configuration) ~~~~~~~~~~~~~~~~~~~ #

--- a/.github/workflows/example-start-and-yarn-workspaces.yml
+++ b/.github/workflows/example-start-and-yarn-workspaces.yml
@@ -4,6 +4,8 @@ on:
     branches:
       - 'master'
   pull_request:
+  workflow_dispatch:
+
 jobs:
 
   # ~~~~~~~~~~~~~~~~~~ Cypress v9 and below (using Legacy configuration) ~~~~~~~~~~~~~~~~~~~ #

--- a/.github/workflows/example-start.yml
+++ b/.github/workflows/example-start.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - 'master'
   pull_request:
+  workflow_dispatch:
 
 env:
   # Disable update-check called by serve through start or start2 script

--- a/.github/workflows/example-wait-on.yml
+++ b/.github/workflows/example-wait-on.yml
@@ -4,6 +4,8 @@ on:
     branches:
       - 'master'
   pull_request:
+  workflow_dispatch:
+
 jobs:
 
   # ~~~~~~~~~~~~~~~~~~ Cypress v9 and below (using Legacy configuration) ~~~~~~~~~~~~~~~~~~~ #

--- a/.github/workflows/example-webpack.yml
+++ b/.github/workflows/example-webpack.yml
@@ -4,6 +4,8 @@ on:
     branches:
       - 'master'
   pull_request:
+  workflow_dispatch:
+
 jobs:
 
   # ~~~~~~~~~~~~~~~~~~ Cypress v9 and below (using Legacy configuration) ~~~~~~~~~~~~~~~~~~~ #


### PR DESCRIPTION
This PR implements the suggestion from issue https://github.com/cypress-io/github-action/issues/678 "Add workflow_dispatch to examples".

It adds `workflow_dispatch` to each of the workflow examples in [.github/workflows](https://github.com/cypress-io/github-action/tree/master/.github/workflows).

This enables any of the example workflows to be run manually, which is very helpful to test an individual workflow, especially after changes have been made.