### PR TITLE
docs: add legacy notation to external examples using only Cypress 9 and below

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@
 - [run tests nightly](#nightly-tests) or on any schedule
 - [more examples](#more-examples)
 
+Current examples contained in this repository are based on Cypress 12.x and can be found in the [examples](./examples) directory. Examples for [Legacy Configuration](https://on.cypress.io/guides/references/legacy-configuration) use Cypress `9.7.0` and are kept in the [examples/v9](./examples/v9) directory.
+
+Some older **external** examples, linked to by this document, are based solely on Cypress 9 and below and therefore use a [Legacy Configuration](https://on.cypress.io/guides/references/legacy-configuration). These may need modification to be applied to Cypress 10 and later. Each of these external links is listed with a `(legacy)` notation.
+
 ### Basic
 
 ```yml
@@ -437,7 +441,7 @@ See [Auto Cancellation](https://docs.cypress.io/guides/cloud/smart-orchestration
 
 ### Artifacts
 
-If you don't record the test run on Cypress Cloud, you can still store generated videos and screenshots as CI artifacts. See [cypress-gh-action-example](https://github.com/bahmutov/cypress-gh-action-example) and the workflow example below
+If you don't record the test run on Cypress Cloud, you can still store generated videos and screenshots as CI artifacts. See [cypress-gh-action-example](https://github.com/bahmutov/cypress-gh-action-example) (legacy) and the workflow example below
 
 ```yml
 name: Artifacts
@@ -963,7 +967,7 @@ jobs:
           working-directory: e2e
 ```
 
-See [cypress-gh-action-subfolders](https://github.com/bahmutov/cypress-gh-action-subfolders) for example.
+See [cypress-gh-action-subfolders](https://github.com/bahmutov/cypress-gh-action-subfolders) (legacy) for example.
 
 ### Yarn workspaces
 
@@ -1082,7 +1086,7 @@ See [cypress-gh-action-monorepo](https://github.com/bahmutov/cypress-gh-action-m
 
 ### Custom install
 
-Finally, you might not need this GH Action at all. For example, if you want to split the NPM dependencies installation from the Cypress binary installation, then it makes no sense to use this action. Instead you can install and cache Cypress yourself. See [cypress-gh-action-split-install](https://github.com/bahmutov/cypress-gh-action-split-install) for working example.
+Finally, you might not need this GH Action at all. For example, if you want to split the NPM dependencies installation from the Cypress binary installation, then it makes no sense to use this action. Instead you can install and cache Cypress yourself. See [cypress-gh-action-split-install](https://github.com/bahmutov/cypress-gh-action-split-install) (legacy) for a working example.
 
 ### Install Cypress only
 
@@ -1124,23 +1128,23 @@ jobs:
         timeout-minutes: 5
 ```
 
-See [cypress-gh-action-example](https://github.com/bahmutov/cypress-gh-action-example)
+See [cypress-gh-action-example](https://github.com/bahmutov/cypress-gh-action-example) (legacy).
 
 ### More examples
 
 <!-- prettier-ignore-start -->
-Name | Description
---- | ---
-[cypress-gh-action-small-example](https://github.com/bahmutov/cypress-gh-action-small-example) | Runs tests and records them on Cypress Cloud
-[cypress-gh-action-example](https://github.com/bahmutov/cypress-gh-action-example) | uses Yarn, and runs in parallel on several versions of Node, different browsers, and more.
-[cypress-gh-action-monorepo](https://github.com/bahmutov/cypress-gh-action-monorepo) | splits install and running tests commands, runs Cypress from sub-folder
-[cypress-gh-action-subfolders](https://github.com/bahmutov/cypress-gh-action-subfolders) | separate folder for Cypress dependencies
-[cypress-gh-action-split-install](https://github.com/bahmutov/cypress-gh-action-split-install) | only install NPM dependencies, then install and cache Cypress binary yourself
-[test-personal-site](https://github.com/bahmutov/test-personal-site) | Testing an external website every night and by manually clicking a button.
-[cypress-gh-action-changed-files](https://github.com/bahmutov/cypress-gh-action-changed-files) | Shows how to run different Cypress projects depending on changed files
-[cypress-examples](https://github.com/bahmutov/cypress-examples) | Shows separate install job from parallel test jobs
-[cypress-gh-action-split-jobs](https://github.com/bahmutov/cypress-gh-action-split-jobs) | Shows a separate install job with the build step, and another job that runs the tests
-[cypress-react-component-example](https://github.com/bahmutov/cypress-react-component-example) | Run E2E and component tests using this action
+| Name                                                                                                    | Description                                                                               |
+| ------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| [cypress-gh-action-small-example](https://github.com/bahmutov/cypress-gh-action-small-example) (legacy) | Runs tests and records them on Cypress Cloud                                              |
+| [cypress-gh-action-example](https://github.com/bahmutov/cypress-gh-action-example)  (legacy)            | Uses Yarn, and runs in parallel on several versions of Node, different browsers, and more |
+| [cypress-gh-action-monorepo](https://github.com/bahmutov/cypress-gh-action-monorepo)                    | Splits install and running tests commands, runs Cypress from sub-folder                   |
+| [cypress-gh-action-subfolders](https://github.com/bahmutov/cypress-gh-action-subfolders) (legacy)       | Has separate folder for Cypress dependencies                                              |
+| [cypress-gh-action-split-install](https://github.com/bahmutov/cypress-gh-action-split-install) (legacy) | Only install NPM dependencies, then install and cache Cypress binary yourself             |
+| [test-personal-site](https://github.com/bahmutov/test-personal-site) (legacy)                           | Testing an external website every night and by manually clicking a button                 |
+| [cypress-gh-action-changed-files](https://github.com/bahmutov/cypress-gh-action-changed-files) (legacy) | Shows how to run different Cypress projects depending on changed files                    |
+| [cypress-examples](https://github.com/bahmutov/cypress-examples)                                        | Shows separate install job from parallel test jobs                                        |
+| [cypress-gh-action-split-jobs](https://github.com/bahmutov/cypress-gh-action-split-jobs) (legacy)       | Shows a separate install job with the build step, and another job that runs the tests     |
+| [cypress-react-component-example](https://github.com/bahmutov/cypress-react-component-example) (legacy) | Run E2E and component tests using this action                                             |
 <!-- prettier-ignore-end -->
 
 ## Notes
@@ -1256,7 +1260,7 @@ This GH Action sets an output `dashboardUrl` if the run was recorded on [Cypress
 
 ### Docker image
 
-If your repository does not have `package.json` or `yarn.json` (maybe it contains a static site and does not need any dependencies), you can run Cypress tests using `cypress/included:...` [Cypress Docker images](https://github.com/cypress-io/cypress-docker-images/tree/master/included). In that case you don't even need this GH Action, instead use the Docker container and write `cypress run` command like this example from [cypress-gh-action-included](https://github.com/bahmutov/cypress-gh-action-included)
+If your repository does not have `package.json` or `yarn.json` (maybe it contains a static site and does not need any dependencies), you can run Cypress tests using `cypress/included:...` [Cypress Docker images](https://github.com/cypress-io/cypress-docker-images/tree/master/included). In that case you don't even need this GH Action, instead use the Docker container and write `cypress run` command like this example from [cypress-gh-action-included](https://github.com/bahmutov/cypress-gh-action-included) (legacy)
 
 ```yml
 name: included


### PR DESCRIPTION
This PR adds a (legacy) note to links which reference external examples in the [README](https://github.com/cypress-io/github-action/blob/master/README.md) file and which only demonstrate a [Legacy Configuration](https://docs.cypress.io/guides/references/legacy-configuration) as used by Cypress 9 and below.

| README Section                                                                                 | Example                                                                                        | Cypress version   |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- | ----------------- |
| [Artifacts](https://github.com/cypress-io/github-action#artifacts)                             | [cypress-gh-action-example](https://github.com/bahmutov/cypress-gh-action-example)             | `7.7.0` (legacy)  |
| [Subfolders](https://github.com/cypress-io/github-action#subfolders)                           | [cypress-gh-action-subfolders](https://github.com/bahmutov/cypress-gh-action-subfolders)       | `9.7.0` (legacy)  |
| [Split install and tests](https://github.com/cypress-io/github-action#split-install-and-tests) | [cypress-gh-action-monorepo](https://github.com/bahmutov/cypress-gh-action-monorepo)           | `12.7.0`          |
| [Custom install](https://github.com/cypress-io/github-action#custom-install)                   | [cypress-gh-action-split-install](https://github.com/bahmutov/cypress-gh-action-split-install) | `3.8.3` (legacy)  |
| [Timeouts](https://github.com/cypress-io/github-action#timeouts)                               | [cypress-gh-action-example](https://github.com/bahmutov/cypress-gh-action-example)             | `7.7.0` (legacy)  |
| [Docker image](https://github.com/cypress-io/github-action#docker-image-1)                     | [cypress-gh-action-included](https://github.com/bahmutov/cypress-gh-action-included)           | `4.11.0` (legacy) |


Table from [More examples](https://github.com/cypress-io/github-action/blob/master/README.md#more-examples):

| Example                                                                                        | Cypress version  |
| ---------------------------------------------------------------------------------------------- | ---------------- |
| [cypress-gh-action-small-example](https://github.com/bahmutov/cypress-gh-action-small-example) | `7.2.0` (legacy) |
| [cypress-gh-action-example](https://github.com/bahmutov/cypress-gh-action-example)             | `7.7.0` (legacy) |
| [cypress-gh-action-monorepo](https://github.com/bahmutov/cypress-gh-action-monorepo)           | `12.7.0`         |
| [cypress-gh-action-subfolders](https://github.com/bahmutov/cypress-gh-action-subfolders)       | `9.7.0` (legacy) |
| [cypress-gh-action-split-install](https://github.com/bahmutov/cypress-gh-action-split-install) | `3.8.3` (legacy) |
| [test-personal-site](https://github.com/bahmutov/test-personal-site)                           | `6.4.0` (legacy) |
| [cypress-gh-action-changed-files](https://github.com/bahmutov/cypress-gh-action-changed-files) | `9.7.0` (legacy) |
| [cypress-examples](https://github.com/bahmutov/cypress-examples)                               | `12.7.0`         |
| [cypress-gh-action-split-jobs](https://github.com/bahmutov/cypress-gh-action-split-jobs)       | `9.7.0` (legacy) |
| [cypress-react-component-example](https://github.com/bahmutov/cypress-react-component-example) | `9.7.0` (legacy) |
