### PR TITLE
Add check for dist/ directory consistent with source files

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -1,0 +1,36 @@
+name: check-dist
+#
+# cypress-io/github-action runs from the dist/ directory
+# This workflow ensures that the contents of this directory
+# are in sync with the source files by using
+# npm run build which in turn calls ncc build
+#
+on:
+  push:
+    branches:
+      - 'master'
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  check-dist:
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16.16.0
+      - uses: bahmutov/npm-install@v1
+      - run: npm run format
+      - run: npm run build
+
+      - name: Compare the expected and actual dist/ directories
+        run: |
+          if [ "$(git diff --ignore-space-at-eol dist/ | wc -l)" -gt "0" ]; then
+            echo "Detected uncommitted changes after build.  See status below:"
+            git diff
+            exit 1
+          fi


### PR DESCRIPTION
This PR addresses issue https://github.com/cypress-io/github-action/issues/706 "Add build & diff "/dist" folder workflow".

It adds a new workflow [.github/workflows/check-dist.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/check-dist.yml) which checks for consistency between source files and the generated contents of the [master/dist](https://github.com/cypress-io/github-action/tree/master/dist) directory.

If the source files and [master/dist](https://github.com/cypress-io/github-action/tree/master/dist) are consistent then the workflow succeeds.

If the source files and [master/dist](https://github.com/cypress-io/github-action/tree/master/dist) are **not** consistent then the workflow fails.

## Verification

Test on Ubuntu 22.04.

### Error case

Make a change to [master/index.js](https://github.com/cypress-io/github-action/blob/master/index.js), for instance, add the following to the top of the source code:

```js
const workflowTest = true
```
Commit the change
Run the workflow [.github/workflows/check-dist.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/check-dist.yml)
Check that the workflow fails, with the message:

"Detected uncommitted changes after build.  See status below:"

### Non-error case

Following on from above, execute:

```bash
npm run format
npm run build
```
Commit the change and retest.

Check that the workflow now succeeds.

### Cross-platform compatibility

After achieving a successful result on Ubuntu 22.04 sync the branch from above onto a Windows 11 platform, then execute:

```bash
npm run format
npm run build
```

Confirm that there are no changes whilst ignoring end-of-line changes:

```bash
git diff --ignore-space-at-eol
```
and note the warnings:
```text
warning: in the working copy of 'dist/thread.js', LF will be replaced by CRLF the next time Git touches it
warning: in the working copy of 'index.js', LF will be replaced by CRLF the next time Git touches it
```

Confirm that there are changes:
```bash
git diff
```

Commit these changes and retest.

Check that the workflow still succeeds despite having replaced the Ubuntu generated `dist/index.js` with a Windows generated version.

