### PR TITLE
Remove release dependency on markdown link check

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,8 +22,6 @@ jobs:
       - run: npm run format
       - run: npm run build
       - run: npm test
-      - run: npm run check:markdown
-
 
   release:
     runs-on: ubuntu-22.04
@@ -56,3 +54,12 @@ jobs:
         run: 'git push https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git HEAD:refs/heads/v${{steps.semantic.outputs.new_release_major_version}}'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  check-markdown-links:
+    runs-on: ubuntu-22.04
+    name: Check links in Markdown files
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - uses: bahmutov/npm-install@v1
+      - run: npm run check:markdown


### PR DESCRIPTION
This PR resolves issue https://github.com/cypress-io/github-action/issues/717 "Bad external links may block release".

In [.github/workflows/main.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/main.yml) `npm run check:markdown` is removed from the `build-and-test` job and placed it inside a new independent job `check-markdown-links` inside the same workflow.

## Verification

### Error case

In a copy of the [cypress-io/github-action/](https://github.com/cypress-io/github-action/) repo:

1. introduce a link error into README.md
2. execute `npm run check:markdown` and verify the test fails
3. simulate a release and check that the markdown failure does not prevent a releas

### Non-error case

As above except with no markdown link error present.

### Production case

Monitor production when a commit with `fix:`, `feat:` or `perf:` in the title is merged into the `master` branch and check that a release takes place correctly.
