### PR TITLE
Provide short instructions for Yarn Berry use

### DIFF
--- a/README.md
+++ b/README.md
@@ -1112,6 +1112,14 @@ Name | Description
 
 This action installs local dependencies using lock files. If `yarn.lock` file is found, the install uses `yarn --frozen-lockfile` command. Otherwise it expects to find `package-lock.json` and install using `npm ci` command.
 
+The above default `yarn` installation command can be replaced for [Yarn Berry](https://yarnpkg.com/) (Yarn 2 and later) using the `install-command` parameter, for example:
+
+```yml
+- uses: cypress-io/github-action@v5
+  with:
+    install-command: yarn install
+```
+
 This action uses several production dependencies. The minimum Node version required to run this action depends on the minimum Node required by the dependencies.
 
 ## Debugging


### PR DESCRIPTION
This PR is a quick and partial fix for issue https://github.com/cypress-io/github-action/issues/798 "Documentation for usage with Yarn Berry (Version 2 and later)".

It adds the following instructions to the [README: Installation](https://github.com/cypress-io/github-action#installation) section:

"The above default `yarn` installation command can be replaced for [Yarn Berry](https://yarnpkg.com/) (Yarn 2 and later) using the `install-command` parameter, for example:

```yml
- uses: cypress-io/github-action@v5
  with:
    install-command: yarn install
```

- More extensive changes should follow. See other suggestions in #798
