### PR TITLE
Remove release dependency on markdown link check (Rev2)

### DIFF
--- a/.github/workflows/check-markdown.yml
+++ b/.github/workflows/check-markdown.yml
@@ -1,0 +1,17 @@
+name: check-markdown
+on:
+  push:
+    branches:
+      - 'master'
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  check-markdown-links:
+    runs-on: ubuntu-22.04
+    name: Check links in Markdown files
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - uses: bahmutov/npm-install@v1
+      - run: npm run check:markdown

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,8 +22,6 @@ jobs:
       - run: npm run format
       - run: npm run build
       - run: npm test
-      - run: npm run check:markdown
-
 
   release:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
This PR resolves issue https://github.com/cypress-io/github-action/issues/717 "Bad external links may block release". It is a rework of PR https://github.com/cypress-io/github-action/pull/762.

In [.github/workflows/main.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/main.yml) `npm run check:markdown` is removed from the `build-and-test` job and placed it inside a new independent workflow [.github/workflows/check-markdown.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/check-markdown.yml).

This means that a release can optionally be carried out independently of a markdown link error. This may be necessary and desired if a link failure is caused by a temporary issue on an external website. If on the other hand there is a hard failure in a markdown hyperlink this should preferably be corrected before a PR is merged for release.

The change in this PR gives the decision-making to the person merging the PR. An automatic block of releasing caused by a bad external website no longer takes place.

## Verification

### Markdown error case

1. Introduce a link error into README.md
2. Execute `npm run check:markdown` locally and verify the test fails
3. Manually run the action [.github/workflows/check-markdown.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/check-markdown.yml) and confirm it fails.

In a copy of the [cypress-io/github-action/](https://github.com/cypress-io/github-action/) repo:

1. Simulate a release in the presence of a markdown link error and confirm that it succeeds, despite there being a markdown link error present.

### Markdown non-error case

1. Remove the link error from README.md
2. Execute `npm run check:markdown` locally and verify the test succeeds
3. Manually run the action [.github/workflows/check-markdown.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/check-markdown.yml) and confirm it succeeds.