### PR TITLE
docs: remove deprecated set-output from example

### DIFF
--- a/README.md
+++ b/README.md
@@ -836,7 +836,7 @@ jobs:
         # take the current commit + timestamp together
         # the typical value would be something like
         # "sha-5d3fe...35d3-time-1620841214"
-        run: echo "::set-output name=value::sha-$GITHUB_SHA-time-$(date +"%s")"
+        run: echo "value=sha-$GITHUB_SHA-time-$(date +"%s")" >> $GITHUB_OUTPUT
   smoke-tests:
     needs: ['prepare']
     steps:


### PR DESCRIPTION
This PR updates the README example [Robust custom build id](https://github.com/cypress-io/github-action#robust-custom-build-id) which contains code

`run: echo "::set-output name=value::sha-$GITHUB_SHA-time-$(date +"%s")"`

that GitHub has deprecated. [GitHub Actions: Deprecating save-state and set-output commands](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) states "We are monitoring telemetry for the usage of these commands and plan to fully disable them on 31st May 2023".

I already changed the workflow [example-custom-ci-build-id](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-custom-ci-build-id.yml) through PR https://github.com/cypress-io/github-action/pull/675 in December 2022 and at the time it was overlooked that the same problem was also contained in the corresponding text version of the example.

The replacement line of code is:

`echo "value=sha-$GITHUB_SHA-time-$(date +"%s")" >> $GITHUB_OUTPUT`

exactly as used in
https://github.com/cypress-io/github-action/blob/9e537519c800b1aba1f3d5596364f41d9a32bcd5/.github/workflows/example-custom-ci-build-id.yml#L36
