### PR TITLE
docs: add  wait-on workaround advice (Node.js 18)

### DIFF
--- a/README.md
+++ b/README.md
@@ -737,6 +737,14 @@ See [example-wait-on.yml](.github/workflows/example-wait-on.yml) workflow file.
 
 If this action times out waiting for the server to respond, please see [Debugging](#debugging) section in this README file.
 
+#### `wait-on` with Node.js 18+
+
+Under Node.js version 18 and later, `wait-on` may fail to recognize that a `localhost` server is running. This affects development web servers which do not listen on both IPv4 and IPv6 network stacks.
+
+- Check your server documentation to see if it can be started using `0.0.0.0` (all addresses) and use this if available. If this option is not available or does not resolve the issue then carry on to the next steps:
+- If the action log shows that wait-on is failing to connect to `127.0.0.1`, replace `localhost` by `[::1]` (the IPv6 loopback address)
+- If the action log shows that wait-on is failing to connect to `::1`, replace `localhost` by `127.0.0.1` (the IPv4 loopback address)
+
 ### Custom install command
 
 If you want to overwrite the install command


### PR DESCRIPTION
This PR is related to https://github.com/cypress-io/github-action/issues/811 "wait-on issues with Node.js 18" and adds simple workaround advice to the README file for the situation where `wait-on` fails due to:

1. changes in dns resolution introduced in Node.js 17 (see History in [dns.lookup(hostname[, options], callback)](https://nodejs.org/dist/latest-v18.x/docs/api/dns.html#dnslookuphostname-options-callback) "The `verbatim` options defaults to `true` now.".)
2. some development servers failing to respond to the `localhost` address which GitHub has set up for both IPv4 `127.0.0.1` and IPv6 `::1` loopback addresses. Notably servers associated with react, only respond to either IPv4 or IPv6 addresses, but not both.

The text is also reviewable under https://github.com/MikeMcC399/github-action/blob/docs/wait-on-workaround/README.md#wait-on-with-nodejs-18.