### PR TITLE
Harmonize Component test workflow to E2E example workflows

### DIFF
--- a/.github/workflows/example-component-test.yml
+++ b/.github/workflows/example-component-test.yml
@@ -1,8 +1,14 @@
-name: Component Tests
-on: [push, workflow_dispatch]
+name: example-component-test
+on:
+  push:
+    branches:
+      - 'master'
+  pull_request:
+  workflow_dispatch:
+
 jobs:
   cypress-run:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
This PR implements the suggestions from issue https://github.com/cypress-io/github-action/issues/770 "Harmonize Component test workflow" regarding the workflow [.github/workflows/example-component-test.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-component-test.yml).

1. It changes the name to `example-component-test` so that it appears sorted in the left-hand side of [GH Action view](https://github.com/cypress-io/github-action/actions) together with the E2E tests.
2. It changes the trigger to be identical to E2E example triggers. This avoids the workflow running on `push` to branches other than `master`.
3. It changes the runner to the explicit Ubuntu version `ubuntu-22.04`. This makes it clearer exactly which version is being used and it aligns it with the default version used in all E2E tests.

## Verification

Manually run workflow and ensure it is successful.

Push to a branch other than `master` and check that the workflow is not triggered.
