### PR TITLE
Change example-debug job name from nightly to debug-logs

### DIFF
--- a/.github/workflows/example-debug.yml
+++ b/.github/workflows/example-debug.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  nightly:
+  debug-logs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout


### PR DESCRIPTION
This PR renames the job in [.github/workflows/example-debug.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-debug.yml) from `nightly` to `debug-logs`, which provides a more accurate description of the purpose of the job.

([.github/workflows/example-cron.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-cron.yml) which does indeed run every night at 04:00 UTC uses the job name `nightly`. This is a fitting job name for this workflow, but not for the debug one.)
