### PR TITLE
Correct log format for start: parameter

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -78818,11 +78818,7 @@ const startServersMaybe = () => {
   )
 
   return separateStartCommands.map((startCommand) => {
-    return execCommand(
-      startCommand,
-      false,
-      `start server "${startCommand}`
-    )
+    return execCommand(startCommand, false, `start server`)
   })
 }
 

--- a/index.js
+++ b/index.js
@@ -372,11 +372,7 @@ const startServersMaybe = () => {
   )
 
   return separateStartCommands.map((startCommand) => {
-    return execCommand(
-      startCommand,
-      false,
-      `start server "${startCommand}`
-    )
+    return execCommand(startCommand, false, `start server`)
   })
 }
 


### PR DESCRIPTION
This PR resolves a log formatting issue when the [start:](https://github.com/cypress-io/github-action/blob/master/README.md#start-server) (server) parameter is used.

If a step:

```yml
      - name: Cypress run
        uses: cypress-io/github-action@v5
        with:
          start: npm start
```

is defined in a GitHub workflow, the log would show:

```text
start server "npm start command "npm start"
```

with the text of the start command incorrectly rendered twice.

The fix is credited to @fbiville who originally submitted PR https://github.com/cypress-io/github-action/pull/481 in Jan, 2022.

With this PR the log output for the above example shows as:

```text
start server command "npm start"
```

## Verification

View the logs of https://github.com/cypress-io/github-action/actions/workflows/example-webpack.yml

Select the `wait` job then `Cypress tests`.

Search for "start server" in the log and confirm that:

```text
start server command "npm start"
```

is shown.