### PR TITLE
Remove stop-build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,8 +27,7 @@
         "@vercel/ncc": "0.36.1",
         "husky": "7.0.4",
         "markdown-link-check": "3.10.3",
-        "prettier": "2.8.3",
-        "stop-build": "1.1.0"
+        "prettier": "2.8.3"
       }
     },
     "node_modules/@actions/cache": {
@@ -546,12 +545,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
     },
-    "node_modules/asap": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
-      "dev": true
-    },
     "node_modules/async": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
@@ -572,12 +565,6 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.3.tgz",
       "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ=="
-    },
-    "node_modules/bluebird": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
-      "integrity": "sha512-3LE8m8bqjGdoxfvf71yhFNrUcwy3NLy00SAo+b6MfJ8l+Bc2DzQ7mUHwX6pjK2AxfgV+YfsjCeVW3T5HLQTBsQ==",
-      "dev": true
     },
     "node_modules/boolbase": {
       "version": "1.0.0",
@@ -660,71 +647,6 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/chdir-promise": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/chdir-promise/-/chdir-promise-0.4.0.tgz",
-      "integrity": "sha512-fAvt/5sjLFKVp5bOc6FnMWB7kcXHk1uZSQa6tWdkkcT/Dv/hmsVwuabyDujd6G7a17mZipoYLJEaQcSEYrTG6Q==",
-      "dev": true,
-      "dependencies": {
-        "check-more-types": "2.23.0",
-        "debug": "^2.3.3",
-        "lazy-ass": "1.5.0",
-        "q": "1.1.2",
-        "spots": "0.4.0"
-      }
-    },
-    "node_modules/chdir-promise/node_modules/check-more-types": {
-      "version": "2.23.0",
-      "resolved": "https://registry.npmjs.org/check-more-types/-/check-more-types-2.23.0.tgz",
-      "integrity": "sha512-dDo5EKT4pZj5GArqso+z2TJmk5/fb+MqtwqJO4IdVhmL9rjglTvndCTRRwxDlQT9FObaYJENljJ0A+8ckAYakQ==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/chdir-promise/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dev": true,
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/chdir-promise/node_modules/lazy-ass": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/lazy-ass/-/lazy-ass-1.5.0.tgz",
-      "integrity": "sha512-5l6J7+KWp/OiisiR/KkwuPgeaIyb8d5jlLZsncDpffa5aBtOCcEcyoXoMGxOw50fr7RrCxEGqXkIHGRl1PL7ig==",
-      "dev": true,
-      "engines": {
-        "node": "> 0.8"
-      }
-    },
-    "node_modules/chdir-promise/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "dev": true
-    },
-    "node_modules/chdir-promise/node_modules/q": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/q/-/q-1.1.2.tgz",
-      "integrity": "sha512-ROtylwux7Vkc4C07oKE/ReigUmb33kVoLtcR4SJ1QVqwaZkBEDL3vX4/kwFzIERQ5PfCl0XafbU8u2YUhyGgVA==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.6.0",
-        "teleport": ">=0.2.0"
-      }
-    },
-    "node_modules/check-more-types": {
-      "version": "2.24.0",
-      "resolved": "https://registry.npmjs.org/check-more-types/-/check-more-types-2.24.0.tgz",
-      "integrity": "sha512-Pj779qHxV2tuapviy1bSZNEL1maXr13bPYpsvSDB68HlYcYuhlDrmGd63i0JHMCLKzc7rUSNIrpdJlhVlNwrxA==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
     "node_modules/cheerio": {
       "version": "1.0.0-rc.12",
       "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.12.tgz",
@@ -763,27 +685,6 @@
         "url": "https://github.com/sponsors/fb55"
       }
     },
-    "node_modules/cli-table": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz",
-      "integrity": "sha512-h/TzJrgwzVV+W6laITBZAxAWfBjX4T0x+LF5XJdS1AzDkXqmraMNnKQ/O/f3AHJKVR85fOglUEdS/B0P1wS7Aw==",
-      "dev": true,
-      "dependencies": {
-        "colors": "1.0.3"
-      },
-      "engines": {
-        "node": ">= 0.2.0"
-      }
-    },
-    "node_modules/cli-table/node_modules/colors": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
-      "integrity": "sha512-pFGrxThWcWQ2MsAz6RtgeWe4NK2kUE1WfsrvvlctdII745EW9I0yflqhe7++M5LEc7bV2c/9/5zc8sFcpL0Drw==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.1.90"
-      }
-    },
     "node_modules/clone-response": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz",
@@ -812,15 +713,6 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
-    },
-    "node_modules/colors": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
-      "integrity": "sha512-ENwblkFQpqqia6b++zLD/KUWafYlVY/UNnAp7oz7LY7E924wmpye416wBOmvv/HMWzl8gL1kJlfvId/1Dg176w==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.1.90"
-      }
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -886,15 +778,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/fb55"
-      }
-    },
-    "node_modules/d3-helpers": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/d3-helpers/-/d3-helpers-0.3.0.tgz",
-      "integrity": "sha512-uNJ5QRsTW7CdNC6CHX528VwIEzYCC/iFHMQ9ReaDUGA+iiJXHcR2uKobK68FkKSWmNYPxwaUV+9SswjoygF6VA==",
-      "dev": true,
-      "engines": {
-        "node": "> 0.8"
       }
     },
     "node_modules/debug": {
@@ -1104,12 +987,6 @@
         "node": ">= 0.12"
       }
     },
-    "node_modules/fs.realpath": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-      "dev": true
-    },
     "node_modules/get-stream": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
@@ -1119,87 +996,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/ggit": {
-      "version": "1.15.1",
-      "resolved": "https://registry.npmjs.org/ggit/-/ggit-1.15.1.tgz",
-      "integrity": "sha512-xfdO/qLRT2Xqv8sZgom726ZhWmBBjhTd6qKhEZ1LnRzAu14bN+qf+CGd/u1YJP0k18KEbC65gsW/pbKnNtOWzg==",
-      "dev": true,
-      "dependencies": {
-        "bluebird": "3.5.0",
-        "chdir-promise": "0.4.0",
-        "check-more-types": "2.24.0",
-        "cli-table": "0.3.1",
-        "colors": "1.1.2",
-        "commander": "2.9.0",
-        "d3-helpers": "0.3.0",
-        "debug": "2.6.3",
-        "glob": "7.1.1",
-        "lazy-ass": "1.6.0",
-        "lodash": "3.10.1",
-        "moment": "2.18.1",
-        "optimist": "0.6.1",
-        "q": "2.0.3",
-        "quote": "0.4.0",
-        "ramda": "0.9.1"
-      },
-      "bin": {
-        "ggit": "bin/ggit.js",
-        "ggit-last": "bin/ggit-last"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/ggit/node_modules/commander": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-      "integrity": "sha512-bmkUukX8wAOjHdN26xj5c4ctEV22TQ7dQYhSmuckKhToXrkUn0iIaolHdIxYYqD55nhpSPA9zPQ1yP57GdXP2A==",
-      "dev": true,
-      "dependencies": {
-        "graceful-readlink": ">= 1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.6.x"
-      }
-    },
-    "node_modules/ggit/node_modules/debug": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.3.tgz",
-      "integrity": "sha512-9k275CFA9z/NW+7nojeyxyOCFYsc+Dfiq4Sg8CBP5WjzmJT5K1utEepahY7wuWhlsumHgmAqnwAnxPCgOOyAHA==",
-      "dev": true,
-      "dependencies": {
-        "ms": "0.7.2"
-      }
-    },
-    "node_modules/ggit/node_modules/lodash": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-      "integrity": "sha512-9mDDwqVIma6OZX79ZlDACZl8sBm0TEnkf99zV3iMA4GzkIT/9hiqP5mY0HoT1iNLCrKc/R1HByV+yJfRWVJryQ==",
-      "dev": true
-    },
-    "node_modules/ggit/node_modules/ms": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
-      "integrity": "sha512-5NnE67nQSQDJHVahPJna1PQ/zCXMnQop3yUCxjKPNzCxuyPSKWTQ/5Gu5CZmjetwGLWRA+PzeF5thlbOdbQldA==",
-      "dev": true
-    },
-    "node_modules/glob": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
-      "integrity": "sha512-mRyN/EsN2SyNhKWykF3eEGhDpeNplMWaW18Bmh76tnOqk5TbELAVwFAYOCmKVssOYFrYvvLMguiA+NXO3ZTuVA==",
-      "dev": true,
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.2",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/got": {
@@ -1225,12 +1021,6 @@
       "funding": {
         "url": "https://github.com/sindresorhus/got?sponsor=1"
       }
-    },
-    "node_modules/graceful-readlink": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-      "integrity": "sha512-8tLu60LgxF6XpdbK8OW3FA+IfTNBn1ZHGHKF4KQbEeSkajYw5PlYJcKluntgegDPTg8UkHjpet1T82vk6TQ68w==",
-      "dev": true
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
@@ -1347,22 +1137,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/inflight": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-      "dev": true,
-      "dependencies": {
-        "once": "^1.3.0",
-        "wrappy": "1"
-      }
-    },
-    "node_modules/inherits": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
-    },
     "node_modules/ip-regex": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
@@ -1453,15 +1227,6 @@
       "integrity": "sha512-5MHbFaKn8cNSmVW7BYnijeAVlE4cYA/SVkifVgrh7yotnfhKmjuXpDKjrABLnT0SfHWV21P8ow07OGfRrNDg8g==",
       "dependencies": {
         "json-buffer": "3.0.1"
-      }
-    },
-    "node_modules/lazy-ass": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/lazy-ass/-/lazy-ass-1.6.0.tgz",
-      "integrity": "sha512-cc8oEVoctTvsFZ/Oje/kGnHbpWHYBe8IAJe4C0QNc3t8uM/0Y8+erSz/7Y1ALuXTEZTMvxXwO6YbX1ey3ujiZw==",
-      "dev": true,
-      "engines": {
-        "node": "> 0.8"
       }
     },
     "node_modules/link-check": {
@@ -1603,21 +1368,6 @@
         "node": "*"
       }
     },
-    "node_modules/minimist": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-      "integrity": "sha512-iotkTvxc+TwOm5Ieim8VnSNvCDjCK9S8G3scJ50ZthspSxa7jx50jkhYduuAtAjvfDUwSgOwf8+If99AlOEhyw==",
-      "dev": true
-    },
-    "node_modules/moment": {
-      "version": "2.18.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.18.1.tgz",
-      "integrity": "sha512-QGcnVKRSEhbWy2i0pqFhjWMCczL/YU5ICMB3maUavFcyUqBszRnzsswvOaGOqSfWZ/R+dMnb9gGBuRT4LMTdVQ==",
-      "dev": true,
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -1738,16 +1488,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/optimist": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-      "integrity": "sha512-snN4O4TkigujZphWLN0E//nQmm7790RYaE53DdL7ZYwee2D8DDo9/EyYiKUfN3rneWUjhJnueija3G9I2i0h3g==",
-      "dev": true,
-      "dependencies": {
-        "minimist": "~0.0.1",
-        "wordwrap": "~0.0.2"
-      }
-    },
     "node_modules/p-cancelable": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
@@ -1781,15 +1521,6 @@
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
-    "node_modules/path-is-absolute": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -1808,21 +1539,6 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
-    },
-    "node_modules/pluralize": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-5.0.0.tgz",
-      "integrity": "sha512-3XyqUZZQZhBf6vt9FP49WhY+ZeqYT7Y6pWn4uWCAifD5tganssOlrsLbMysFM1Rgnmd9k2OUsgvDe7jWSXrchQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/pop-iterate": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/pop-iterate/-/pop-iterate-1.0.1.tgz",
-      "integrity": "sha512-HRCx4+KJE30JhX84wBN4+vja9bNfysxg1y28l0DuJmkoaICiv2ZSilKddbS48pq50P8d2erAhqDLbp47yv3MbQ==",
-      "dev": true
     },
     "node_modules/prettier": {
       "version": "2.8.3",
@@ -1878,17 +1594,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/q": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/q/-/q-2.0.3.tgz",
-      "integrity": "sha512-gv6vLGcmAOg96/fgo3d9tvA4dJNZL3fMyBqVRrGxQ+Q/o4k9QzbJ3NQF9cOO/71wRodoXhaPgphvMFU68qVAJQ==",
-      "dev": true,
-      "dependencies": {
-        "asap": "^2.0.0",
-        "pop-iterate": "^1.0.1",
-        "weak-map": "^1.0.5"
-      }
-    },
     "node_modules/querystringify": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
@@ -1909,12 +1614,6 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/quote/-/quote-0.4.0.tgz",
       "integrity": "sha512-KHp3y3xDjuBhRx+tYKOgzPnVHMRlgpn2rU450GcU4PL24r1H6ls/hfPrxDwX2pvYMlwODHI2l8WwgoV69x5rUQ=="
-    },
-    "node_modules/ramda": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.9.1.tgz",
-      "integrity": "sha512-Rccpyj5OM4v2ecM8Ej0canQkH4FSAu9o+mZezRl20/Uph1B1deJ26NjevZH4v7E0ngANvbKw7azX1a8v6KoBrQ==",
-      "dev": true
     },
     "node_modules/requires-port": {
       "version": "1.0.0",
@@ -1979,31 +1678,6 @@
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
-    },
-    "node_modules/spots": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/spots/-/spots-0.4.0.tgz",
-      "integrity": "sha512-WugtpL4zoap6ZE2VWKZTMfmhEE32jSHYHdbzoMbaXjgLmbE0aUnEErIzpyeb3JyfW8HLmcfcCCIjK1jrdTRg1Q==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/stop-build": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/stop-build/-/stop-build-1.1.0.tgz",
-      "integrity": "sha512-RKkSh9/FY4YbK9Pbf5lbnTcjI3mpkgfBDuD0ZeL0N4DxdZCRA8TVEuAlinbzoKcNBv+UtyPr1VekSybbuwUugg==",
-      "dev": true,
-      "dependencies": {
-        "ggit": "1.15.1",
-        "pluralize": "5.0.0"
-      },
-      "bin": {
-        "stop-build": "src/index.js"
-      },
-      "engines": {
-        "node": ">=6"
-      }
     },
     "node_modules/strip-final-newline": {
       "version": "3.0.0",
@@ -2109,12 +1783,6 @@
         "uuid": "bin/uuid"
       }
     },
-    "node_modules/weak-map": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/weak-map/-/weak-map-1.0.8.tgz",
-      "integrity": "sha512-lNR9aAefbGPpHO7AEnY0hCFjz1eTkWCXYvkTRrTHs9qv8zJp+SkVYpzfLIFXQQiG3tVvbNFQgVg2bQS8YGgxyw==",
-      "dev": true
-    },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
@@ -2141,15 +1809,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/wordwrap": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-      "integrity": "sha512-1tMA907+V4QmxV7dbRvb4/8MaRALK6q9Abid3ndMYnbyo8piisCmeONVqVSXqQA3KaP4SLt5b7ud6E2sqP8TFw==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.4.0"
       }
     },
     "node_modules/wrappy": {
@@ -2619,12 +2278,6 @@
         }
       }
     },
-    "asap": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
-      "dev": true
-    },
     "async": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
@@ -2645,12 +2298,6 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.3.tgz",
       "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ=="
-    },
-    "bluebird": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
-      "integrity": "sha512-3LE8m8bqjGdoxfvf71yhFNrUcwy3NLy00SAo+b6MfJ8l+Bc2DzQ7mUHwX6pjK2AxfgV+YfsjCeVW3T5HLQTBsQ==",
-      "dev": true
     },
     "boolbase": {
       "version": "1.0.0",
@@ -2714,60 +2361,6 @@
         "supports-color": "^7.1.0"
       }
     },
-    "chdir-promise": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/chdir-promise/-/chdir-promise-0.4.0.tgz",
-      "integrity": "sha512-fAvt/5sjLFKVp5bOc6FnMWB7kcXHk1uZSQa6tWdkkcT/Dv/hmsVwuabyDujd6G7a17mZipoYLJEaQcSEYrTG6Q==",
-      "dev": true,
-      "requires": {
-        "check-more-types": "2.23.0",
-        "debug": "^2.3.3",
-        "lazy-ass": "1.5.0",
-        "q": "1.1.2",
-        "spots": "0.4.0"
-      },
-      "dependencies": {
-        "check-more-types": {
-          "version": "2.23.0",
-          "resolved": "https://registry.npmjs.org/check-more-types/-/check-more-types-2.23.0.tgz",
-          "integrity": "sha512-dDo5EKT4pZj5GArqso+z2TJmk5/fb+MqtwqJO4IdVhmL9rjglTvndCTRRwxDlQT9FObaYJENljJ0A+8ckAYakQ==",
-          "dev": true
-        },
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "lazy-ass": {
-          "version": "1.5.0",
-          "resolved": "https://registry.npmjs.org/lazy-ass/-/lazy-ass-1.5.0.tgz",
-          "integrity": "sha512-5l6J7+KWp/OiisiR/KkwuPgeaIyb8d5jlLZsncDpffa5aBtOCcEcyoXoMGxOw50fr7RrCxEGqXkIHGRl1PL7ig==",
-          "dev": true
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-          "dev": true
-        },
-        "q": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/q/-/q-1.1.2.tgz",
-          "integrity": "sha512-ROtylwux7Vkc4C07oKE/ReigUmb33kVoLtcR4SJ1QVqwaZkBEDL3vX4/kwFzIERQ5PfCl0XafbU8u2YUhyGgVA==",
-          "dev": true
-        }
-      }
-    },
-    "check-more-types": {
-      "version": "2.24.0",
-      "resolved": "https://registry.npmjs.org/check-more-types/-/check-more-types-2.24.0.tgz",
-      "integrity": "sha512-Pj779qHxV2tuapviy1bSZNEL1maXr13bPYpsvSDB68HlYcYuhlDrmGd63i0JHMCLKzc7rUSNIrpdJlhVlNwrxA==",
-      "dev": true
-    },
     "cheerio": {
       "version": "1.0.0-rc.12",
       "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.12.tgz",
@@ -2797,23 +2390,6 @@
         "domutils": "^3.0.1"
       }
     },
-    "cli-table": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz",
-      "integrity": "sha512-h/TzJrgwzVV+W6laITBZAxAWfBjX4T0x+LF5XJdS1AzDkXqmraMNnKQ/O/f3AHJKVR85fOglUEdS/B0P1wS7Aw==",
-      "dev": true,
-      "requires": {
-        "colors": "1.0.3"
-      },
-      "dependencies": {
-        "colors": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
-          "integrity": "sha512-pFGrxThWcWQ2MsAz6RtgeWe4NK2kUE1WfsrvvlctdII745EW9I0yflqhe7++M5LEc7bV2c/9/5zc8sFcpL0Drw==",
-          "dev": true
-        }
-      }
-    },
     "clone-response": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz",
@@ -2835,12 +2411,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
-    },
-    "colors": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
-      "integrity": "sha512-ENwblkFQpqqia6b++zLD/KUWafYlVY/UNnAp7oz7LY7E924wmpye416wBOmvv/HMWzl8gL1kJlfvId/1Dg176w==",
       "dev": true
     },
     "combined-stream": {
@@ -2889,12 +2459,6 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
       "integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==",
-      "dev": true
-    },
-    "d3-helpers": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/d3-helpers/-/d3-helpers-0.3.0.tgz",
-      "integrity": "sha512-uNJ5QRsTW7CdNC6CHX528VwIEzYCC/iFHMQ9ReaDUGA+iiJXHcR2uKobK68FkKSWmNYPxwaUV+9SswjoygF6VA==",
       "dev": true
     },
     "debug": {
@@ -3038,86 +2602,10 @@
         "mime-types": "^2.1.12"
       }
     },
-    "fs.realpath": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-      "dev": true
-    },
     "get-stream": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
       "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg=="
-    },
-    "ggit": {
-      "version": "1.15.1",
-      "resolved": "https://registry.npmjs.org/ggit/-/ggit-1.15.1.tgz",
-      "integrity": "sha512-xfdO/qLRT2Xqv8sZgom726ZhWmBBjhTd6qKhEZ1LnRzAu14bN+qf+CGd/u1YJP0k18KEbC65gsW/pbKnNtOWzg==",
-      "dev": true,
-      "requires": {
-        "bluebird": "3.5.0",
-        "chdir-promise": "0.4.0",
-        "check-more-types": "2.24.0",
-        "cli-table": "0.3.1",
-        "colors": "1.1.2",
-        "commander": "2.9.0",
-        "d3-helpers": "0.3.0",
-        "debug": "2.6.3",
-        "glob": "7.1.1",
-        "lazy-ass": "1.6.0",
-        "lodash": "3.10.1",
-        "moment": "2.18.1",
-        "optimist": "0.6.1",
-        "q": "2.0.3",
-        "quote": "0.4.0",
-        "ramda": "0.9.1"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "2.9.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-          "integrity": "sha512-bmkUukX8wAOjHdN26xj5c4ctEV22TQ7dQYhSmuckKhToXrkUn0iIaolHdIxYYqD55nhpSPA9zPQ1yP57GdXP2A==",
-          "dev": true,
-          "requires": {
-            "graceful-readlink": ">= 1.0.0"
-          }
-        },
-        "debug": {
-          "version": "2.6.3",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.3.tgz",
-          "integrity": "sha512-9k275CFA9z/NW+7nojeyxyOCFYsc+Dfiq4Sg8CBP5WjzmJT5K1utEepahY7wuWhlsumHgmAqnwAnxPCgOOyAHA==",
-          "dev": true,
-          "requires": {
-            "ms": "0.7.2"
-          }
-        },
-        "lodash": {
-          "version": "3.10.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-          "integrity": "sha512-9mDDwqVIma6OZX79ZlDACZl8sBm0TEnkf99zV3iMA4GzkIT/9hiqP5mY0HoT1iNLCrKc/R1HByV+yJfRWVJryQ==",
-          "dev": true
-        },
-        "ms": {
-          "version": "0.7.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
-          "integrity": "sha512-5NnE67nQSQDJHVahPJna1PQ/zCXMnQop3yUCxjKPNzCxuyPSKWTQ/5Gu5CZmjetwGLWRA+PzeF5thlbOdbQldA==",
-          "dev": true
-        }
-      }
-    },
-    "glob": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
-      "integrity": "sha512-mRyN/EsN2SyNhKWykF3eEGhDpeNplMWaW18Bmh76tnOqk5TbELAVwFAYOCmKVssOYFrYvvLMguiA+NXO3ZTuVA==",
-      "dev": true,
-      "requires": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.2",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      }
     },
     "got": {
       "version": "11.8.6",
@@ -3136,12 +2624,6 @@
         "p-cancelable": "^2.0.0",
         "responselike": "^2.0.0"
       }
-    },
-    "graceful-readlink": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-      "integrity": "sha512-8tLu60LgxF6XpdbK8OW3FA+IfTNBn1ZHGHKF4KQbEeSkajYw5PlYJcKluntgegDPTg8UkHjpet1T82vk6TQ68w==",
-      "dev": true
     },
     "has-flag": {
       "version": "4.0.0",
@@ -3220,22 +2702,6 @@
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       }
     },
-    "inflight": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-      "dev": true,
-      "requires": {
-        "once": "^1.3.0",
-        "wrappy": "1"
-      }
-    },
-    "inherits": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
-    },
     "ip-regex": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
@@ -3297,12 +2763,6 @@
       "requires": {
         "json-buffer": "3.0.1"
       }
-    },
-    "lazy-ass": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/lazy-ass/-/lazy-ass-1.6.0.tgz",
-      "integrity": "sha512-cc8oEVoctTvsFZ/Oje/kGnHbpWHYBe8IAJe4C0QNc3t8uM/0Y8+erSz/7Y1ALuXTEZTMvxXwO6YbX1ey3ujiZw==",
-      "dev": true
     },
     "link-check": {
       "version": "5.2.0",
@@ -3412,18 +2872,6 @@
         "brace-expansion": "^1.1.7"
       }
     },
-    "minimist": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-      "integrity": "sha512-iotkTvxc+TwOm5Ieim8VnSNvCDjCK9S8G3scJ50ZthspSxa7jx50jkhYduuAtAjvfDUwSgOwf8+If99AlOEhyw==",
-      "dev": true
-    },
-    "moment": {
-      "version": "2.18.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.18.1.tgz",
-      "integrity": "sha512-QGcnVKRSEhbWy2i0pqFhjWMCczL/YU5ICMB3maUavFcyUqBszRnzsswvOaGOqSfWZ/R+dMnb9gGBuRT4LMTdVQ==",
-      "dev": true
-    },
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -3504,16 +2952,6 @@
         "mimic-fn": "^4.0.0"
       }
     },
-    "optimist": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-      "integrity": "sha512-snN4O4TkigujZphWLN0E//nQmm7790RYaE53DdL7ZYwee2D8DDo9/EyYiKUfN3rneWUjhJnueija3G9I2i0h3g==",
-      "dev": true,
-      "requires": {
-        "minimist": "~0.0.1",
-        "wordwrap": "~0.0.2"
-      }
-    },
     "p-cancelable": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
@@ -3538,12 +2976,6 @@
         "parse5": "^7.0.0"
       }
     },
-    "path-is-absolute": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-      "dev": true
-    },
     "path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -3553,18 +2985,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="
-    },
-    "pluralize": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-5.0.0.tgz",
-      "integrity": "sha512-3XyqUZZQZhBf6vt9FP49WhY+ZeqYT7Y6pWn4uWCAifD5tganssOlrsLbMysFM1Rgnmd9k2OUsgvDe7jWSXrchQ==",
-      "dev": true
-    },
-    "pop-iterate": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/pop-iterate/-/pop-iterate-1.0.1.tgz",
-      "integrity": "sha512-HRCx4+KJE30JhX84wBN4+vja9bNfysxg1y28l0DuJmkoaICiv2ZSilKddbS48pq50P8d2erAhqDLbp47yv3MbQ==",
-      "dev": true
     },
     "prettier": {
       "version": "2.8.3",
@@ -3602,17 +3022,6 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
-    "q": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/q/-/q-2.0.3.tgz",
-      "integrity": "sha512-gv6vLGcmAOg96/fgo3d9tvA4dJNZL3fMyBqVRrGxQ+Q/o4k9QzbJ3NQF9cOO/71wRodoXhaPgphvMFU68qVAJQ==",
-      "dev": true,
-      "requires": {
-        "asap": "^2.0.0",
-        "pop-iterate": "^1.0.1",
-        "weak-map": "^1.0.5"
-      }
-    },
     "querystringify": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
@@ -3627,12 +3036,6 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/quote/-/quote-0.4.0.tgz",
       "integrity": "sha512-KHp3y3xDjuBhRx+tYKOgzPnVHMRlgpn2rU450GcU4PL24r1H6ls/hfPrxDwX2pvYMlwODHI2l8WwgoV69x5rUQ=="
-    },
-    "ramda": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.9.1.tgz",
-      "integrity": "sha512-Rccpyj5OM4v2ecM8Ej0canQkH4FSAu9o+mZezRl20/Uph1B1deJ26NjevZH4v7E0ngANvbKw7azX1a8v6KoBrQ==",
-      "dev": true
     },
     "requires-port": {
       "version": "1.0.0",
@@ -3685,22 +3088,6 @@
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
-    },
-    "spots": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/spots/-/spots-0.4.0.tgz",
-      "integrity": "sha512-WugtpL4zoap6ZE2VWKZTMfmhEE32jSHYHdbzoMbaXjgLmbE0aUnEErIzpyeb3JyfW8HLmcfcCCIjK1jrdTRg1Q==",
-      "dev": true
-    },
-    "stop-build": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/stop-build/-/stop-build-1.1.0.tgz",
-      "integrity": "sha512-RKkSh9/FY4YbK9Pbf5lbnTcjI3mpkgfBDuD0ZeL0N4DxdZCRA8TVEuAlinbzoKcNBv+UtyPr1VekSybbuwUugg==",
-      "dev": true,
-      "requires": {
-        "ggit": "1.15.1",
-        "pluralize": "5.0.0"
-      }
     },
     "strip-final-newline": {
       "version": "3.0.0",
@@ -3778,12 +3165,6 @@
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
       "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
     },
-    "weak-map": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/weak-map/-/weak-map-1.0.8.tgz",
-      "integrity": "sha512-lNR9aAefbGPpHO7AEnY0hCFjz1eTkWCXYvkTRrTHs9qv8zJp+SkVYpzfLIFXQQiG3tVvbNFQgVg2bQS8YGgxyw==",
-      "dev": true
-    },
     "webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
@@ -3805,12 +3186,6 @@
       "requires": {
         "isexe": "^2.0.0"
       }
-    },
-    "wordwrap": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-      "integrity": "sha512-1tMA907+V4QmxV7dbRvb4/8MaRALK6q9Abid3ndMYnbyo8piisCmeONVqVSXqQA3KaP4SLt5b7ud6E2sqP8TFw==",
-      "dev": true
     },
     "wrappy": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -49,8 +49,7 @@
     "@vercel/ncc": "0.36.1",
     "husky": "7.0.4",
     "markdown-link-check": "3.10.3",
-    "prettier": "2.8.3",
-    "stop-build": "1.1.0"
+    "prettier": "2.8.3"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
This PR removes the unused npm package [stop-build](https://www.npmjs.com/package/stop-build) which invokes two critical vulnerabilities in `npm audit` through `minimist@0.0.10` and `lodash@3.10.1`. The package was last updated 6 years ago.

