### PR TITLE
docs: remove external component test example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1145,7 +1145,6 @@ See [cypress-gh-action-example](https://github.com/bahmutov/cypress-gh-action-ex
 | [cypress-gh-action-changed-files](https://github.com/bahmutov/cypress-gh-action-changed-files) (legacy) | Shows how to run different Cypress projects depending on changed files                    |
 | [cypress-examples](https://github.com/bahmutov/cypress-examples)                                        | Shows separate install job from parallel test jobs                                        |
 | [cypress-gh-action-split-jobs](https://github.com/bahmutov/cypress-gh-action-split-jobs) (legacy)       | Shows a separate install job with the build step, and another job that runs the tests     |
-| [cypress-react-component-example](https://github.com/bahmutov/cypress-react-component-example) (legacy) | Run E2E and component tests using this action                                             |
 <!-- prettier-ignore-end -->
 
 ## Notes
@@ -1351,7 +1350,7 @@ See the [example-cron.yml](./.github/workflows/example-cron.yml) workflow.
 ### Suppress test summary
 
 The default test summary can be suppressed by using the parameter `publish-summary` and setting its value to `false`.
-Sometimes users want to publish test summary using a specific action. 
+Sometimes users want to publish test summary using a specific action.
 For example, a user running Cypress tests using a matrix and wants to retrieve the test summary for each matrix job and use a specific action that merges reports.
 
 ```yml


### PR DESCRIPTION
This PR removes the link to the external repo

https://github.com/bahmutov/cypress-react-component-example

from the [README: More examples](https://github.com/cypress-io/github-action#more-examples) table. The repository is out-of-date and even if it were updated it would duplicate [example-component-test.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-component-test.yml) in this repository.

This repository already contains a working example of component testing running under Cypress `12.7.0` - see workflow [example-component-test.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-component-test.yml) based on the project [component-tests](https://github.com/cypress-io/github-action/tree/master/examples/component-tests) which is built using the instructions from the Cypress documentation [React Quickstart](https://docs.cypress.io/guides/component-testing/react/quickstart).

The repository https://github.com/bahmutov/cypress-react-component-example is out of date.

1. It is based on using Cypress `9.7.0`, before Component Testing for Cypress was officially declared GA in [`11.0.0`](https://docs.cypress.io/guides/references/changelog#11-0-0).
2. The instructions for using component testing are now significantly different
    - the repository does not use the `component` parameter of the github-action
    - it calls component testing instead with `yarn cypress run-ct`
3. The repo is not compatible with Node.js 18 (LTS). The react-scripts will not build
