### PR TITLE
ci: skip triage workflows in fork

### DIFF
--- a/.github/workflows/add-issue-to-triage-board.yml
+++ b/.github/workflows/add-issue-to-triage-board.yml
@@ -8,5 +8,7 @@ on:
       - opened
 jobs:
   add-to-triage-project-board:
+    # skip in fork
+    if: github.repository == 'cypress-io/github-action'
     uses: cypress-io/cypress/.github/workflows/triage_add_to_project.yml@develop
     secrets: inherit

--- a/.github/workflows/triage_closed_issue_comment.yml
+++ b/.github/workflows/triage_closed_issue_comment.yml
@@ -5,5 +5,7 @@ on:
       - created
 jobs:
   closed-issue-comment:
+    # skip in fork
+    if: github.repository == 'cypress-io/github-action'
     uses: cypress-io/cypress/.github/workflows/triage_closed_issue_comment.yml@develop
     secrets: inherit


### PR DESCRIPTION
This PR disables the following workflows from running in a fork if they are triggered there:

- [add-issue-to-triage-board.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/add-issue-to-triage-board.yml)
- [triage_closed_issue_comment.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/triage_closed_issue_comment.yml)

The workflows are not intended for use in a fork. The activities there are not of interest for the triage board and if the workflows are triggered they fail due to lack of access to necessary secrets.

The following conditional is added so that the corresponding workflow is skipped if it is triggered in a fork:

```yml
    if: github.repository == 'cypress-io/github-action'
```

See [Example: Only run job for specific repository](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-only-run-job-for-specific-repository).

## Verification

1. Open a PR in a fork which targets a branch in the fork. Check that [add-issue-to-triage-board.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/add-issue-to-triage-board.yml) does not produce an error.
2. Create a comment for the previously created PR and check that [triage_closed_issue_comment.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/triage_closed_issue_comment.yml) does not produce an error.

## Workaround

Manually disable each workflow in fork. See [Disabling and enabling a workflow](https://docs.github.com/en/actions/managing-workflow-runs/disabling-and-enabling-a-workflow).
