### PR TITLE
wait-on example changes for react-scripts and vite server under Node.js 18

### DIFF
--- a/.github/workflows/example-wait-on.yml
+++ b/.github/workflows/example-wait-on.yml
@@ -144,7 +144,7 @@ jobs:
         with:
           working-directory: examples/v9/react-scripts
           start: npm start
-          wait-on: 'http://localhost:3000'
+          wait-on: 'http://127.0.0.1:3000'
 
   wait-using-custom-command-v9:
     runs-on: ubuntu-22.04
@@ -157,7 +157,7 @@ jobs:
           working-directory: examples/v9/react-scripts
           start: npm start
           # let's use wait-on NPM package to check the URL
-          wait-on: 'npx wait-on --timeout 5000 http://localhost:3000'
+          wait-on: 'npx wait-on --timeout 5000 http://127.0.0.1:3000'
 
   ping-cli-v9:
     runs-on: ubuntu-22.04
@@ -179,7 +179,7 @@ jobs:
         with:
           working-directory: examples/v9/wait-on-vite
           start: npm run dev
-          wait-on: 'http://localhost:5173'
+          wait-on: 'http://ip6-localhost:5173'
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Cypress v10 and higher ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ #
 
@@ -317,7 +317,7 @@ jobs:
         with:
           working-directory: examples/react-scripts
           start: npm start
-          wait-on: 'http://localhost:3000'
+          wait-on: 'http://127.0.0.1:3000'
 
   wait-using-custom-command:
     runs-on: ubuntu-22.04
@@ -330,7 +330,7 @@ jobs:
           working-directory: examples/react-scripts
           start: npm start
           # let's use wait-on NPM package to check the URL
-          wait-on: 'npx wait-on --timeout 5000 http://localhost:3000'
+          wait-on: 'npx wait-on --timeout 5000 http://127.0.0.1:3000'
 
   ping-cli:
     runs-on: ubuntu-22.04
@@ -352,4 +352,4 @@ jobs:
         with:
           working-directory: examples/wait-on-vite
           start: npm run dev
-          wait-on: 'http://localhost:5173'
+          wait-on: 'http://ip6-localhost:5173'

--- a/.github/workflows/example-wait-on.yml
+++ b/.github/workflows/example-wait-on.yml
@@ -178,8 +178,8 @@ jobs:
         uses: ./
         with:
           working-directory: examples/v9/wait-on-vite
-          start: npm run dev
-          wait-on: 'http://ip6-localhost:5173'
+          start: npx vite --host
+          wait-on: 'http://localhost:5173'
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Cypress v10 and higher ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ #
 
@@ -351,5 +351,5 @@ jobs:
         uses: ./
         with:
           working-directory: examples/wait-on-vite
-          start: npm run dev
-          wait-on: 'http://ip6-localhost:5173'
+          start: npx vite --host
+          wait-on: 'http://localhost:5173'


### PR DESCRIPTION
This PR resolves issue https://github.com/cypress-io/github-action/issues/802 "example-wait-on fails on GitHub waiting for localhost".

Due to the migration of [GitHub runners](https://github.com/actions/runner-images) to use Node.js 18, name resolution is behaving differently when accessing `localhost`. This affects webservers used for testing which only listen on IPv4 or IPv6, but not on both network stacks.

In [example-wait-on](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-wait-on.yml) it changes the network name / address

- to wait for [react-scripts][react] server using the IPv4 address `127.0.0.1`

and 

- changes the startup of [vite server][vite] to `npx vite --host` (see Vite Server Options [server.host](https://vitejs.dev/config/server-options.html#server-host) documentation)

to allow the respective servers to be monitored until they are running, at which time control is passed to Cypress to carry out testing.

[react]: <https://github.com/facebook/create-react-app>
[vite]: <https://github.com/vitejs/vite>