### PR TITLE
Check cypress cache folder on macOS

### DIFF
--- a/index.js
+++ b/index.js
@@ -149,11 +149,23 @@ const getNpmCache = () => {
   return o
 }
 
+const getCypressCacheFolder = () => {
+  const paths = process.env.CYPRESS_CACHE_FOLDER 
+    ? [process.env.CYPRESS_CACHE_FOLDER] : 
+    [
+      path.join(homeDirectory, '.cache', 'Cypress'),
+      path.join(homeDirectory, "Library", "Caches", "Cypress"),
+    ]
+  const result = paths.find(p => fs.existsSync(p))
+  if (!result) {
+    throw new Error(`Cypress cache folder missing`)
+  }
+  return result
+}
+
 // custom Cypress binary cache folder
 // see https://on.cypress.io/caching
-const CYPRESS_CACHE_FOLDER =
-  process.env.CYPRESS_CACHE_FOLDER ||
-  path.join(homeDirectory, '.cache', 'Cypress')
+const CYPRESS_CACHE_FOLDER = getCypressCacheFolder()
 debug(`using custom Cypress cache folder "${CYPRESS_CACHE_FOLDER}"`)
 
 const getCypressBinaryCache = () => {


### PR DESCRIPTION
Added cache folder validation when setting the cache folder variable. If the path is invalid the script won't run,

On macOS, the cache is installed in `~/Library/Caches`, and the script won't run if the symbolic link in `~/.cache` is missing. It solves the issue when running the CI, but maybe the fix should be in the cypress install script to ensure that the link in `~/.cache` is defined