### PR TITLE
Correct README typo for ping debug example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1160,7 +1160,7 @@ $ node src/ping-cli.js <url>
 For example
 
 ```
-$ node src/ping.js https://example.cypress.io
+$ node src/ping-cli.js https://example.cypress.io
 pinging url https://example.cypress.io for 30 seconds
 ::debug::pinging https://example.cypress.io has finished ok
 ```


### PR DESCRIPTION
This PR corrects the example instructions in [README: "Debugging waiting for URL to respond"](https://github.com/cypress-io/github-action/blob/master/README.md#debugging-waiting-for-url-to-respond).

The correct example use of `ping` from the CLI is:

```bash
$ node src/ping-cli.js https://example.cypress.io
```

Attempting to call `src/ping.js` is incorrect, does nothing and produces no output.

## Verification

Follow the example instructions and execute

```bash
node src/ping-cli.js https://example.cypress.io
```

from a `bash` terminal window.

Check the response:

```text
pinging url https://example.cypress.io for 30 seconds
```
