### PR TITLE
Add test for Node.js 19

### DIFF
--- a/.github/workflows/example-node-versions.yml
+++ b/.github/workflows/example-node-versions.yml
@@ -14,8 +14,9 @@ jobs:
     runs-on: ubuntu-22.04
     # let's make sure Cypress works on several versions of Node
     strategy:
+      fail-fast: false
       matrix:
-        node: [14, 16, 18]
+        node: [14, 16, 18, 19]
     name: Cypress v9 E2E on Node v${{ matrix.node }}
     steps:
       - name: Setup Node
@@ -40,8 +41,9 @@ jobs:
     runs-on: ubuntu-22.04
     # let's make sure Cypress works on several versions of Node
     strategy:
+      fail-fast: false
       matrix:
-        node: [14, 16, 18]
+        node: [14, 16, 18, 19]
     name: Cypress E2E on Node v${{ matrix.node }}
     steps:
       - name: Setup Node


### PR DESCRIPTION
This PR implements the suggestion from https://github.com/cypress-io/github-action/issues/807 "Add Node.js 19 to tested versions" to modify [.github/workflows/example-node-versions.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-node-versions.yml) so that it additionally tests with Node.js 19. It also sets `fail-fast` to false so that each Node.js version test is carried out even if the test of another Node.js version should fail.

According to the [Node.js Release Schedule](https://github.com/nodejs/release#release-schedule) Node.js 19.x is the Current version. It was released on Oct 18, 2022, enters maintenance on Apr 1, 2023 and goes into end-of-life status on Jun 1, 2023.

This is to be followed by the next Node.js LTS version 20.x, planned for release on Apr 18, 2023.