### PR TITLE
Prevent release attempt from fork

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,9 @@ jobs:
     name: release
     needs: [build-and-test]
     # only release from the master branch
-    if: github.ref == 'refs/heads/master'
+    # in parent repository, not in a fork
+    if: (github.ref == 'refs/heads/master') &&
+      (github.repository == 'cypress-io/github-action')
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
This PR partially addresses issue https://github.com/cypress-io/github-action/issues/715 "Issues with cycjimmy/semantic-release-action in main workflow (Rev 2)" where [.github/workflows/main.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/main.yml) may run in a fork, attempting to carry out a release, which then fails with an error message due to lack of write permissions to the parent repository.

The PR restricts the `release` job of [.github/workflows/main.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/main.yml) so that it only runs on the repository [cypress-io/github-action](https://github.com/cypress-io/github-action) and not on a fork of this repository.

## Verification

In a fork, ensure that workflows are enabled (Settings > Actions > General > Allow all actions and reusable workflows) and that the specific main workflow is not disabled (Actions > Show more workflows ... > main).

Push a commit to the `master` branch.

The release job should show "This job was skipped".

Verify also on a copy of the repository that a release is carried out when pushing to the parent `master` branch.