### PR TITLE
Update examples to cypress 12.7.0

### DIFF
--- a/.github/workflows/example-install-only.yml
+++ b/.github/workflows/example-install-only.yml
@@ -63,7 +63,7 @@ jobs:
           key: my-cache-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
 
       - name: Install Cypress 📥
-        run: npm i cypress@12.6.0
+        run: npm i cypress@12.7.0
 
       - name: Cypress tests 🧪
         uses: ./

--- a/examples/basic-pnpm/package.json
+++ b/examples/basic-pnpm/package.json
@@ -10,6 +10,6 @@
   "license": "ISC",
   "private": true,
   "devDependencies": {
-    "cypress": "^12.6.0"
+    "cypress": "12.7.0"
   }
 }

--- a/examples/basic-pnpm/pnpm-lock.yaml
+++ b/examples/basic-pnpm/pnpm-lock.yaml
@@ -1,10 +1,10 @@
 lockfileVersion: 5.4
 
 specifiers:
-  cypress: ^12.6.0
+  cypress: 12.7.0
 
 devDependencies:
-  cypress: 12.6.0
+  cypress: 12.7.0
 
 packages:
 
@@ -293,8 +293,8 @@ packages:
       which: 2.0.2
     dev: true
 
-  /cypress/12.6.0:
-    resolution: {integrity: sha512-WdHSVaS1lumSd5XpVTslZd8ui9GIGphrzvXq9+3DtVhqjRZC5M70gu5SW/Y/SLPq3D1wiXGZoHC6HJ7ESVE2lw==}
+  /cypress/12.7.0:
+    resolution: {integrity: sha512-7rq+nmhzz0u6yabCFyPtADU2OOrYt6pvUau9qV7xyifJ/hnsaw/vkr0tnLlcuuQKUAOC1v1M1e4Z0zG7S0IAvA==}
     engines: {node: ^14.0.0 || ^16.0.0 || >=18.0.0}
     hasBin: true
     requiresBuild: true

--- a/examples/basic/package-lock.json
+++ b/examples/basic/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {
-        "cypress": "12.6.0"
+        "cypress": "12.7.0"
       }
     },
     "node_modules/@cypress/request": {
@@ -511,9 +511,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "12.6.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.6.0.tgz",
-      "integrity": "sha512-WdHSVaS1lumSd5XpVTslZd8ui9GIGphrzvXq9+3DtVhqjRZC5M70gu5SW/Y/SLPq3D1wiXGZoHC6HJ7ESVE2lw==",
+      "version": "12.7.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.7.0.tgz",
+      "integrity": "sha512-7rq+nmhzz0u6yabCFyPtADU2OOrYt6pvUau9qV7xyifJ/hnsaw/vkr0tnLlcuuQKUAOC1v1M1e4Z0zG7S0IAvA==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -2194,9 +2194,9 @@
       }
     },
     "cypress": {
-      "version": "12.6.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.6.0.tgz",
-      "integrity": "sha512-WdHSVaS1lumSd5XpVTslZd8ui9GIGphrzvXq9+3DtVhqjRZC5M70gu5SW/Y/SLPq3D1wiXGZoHC6HJ7ESVE2lw==",
+      "version": "12.7.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.7.0.tgz",
+      "integrity": "sha512-7rq+nmhzz0u6yabCFyPtADU2OOrYt6pvUau9qV7xyifJ/hnsaw/vkr0tnLlcuuQKUAOC1v1M1e4Z0zG7S0IAvA==",
       "dev": true,
       "requires": {
         "@cypress/request": "^2.88.10",

--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -10,6 +10,6 @@
   "license": "ISC",
   "private": true,
   "devDependencies": {
-    "cypress": "12.6.0"
+    "cypress": "12.7.0"
   }
 }

--- a/examples/chrome/package-lock.json
+++ b/examples/chrome/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {
-        "cypress": "12.6.0",
+        "cypress": "12.7.0",
         "image-size": "0.8.3"
       }
     },
@@ -525,9 +525,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "12.6.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.6.0.tgz",
-      "integrity": "sha512-WdHSVaS1lumSd5XpVTslZd8ui9GIGphrzvXq9+3DtVhqjRZC5M70gu5SW/Y/SLPq3D1wiXGZoHC6HJ7ESVE2lw==",
+      "version": "12.7.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.7.0.tgz",
+      "integrity": "sha512-7rq+nmhzz0u6yabCFyPtADU2OOrYt6pvUau9qV7xyifJ/hnsaw/vkr0tnLlcuuQKUAOC1v1M1e4Z0zG7S0IAvA==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -2228,9 +2228,9 @@
       }
     },
     "cypress": {
-      "version": "12.6.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.6.0.tgz",
-      "integrity": "sha512-WdHSVaS1lumSd5XpVTslZd8ui9GIGphrzvXq9+3DtVhqjRZC5M70gu5SW/Y/SLPq3D1wiXGZoHC6HJ7ESVE2lw==",
+      "version": "12.7.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.7.0.tgz",
+      "integrity": "sha512-7rq+nmhzz0u6yabCFyPtADU2OOrYt6pvUau9qV7xyifJ/hnsaw/vkr0tnLlcuuQKUAOC1v1M1e4Z0zG7S0IAvA==",
       "dev": true,
       "requires": {
         "@cypress/request": "^2.88.10",

--- a/examples/chrome/package.json
+++ b/examples/chrome/package.json
@@ -11,7 +11,7 @@
   "license": "ISC",
   "private": true,
   "devDependencies": {
-    "cypress": "12.6.0",
+    "cypress": "12.7.0",
     "image-size": "0.8.3"
   }
 }

--- a/examples/component-tests/package-lock.json
+++ b/examples/component-tests/package-lock.json
@@ -15,7 +15,7 @@
         "@types/react": "^18.0.26",
         "@types/react-dom": "^18.0.9",
         "@vitejs/plugin-react": "^3.0.0",
-        "cypress": "12.6.0",
+        "cypress": "12.7.0",
         "vite": "^4.0.0"
       }
     },
@@ -1393,9 +1393,9 @@
       "dev": true
     },
     "node_modules/cypress": {
-      "version": "12.6.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.6.0.tgz",
-      "integrity": "sha512-WdHSVaS1lumSd5XpVTslZd8ui9GIGphrzvXq9+3DtVhqjRZC5M70gu5SW/Y/SLPq3D1wiXGZoHC6HJ7ESVE2lw==",
+      "version": "12.7.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.7.0.tgz",
+      "integrity": "sha512-7rq+nmhzz0u6yabCFyPtADU2OOrYt6pvUau9qV7xyifJ/hnsaw/vkr0tnLlcuuQKUAOC1v1M1e4Z0zG7S0IAvA==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -4333,9 +4333,9 @@
       "dev": true
     },
     "cypress": {
-      "version": "12.6.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.6.0.tgz",
-      "integrity": "sha512-WdHSVaS1lumSd5XpVTslZd8ui9GIGphrzvXq9+3DtVhqjRZC5M70gu5SW/Y/SLPq3D1wiXGZoHC6HJ7ESVE2lw==",
+      "version": "12.7.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.7.0.tgz",
+      "integrity": "sha512-7rq+nmhzz0u6yabCFyPtADU2OOrYt6pvUau9qV7xyifJ/hnsaw/vkr0tnLlcuuQKUAOC1v1M1e4Z0zG7S0IAvA==",
       "dev": true,
       "requires": {
         "@cypress/request": "^2.88.10",

--- a/examples/component-tests/package.json
+++ b/examples/component-tests/package.json
@@ -17,7 +17,7 @@
     "@types/react": "^18.0.26",
     "@types/react-dom": "^18.0.9",
     "@vitejs/plugin-react": "^3.0.0",
-    "cypress": "12.6.0",
+    "cypress": "12.7.0",
     "vite": "^4.0.0"
   }
 }

--- a/examples/config/package-lock.json
+++ b/examples/config/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {
-        "cypress": "12.6.0",
+        "cypress": "12.7.0",
         "serve": "^14.2.0",
         "start-server-and-test": "1.11.5"
       }
@@ -922,9 +922,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "12.6.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.6.0.tgz",
-      "integrity": "sha512-WdHSVaS1lumSd5XpVTslZd8ui9GIGphrzvXq9+3DtVhqjRZC5M70gu5SW/Y/SLPq3D1wiXGZoHC6HJ7ESVE2lw==",
+      "version": "12.7.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.7.0.tgz",
+      "integrity": "sha512-7rq+nmhzz0u6yabCFyPtADU2OOrYt6pvUau9qV7xyifJ/hnsaw/vkr0tnLlcuuQKUAOC1v1M1e4Z0zG7S0IAvA==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -3443,9 +3443,9 @@
       }
     },
     "cypress": {
-      "version": "12.6.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.6.0.tgz",
-      "integrity": "sha512-WdHSVaS1lumSd5XpVTslZd8ui9GIGphrzvXq9+3DtVhqjRZC5M70gu5SW/Y/SLPq3D1wiXGZoHC6HJ7ESVE2lw==",
+      "version": "12.7.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.7.0.tgz",
+      "integrity": "sha512-7rq+nmhzz0u6yabCFyPtADU2OOrYt6pvUau9qV7xyifJ/hnsaw/vkr0tnLlcuuQKUAOC1v1M1e4Z0zG7S0IAvA==",
       "dev": true,
       "requires": {
         "@cypress/request": "^2.88.10",

--- a/examples/config/package.json
+++ b/examples/config/package.json
@@ -14,7 +14,7 @@
   "license": "ISC",
   "private": true,
   "devDependencies": {
-    "cypress": "12.6.0",
+    "cypress": "12.7.0",
     "serve": "^14.2.0",
     "start-server-and-test": "1.11.5"
   }

--- a/examples/custom-command/package-lock.json
+++ b/examples/custom-command/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {
-        "cypress": "12.6.0",
+        "cypress": "12.7.0",
         "lodash": "4.17.15"
       }
     },
@@ -525,9 +525,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "12.6.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.6.0.tgz",
-      "integrity": "sha512-WdHSVaS1lumSd5XpVTslZd8ui9GIGphrzvXq9+3DtVhqjRZC5M70gu5SW/Y/SLPq3D1wiXGZoHC6HJ7ESVE2lw==",
+      "version": "12.7.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.7.0.tgz",
+      "integrity": "sha512-7rq+nmhzz0u6yabCFyPtADU2OOrYt6pvUau9qV7xyifJ/hnsaw/vkr0tnLlcuuQKUAOC1v1M1e4Z0zG7S0IAvA==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -2210,9 +2210,9 @@
       }
     },
     "cypress": {
-      "version": "12.6.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.6.0.tgz",
-      "integrity": "sha512-WdHSVaS1lumSd5XpVTslZd8ui9GIGphrzvXq9+3DtVhqjRZC5M70gu5SW/Y/SLPq3D1wiXGZoHC6HJ7ESVE2lw==",
+      "version": "12.7.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.7.0.tgz",
+      "integrity": "sha512-7rq+nmhzz0u6yabCFyPtADU2OOrYt6pvUau9qV7xyifJ/hnsaw/vkr0tnLlcuuQKUAOC1v1M1e4Z0zG7S0IAvA==",
       "dev": true,
       "requires": {
         "@cypress/request": "^2.88.10",

--- a/examples/custom-command/package.json
+++ b/examples/custom-command/package.json
@@ -11,7 +11,7 @@
   "license": "ISC",
   "private": true,
   "devDependencies": {
-    "cypress": "12.6.0",
+    "cypress": "12.7.0",
     "lodash": "4.17.15"
   }
 }

--- a/examples/env/package-lock.json
+++ b/examples/env/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {
-        "cypress": "12.6.0"
+        "cypress": "12.7.0"
       }
     },
     "node_modules/@cypress/request": {
@@ -512,9 +512,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "12.6.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.6.0.tgz",
-      "integrity": "sha512-WdHSVaS1lumSd5XpVTslZd8ui9GIGphrzvXq9+3DtVhqjRZC5M70gu5SW/Y/SLPq3D1wiXGZoHC6HJ7ESVE2lw==",
+      "version": "12.7.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.7.0.tgz",
+      "integrity": "sha512-7rq+nmhzz0u6yabCFyPtADU2OOrYt6pvUau9qV7xyifJ/hnsaw/vkr0tnLlcuuQKUAOC1v1M1e4Z0zG7S0IAvA==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -2173,9 +2173,9 @@
       }
     },
     "cypress": {
-      "version": "12.6.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.6.0.tgz",
-      "integrity": "sha512-WdHSVaS1lumSd5XpVTslZd8ui9GIGphrzvXq9+3DtVhqjRZC5M70gu5SW/Y/SLPq3D1wiXGZoHC6HJ7ESVE2lw==",
+      "version": "12.7.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.7.0.tgz",
+      "integrity": "sha512-7rq+nmhzz0u6yabCFyPtADU2OOrYt6pvUau9qV7xyifJ/hnsaw/vkr0tnLlcuuQKUAOC1v1M1e4Z0zG7S0IAvA==",
       "dev": true,
       "requires": {
         "@cypress/request": "^2.88.10",

--- a/examples/env/package.json
+++ b/examples/env/package.json
@@ -10,6 +10,6 @@
   "license": "ISC",
   "private": true,
   "devDependencies": {
-    "cypress": "12.6.0"
+    "cypress": "12.7.0"
   }
 }

--- a/examples/firefox/package-lock.json
+++ b/examples/firefox/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {
-        "cypress": "12.6.0",
+        "cypress": "12.7.0",
         "image-size": "0.8.3"
       }
     },
@@ -512,9 +512,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "12.6.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.6.0.tgz",
-      "integrity": "sha512-WdHSVaS1lumSd5XpVTslZd8ui9GIGphrzvXq9+3DtVhqjRZC5M70gu5SW/Y/SLPq3D1wiXGZoHC6HJ7ESVE2lw==",
+      "version": "12.7.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.7.0.tgz",
+      "integrity": "sha512-7rq+nmhzz0u6yabCFyPtADU2OOrYt6pvUau9qV7xyifJ/hnsaw/vkr0tnLlcuuQKUAOC1v1M1e4Z0zG7S0IAvA==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -2197,9 +2197,9 @@
       }
     },
     "cypress": {
-      "version": "12.6.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.6.0.tgz",
-      "integrity": "sha512-WdHSVaS1lumSd5XpVTslZd8ui9GIGphrzvXq9+3DtVhqjRZC5M70gu5SW/Y/SLPq3D1wiXGZoHC6HJ7ESVE2lw==",
+      "version": "12.7.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.7.0.tgz",
+      "integrity": "sha512-7rq+nmhzz0u6yabCFyPtADU2OOrYt6pvUau9qV7xyifJ/hnsaw/vkr0tnLlcuuQKUAOC1v1M1e4Z0zG7S0IAvA==",
       "dev": true,
       "requires": {
         "@cypress/request": "^2.88.10",

--- a/examples/firefox/package.json
+++ b/examples/firefox/package.json
@@ -10,7 +10,7 @@
   "license": "ISC",
   "private": true,
   "devDependencies": {
-    "cypress": "12.6.0",
+    "cypress": "12.7.0",
     "image-size": "0.8.3"
   }
 }

--- a/examples/install-command/package.json
+++ b/examples/install-command/package.json
@@ -9,7 +9,7 @@
   "license": "MIT",
   "private": true,
   "devDependencies": {
-    "cypress": "12.6.0"
+    "cypress": "12.7.0"
   },
   "dependencies": {
     "arg": "5.0.0",

--- a/examples/install-command/yarn.lock
+++ b/examples/install-command/yarn.lock
@@ -308,10 +308,10 @@ cross-spawn@^7.0.0:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
-cypress@12.6.0:
-  version "12.6.0"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-12.6.0.tgz#d71a82639756173c0682b3d467eb9f0523460e91"
-  integrity sha512-WdHSVaS1lumSd5XpVTslZd8ui9GIGphrzvXq9+3DtVhqjRZC5M70gu5SW/Y/SLPq3D1wiXGZoHC6HJ7ESVE2lw==
+cypress@12.7.0:
+  version "12.7.0"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-12.7.0.tgz#69900f82af76cf3ba0ddb9b59ec3b0d38222ab22"
+  integrity sha512-7rq+nmhzz0u6yabCFyPtADU2OOrYt6pvUau9qV7xyifJ/hnsaw/vkr0tnLlcuuQKUAOC1v1M1e4Z0zG7S0IAvA==
   dependencies:
     "@cypress/request" "^2.88.10"
     "@cypress/xvfb" "^1.2.4"

--- a/examples/install-only/package-lock.json
+++ b/examples/install-only/package-lock.json
@@ -13,7 +13,7 @@
         "debug": "4.2.0"
       },
       "devDependencies": {
-        "cypress": "12.6.0"
+        "cypress": "12.7.0"
       }
     },
     "node_modules/@cypress/request": {
@@ -520,9 +520,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "12.6.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.6.0.tgz",
-      "integrity": "sha512-WdHSVaS1lumSd5XpVTslZd8ui9GIGphrzvXq9+3DtVhqjRZC5M70gu5SW/Y/SLPq3D1wiXGZoHC6HJ7ESVE2lw==",
+      "version": "12.7.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.7.0.tgz",
+      "integrity": "sha512-7rq+nmhzz0u6yabCFyPtADU2OOrYt6pvUau9qV7xyifJ/hnsaw/vkr0tnLlcuuQKUAOC1v1M1e4Z0zG7S0IAvA==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -2202,9 +2202,9 @@
       }
     },
     "cypress": {
-      "version": "12.6.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.6.0.tgz",
-      "integrity": "sha512-WdHSVaS1lumSd5XpVTslZd8ui9GIGphrzvXq9+3DtVhqjRZC5M70gu5SW/Y/SLPq3D1wiXGZoHC6HJ7ESVE2lw==",
+      "version": "12.7.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.7.0.tgz",
+      "integrity": "sha512-7rq+nmhzz0u6yabCFyPtADU2OOrYt6pvUau9qV7xyifJ/hnsaw/vkr0tnLlcuuQKUAOC1v1M1e4Z0zG7S0IAvA==",
       "dev": true,
       "requires": {
         "@cypress/request": "^2.88.10",

--- a/examples/install-only/package.json
+++ b/examples/install-only/package.json
@@ -9,7 +9,7 @@
   "license": "MIT",
   "private": true,
   "devDependencies": {
-    "cypress": "12.6.0"
+    "cypress": "12.7.0"
   },
   "dependencies": {
     "arg": "5.0.0",

--- a/examples/node-versions/package-lock.json
+++ b/examples/node-versions/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {
-        "cypress": "12.6.0"
+        "cypress": "12.7.0"
       }
     },
     "node_modules/@cypress/request": {
@@ -524,9 +524,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "12.6.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.6.0.tgz",
-      "integrity": "sha512-WdHSVaS1lumSd5XpVTslZd8ui9GIGphrzvXq9+3DtVhqjRZC5M70gu5SW/Y/SLPq3D1wiXGZoHC6HJ7ESVE2lw==",
+      "version": "12.7.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.7.0.tgz",
+      "integrity": "sha512-7rq+nmhzz0u6yabCFyPtADU2OOrYt6pvUau9qV7xyifJ/hnsaw/vkr0tnLlcuuQKUAOC1v1M1e4Z0zG7S0IAvA==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -2203,9 +2203,9 @@
       }
     },
     "cypress": {
-      "version": "12.6.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.6.0.tgz",
-      "integrity": "sha512-WdHSVaS1lumSd5XpVTslZd8ui9GIGphrzvXq9+3DtVhqjRZC5M70gu5SW/Y/SLPq3D1wiXGZoHC6HJ7ESVE2lw==",
+      "version": "12.7.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.7.0.tgz",
+      "integrity": "sha512-7rq+nmhzz0u6yabCFyPtADU2OOrYt6pvUau9qV7xyifJ/hnsaw/vkr0tnLlcuuQKUAOC1v1M1e4Z0zG7S0IAvA==",
       "dev": true,
       "requires": {
         "@cypress/request": "^2.88.10",

--- a/examples/node-versions/package.json
+++ b/examples/node-versions/package.json
@@ -10,6 +10,6 @@
   "license": "ISC",
   "private": true,
   "devDependencies": {
-    "cypress": "12.6.0"
+    "cypress": "12.7.0"
   }
 }

--- a/examples/quiet/package-lock.json
+++ b/examples/quiet/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {
-        "cypress": "12.6.0",
+        "cypress": "12.7.0",
         "image-size": "0.8.3"
       }
     },
@@ -525,9 +525,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "12.6.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.6.0.tgz",
-      "integrity": "sha512-WdHSVaS1lumSd5XpVTslZd8ui9GIGphrzvXq9+3DtVhqjRZC5M70gu5SW/Y/SLPq3D1wiXGZoHC6HJ7ESVE2lw==",
+      "version": "12.7.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.7.0.tgz",
+      "integrity": "sha512-7rq+nmhzz0u6yabCFyPtADU2OOrYt6pvUau9qV7xyifJ/hnsaw/vkr0tnLlcuuQKUAOC1v1M1e4Z0zG7S0IAvA==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -2228,9 +2228,9 @@
       }
     },
     "cypress": {
-      "version": "12.6.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.6.0.tgz",
-      "integrity": "sha512-WdHSVaS1lumSd5XpVTslZd8ui9GIGphrzvXq9+3DtVhqjRZC5M70gu5SW/Y/SLPq3D1wiXGZoHC6HJ7ESVE2lw==",
+      "version": "12.7.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.7.0.tgz",
+      "integrity": "sha512-7rq+nmhzz0u6yabCFyPtADU2OOrYt6pvUau9qV7xyifJ/hnsaw/vkr0tnLlcuuQKUAOC1v1M1e4Z0zG7S0IAvA==",
       "dev": true,
       "requires": {
         "@cypress/request": "^2.88.10",

--- a/examples/quiet/package.json
+++ b/examples/quiet/package.json
@@ -11,7 +11,7 @@
   "license": "ISC",
   "private": true,
   "devDependencies": {
-    "cypress": "12.6.0",
+    "cypress": "12.7.0",
     "image-size": "0.8.3"
   }
 }

--- a/examples/react-scripts/package-lock.json
+++ b/examples/react-scripts/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {
-        "cypress": "12.6.0",
+        "cypress": "12.7.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-scripts": "^5.0.1"
@@ -6289,9 +6289,9 @@
       "dev": true
     },
     "node_modules/cypress": {
-      "version": "12.6.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.6.0.tgz",
-      "integrity": "sha512-WdHSVaS1lumSd5XpVTslZd8ui9GIGphrzvXq9+3DtVhqjRZC5M70gu5SW/Y/SLPq3D1wiXGZoHC6HJ7ESVE2lw==",
+      "version": "12.7.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.7.0.tgz",
+      "integrity": "sha512-7rq+nmhzz0u6yabCFyPtADU2OOrYt6pvUau9qV7xyifJ/hnsaw/vkr0tnLlcuuQKUAOC1v1M1e4Z0zG7S0IAvA==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -21930,9 +21930,9 @@
       }
     },
     "cypress": {
-      "version": "12.6.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.6.0.tgz",
-      "integrity": "sha512-WdHSVaS1lumSd5XpVTslZd8ui9GIGphrzvXq9+3DtVhqjRZC5M70gu5SW/Y/SLPq3D1wiXGZoHC6HJ7ESVE2lw==",
+      "version": "12.7.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.7.0.tgz",
+      "integrity": "sha512-7rq+nmhzz0u6yabCFyPtADU2OOrYt6pvUau9qV7xyifJ/hnsaw/vkr0tnLlcuuQKUAOC1v1M1e4Z0zG7S0IAvA==",
       "dev": true,
       "requires": {
         "@cypress/request": "^2.88.10",

--- a/examples/react-scripts/package.json
+++ b/examples/react-scripts/package.json
@@ -9,7 +9,7 @@
   "license": "ISC",
   "private": true,
   "devDependencies": {
-    "cypress": "12.6.0",
+    "cypress": "12.7.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-scripts": "^5.0.1"

--- a/examples/recording/package-lock.json
+++ b/examples/recording/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {
-        "cypress": "12.6.0"
+        "cypress": "12.7.0"
       }
     },
     "node_modules/@cypress/request": {
@@ -511,9 +511,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "12.6.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.6.0.tgz",
-      "integrity": "sha512-WdHSVaS1lumSd5XpVTslZd8ui9GIGphrzvXq9+3DtVhqjRZC5M70gu5SW/Y/SLPq3D1wiXGZoHC6HJ7ESVE2lw==",
+      "version": "12.7.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.7.0.tgz",
+      "integrity": "sha512-7rq+nmhzz0u6yabCFyPtADU2OOrYt6pvUau9qV7xyifJ/hnsaw/vkr0tnLlcuuQKUAOC1v1M1e4Z0zG7S0IAvA==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -2194,9 +2194,9 @@
       }
     },
     "cypress": {
-      "version": "12.6.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.6.0.tgz",
-      "integrity": "sha512-WdHSVaS1lumSd5XpVTslZd8ui9GIGphrzvXq9+3DtVhqjRZC5M70gu5SW/Y/SLPq3D1wiXGZoHC6HJ7ESVE2lw==",
+      "version": "12.7.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.7.0.tgz",
+      "integrity": "sha512-7rq+nmhzz0u6yabCFyPtADU2OOrYt6pvUau9qV7xyifJ/hnsaw/vkr0tnLlcuuQKUAOC1v1M1e4Z0zG7S0IAvA==",
       "dev": true,
       "requires": {
         "@cypress/request": "^2.88.10",

--- a/examples/recording/package.json
+++ b/examples/recording/package.json
@@ -11,6 +11,6 @@
   "license": "ISC",
   "private": true,
   "devDependencies": {
-    "cypress": "12.6.0"
+    "cypress": "12.7.0"
   }
 }

--- a/examples/start-and-yarn-workspaces/workspace-1/package.json
+++ b/examples/start-and-yarn-workspaces/workspace-1/package.json
@@ -12,7 +12,7 @@
   "license": "ISC",
   "private": true,
   "devDependencies": {
-    "cypress": "12.6.0",
+    "cypress": "12.7.0",
     "serve": "^14.2.0"
   }
 }

--- a/examples/start-and-yarn-workspaces/workspace-2/package.json
+++ b/examples/start-and-yarn-workspaces/workspace-2/package.json
@@ -12,7 +12,7 @@
   "license": "ISC",
   "private": true,
   "devDependencies": {
-    "cypress": "12.6.0",
+    "cypress": "12.7.0",
     "serve": "^14.2.0"
   }
 }

--- a/examples/start-and-yarn-workspaces/yarn.lock
+++ b/examples/start-and-yarn-workspaces/yarn.lock
@@ -436,10 +436,10 @@ cross-spawn@^7.0.0, cross-spawn@^7.0.3:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
-cypress@12.6.0:
-  version "12.6.0"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-12.6.0.tgz#d71a82639756173c0682b3d467eb9f0523460e91"
-  integrity sha512-WdHSVaS1lumSd5XpVTslZd8ui9GIGphrzvXq9+3DtVhqjRZC5M70gu5SW/Y/SLPq3D1wiXGZoHC6HJ7ESVE2lw==
+cypress@12.7.0:
+  version "12.7.0"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-12.7.0.tgz#69900f82af76cf3ba0ddb9b59ec3b0d38222ab22"
+  integrity sha512-7rq+nmhzz0u6yabCFyPtADU2OOrYt6pvUau9qV7xyifJ/hnsaw/vkr0tnLlcuuQKUAOC1v1M1e4Z0zG7S0IAvA==
   dependencies:
     "@cypress/request" "^2.88.10"
     "@cypress/xvfb" "^1.2.4"

--- a/examples/start/package-lock.json
+++ b/examples/start/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {
-        "cypress": "12.6.0",
+        "cypress": "12.7.0",
         "serve": "^14.2.0"
       }
     },
@@ -871,9 +871,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "12.6.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.6.0.tgz",
-      "integrity": "sha512-WdHSVaS1lumSd5XpVTslZd8ui9GIGphrzvXq9+3DtVhqjRZC5M70gu5SW/Y/SLPq3D1wiXGZoHC6HJ7ESVE2lw==",
+      "version": "12.7.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.7.0.tgz",
+      "integrity": "sha512-7rq+nmhzz0u6yabCFyPtADU2OOrYt6pvUau9qV7xyifJ/hnsaw/vkr0tnLlcuuQKUAOC1v1M1e4Z0zG7S0IAvA==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -3129,9 +3129,9 @@
       }
     },
     "cypress": {
-      "version": "12.6.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.6.0.tgz",
-      "integrity": "sha512-WdHSVaS1lumSd5XpVTslZd8ui9GIGphrzvXq9+3DtVhqjRZC5M70gu5SW/Y/SLPq3D1wiXGZoHC6HJ7ESVE2lw==",
+      "version": "12.7.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.7.0.tgz",
+      "integrity": "sha512-7rq+nmhzz0u6yabCFyPtADU2OOrYt6pvUau9qV7xyifJ/hnsaw/vkr0tnLlcuuQKUAOC1v1M1e4Z0zG7S0IAvA==",
       "dev": true,
       "requires": {
         "@cypress/request": "^2.88.10",

--- a/examples/start/package.json
+++ b/examples/start/package.json
@@ -13,7 +13,7 @@
   "license": "ISC",
   "private": true,
   "devDependencies": {
-    "cypress": "12.6.0",
+    "cypress": "12.7.0",
     "serve": "^14.2.0"
   }
 }

--- a/examples/wait-on-vite/package-lock.json
+++ b/examples/wait-on-vite/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.0.0",
       "license": "ISC",
       "devDependencies": {
-        "cypress": "12.6.0",
+        "cypress": "12.7.0",
         "vite": "^4.0.0"
       }
     },
@@ -858,9 +858,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "12.6.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.6.0.tgz",
-      "integrity": "sha512-WdHSVaS1lumSd5XpVTslZd8ui9GIGphrzvXq9+3DtVhqjRZC5M70gu5SW/Y/SLPq3D1wiXGZoHC6HJ7ESVE2lw==",
+      "version": "12.7.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.7.0.tgz",
+      "integrity": "sha512-7rq+nmhzz0u6yabCFyPtADU2OOrYt6pvUau9qV7xyifJ/hnsaw/vkr0tnLlcuuQKUAOC1v1M1e4Z0zG7S0IAvA==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -2911,9 +2911,9 @@
       }
     },
     "cypress": {
-      "version": "12.6.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.6.0.tgz",
-      "integrity": "sha512-WdHSVaS1lumSd5XpVTslZd8ui9GIGphrzvXq9+3DtVhqjRZC5M70gu5SW/Y/SLPq3D1wiXGZoHC6HJ7ESVE2lw==",
+      "version": "12.7.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.7.0.tgz",
+      "integrity": "sha512-7rq+nmhzz0u6yabCFyPtADU2OOrYt6pvUau9qV7xyifJ/hnsaw/vkr0tnLlcuuQKUAOC1v1M1e4Z0zG7S0IAvA==",
       "dev": true,
       "requires": {
         "@cypress/request": "^2.88.10",

--- a/examples/wait-on-vite/package.json
+++ b/examples/wait-on-vite/package.json
@@ -12,7 +12,7 @@
   "license": "ISC",
   "private": true,
   "devDependencies": {
-    "cypress": "12.6.0",
+    "cypress": "12.7.0",
     "vite": "^4.0.0"
   }
 }

--- a/examples/wait-on/package-lock.json
+++ b/examples/wait-on/package-lock.json
@@ -13,7 +13,7 @@
         "debug": "4.2.0"
       },
       "devDependencies": {
-        "cypress": "12.6.0"
+        "cypress": "12.7.0"
       }
     },
     "node_modules/@cypress/request": {
@@ -520,9 +520,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "12.6.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.6.0.tgz",
-      "integrity": "sha512-WdHSVaS1lumSd5XpVTslZd8ui9GIGphrzvXq9+3DtVhqjRZC5M70gu5SW/Y/SLPq3D1wiXGZoHC6HJ7ESVE2lw==",
+      "version": "12.7.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.7.0.tgz",
+      "integrity": "sha512-7rq+nmhzz0u6yabCFyPtADU2OOrYt6pvUau9qV7xyifJ/hnsaw/vkr0tnLlcuuQKUAOC1v1M1e4Z0zG7S0IAvA==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -2218,9 +2218,9 @@
       }
     },
     "cypress": {
-      "version": "12.6.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.6.0.tgz",
-      "integrity": "sha512-WdHSVaS1lumSd5XpVTslZd8ui9GIGphrzvXq9+3DtVhqjRZC5M70gu5SW/Y/SLPq3D1wiXGZoHC6HJ7ESVE2lw==",
+      "version": "12.7.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.7.0.tgz",
+      "integrity": "sha512-7rq+nmhzz0u6yabCFyPtADU2OOrYt6pvUau9qV7xyifJ/hnsaw/vkr0tnLlcuuQKUAOC1v1M1e4Z0zG7S0IAvA==",
       "dev": true,
       "requires": {
         "@cypress/request": "^2.88.10",

--- a/examples/wait-on/package.json
+++ b/examples/wait-on/package.json
@@ -18,7 +18,7 @@
   "license": "ISC",
   "private": true,
   "devDependencies": {
-    "cypress": "12.6.0"
+    "cypress": "12.7.0"
   },
   "dependencies": {
     "arg": "5.0.0",

--- a/examples/webpack/package-lock.json
+++ b/examples/webpack/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {
-        "cypress": "12.6.0",
+        "cypress": "12.7.0",
         "webpack": "^5.75.0",
         "webpack-cli": "^5.0.1",
         "webpack-dev-server": "^4.11.1"
@@ -1466,9 +1466,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "12.6.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.6.0.tgz",
-      "integrity": "sha512-WdHSVaS1lumSd5XpVTslZd8ui9GIGphrzvXq9+3DtVhqjRZC5M70gu5SW/Y/SLPq3D1wiXGZoHC6HJ7ESVE2lw==",
+      "version": "12.7.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.7.0.tgz",
+      "integrity": "sha512-7rq+nmhzz0u6yabCFyPtADU2OOrYt6pvUau9qV7xyifJ/hnsaw/vkr0tnLlcuuQKUAOC1v1M1e4Z0zG7S0IAvA==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -6351,9 +6351,9 @@
       }
     },
     "cypress": {
-      "version": "12.6.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.6.0.tgz",
-      "integrity": "sha512-WdHSVaS1lumSd5XpVTslZd8ui9GIGphrzvXq9+3DtVhqjRZC5M70gu5SW/Y/SLPq3D1wiXGZoHC6HJ7ESVE2lw==",
+      "version": "12.7.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.7.0.tgz",
+      "integrity": "sha512-7rq+nmhzz0u6yabCFyPtADU2OOrYt6pvUau9qV7xyifJ/hnsaw/vkr0tnLlcuuQKUAOC1v1M1e4Z0zG7S0IAvA==",
       "dev": true,
       "requires": {
         "@cypress/request": "^2.88.10",

--- a/examples/webpack/package.json
+++ b/examples/webpack/package.json
@@ -9,7 +9,7 @@
   "license": "ISC",
   "private": true,
   "devDependencies": {
-    "cypress": "12.6.0",
+    "cypress": "12.7.0",
     "webpack": "^5.75.0",
     "webpack-cli": "^5.0.1",
     "webpack-dev-server": "^4.11.1"


### PR DESCRIPTION
This PR updates the Cypress 12.x [examples](https://github.com/cypress-io/github-action/tree/master/examples) to [Cypress 12.7.0](https://docs.cypress.io/guides/references/changelog#12-7-0) released Feb 24, 2023.

Versions are now exact for all examples.
Previously `basic-pnpm` was using semantic versioning `^12.6.0`. It now uses `12.7.0` like the other examples.

