### PR TITLE
docs: remove test-personal-site from example list

### DIFF
--- a/README.md
+++ b/README.md
@@ -1141,7 +1141,6 @@ See [cypress-gh-action-example](https://github.com/bahmutov/cypress-gh-action-ex
 | [cypress-gh-action-monorepo](https://github.com/bahmutov/cypress-gh-action-monorepo)                    | Splits install and running tests commands, runs Cypress from sub-folder                   |
 | [cypress-gh-action-subfolders](https://github.com/bahmutov/cypress-gh-action-subfolders) (legacy)       | Has separate folder for Cypress dependencies                                              |
 | [cypress-gh-action-split-install](https://github.com/bahmutov/cypress-gh-action-split-install) (legacy) | Only install NPM dependencies, then install and cache Cypress binary yourself             |
-| [test-personal-site](https://github.com/bahmutov/test-personal-site) (legacy)                           | Testing an external website every night and by manually clicking a button                 |
 | [cypress-gh-action-changed-files](https://github.com/bahmutov/cypress-gh-action-changed-files) (legacy) | Shows how to run different Cypress projects depending on changed files                    |
 | [cypress-examples](https://github.com/bahmutov/cypress-examples)                                        | Shows separate install job from parallel test jobs                                        |
 | [cypress-gh-action-split-jobs](https://github.com/bahmutov/cypress-gh-action-split-jobs) (legacy)       | Shows a separate install job with the build step, and another job that runs the tests     |
@@ -1351,7 +1350,7 @@ See the [example-cron.yml](./.github/workflows/example-cron.yml) workflow.
 ### Suppress test summary
 
 The default test summary can be suppressed by using the parameter `publish-summary` and setting its value to `false`.
-Sometimes users want to publish test summary using a specific action. 
+Sometimes users want to publish test summary using a specific action.
 For example, a user running Cypress tests using a matrix and wants to retrieve the test summary for each matrix job and use a specific action that merges reports.
 
 ```yml


### PR DESCRIPTION
This PR resolves issue "Example test-personal-site outdated" by removing [test-personal-site](https://github.com/bahmutov/test-personal-site) from the [README: More examples](https://github.com/cypress-io/github-action/blob/master/README.md#more-examples) section.

Reasons:

1. The repo [test-personal-site](https://github.com/bahmutov/test-personal-site) uses outdated versions, for example `cypress-io/github-action@v2` (current version is `v5`) and Cypress `6.4.0` (current version is `12.7.0`).
2. A request to update was labeled with https://github.com/cypress-io/github-action/labels/wontfix and the owner wrote "... don't want to update this repo and its corresponding blog post".
3. The workflow in [test-personal-site](https://github.com/bahmutov/test-personal-site) duplicates internal [example workflows](https://github.com/cypress-io/github-action/tree/master/.github/workflows). The use of `cron` is specifically covered by [example-cron.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-cron.yml). All example workflows now include the event trigger `workflow_dispatch`.

So, in summary the repo is outdated, does not demonstrate anything which is not already demonstrated in existing internal examples, and there are no plans to enhance the repo to make it useful. Hence the proposal to remove it from the [More examples](https://github.com/cypress-io/github-action/blob/master/README.md#more-examples) table in the [README.md](https://github.com/cypress-io/github-action/blob/master/README.md) document.
