### PR TITLE
Correct example-basic for pnpm package.json to add pnpm to name

### DIFF
--- a/examples/basic-pnpm/package.json
+++ b/examples/basic-pnpm/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "example-basic",
-  "version": "1.0.0",
-  "description": "basic example how to run Cypress tests",
+  "name": "example-basic-pnpm",
+  "version": "2.0.0",
+  "description": "basic pnpm example how to run Cypress tests",
   "main": "index.js",
   "scripts": {
     "test": "cypress run"

--- a/examples/v9/basic-pnpm/package.json
+++ b/examples/v9/basic-pnpm/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "example-basic",
-  "version": "1.0.0",
-  "description": "basic example how to run Cypress tests",
+  "name": "example-basic-pnpm",
+  "version": "2.0.0",
+  "description": "basic pnpm example how to run Cypress tests",
   "main": "index.js",
   "scripts": {
     "test": "cypress run"


### PR DESCRIPTION
This PR corrects a minor inconsistency in:

- [examples/basic-pnpm/package.json](https://github.com/cypress-io/github-action/blob/master/examples/basic-pnpm/package.json) and
- [examples/v9/basic-pnpm/package.json](https://github.com/cypress-io/github-action/blob/master/examples/v9/basic-pnpm/package.json)

It adds `pnpm` to the package name `example-basic` and to the package description to distinguish it from the other `example-basic` based on `npm`.
