### PR TITLE
build: improve update script error handling

### DIFF
--- a/docs/MAINTENANCE.md
+++ b/docs/MAINTENANCE.md
@@ -40,6 +40,12 @@ Again, this needs to be repeated if you change the base node version using nvm.
 
 - [Visual Studio Code](https://code.visualstudio.com/) or other editor
 
+Under Microsoft Windows it may be necessary to also execute the following preparatory command:
+
+```bash
+npm config set script-shell "C:\\Program Files\\git\\bin\\bash.exe" --location user
+```
+
 ## Updating examples
 
 When a new version of [Cypress](https://docs.cypress.io/guides/references/changelog) is published, the examples can be updated.

--- a/scripts/check-package-manager-npm.sh
+++ b/scripts/check-package-manager-npm.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# This script checks that the prerequisite
+# npm is installed
+
+if ! command -v npm &> /dev/null
+then
+    echo "**npm is required and not installed**"
+    echo "install Node.js LTS from:"
+    echo "https://nodejs.org/en/"
+    echo "or install and use nvm"
+    echo
+exit 1 # failure
+else
+    echo "npm is installed"
+fi

--- a/scripts/check-package-managers-other.sh
+++ b/scripts/check-package-managers-other.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# This script checks that the prerequisites
+# pnpm and yarn are installed
+
+pnpmInstalled=false
+if ! command -v pnpm &> /dev/null
+then
+    echo "**pnpm not installed**"
+    echo "execute the following command:"
+    echo "npm install pnpm -g"
+    echo
+else
+pnpmInstalled=true
+fi
+
+yarnInstalled=false
+if ! command -v yarn &> /dev/null
+then
+    echo "**yarn not installed**"
+    echo "execute the following command:"
+    echo "npm install yarn -g"
+    echo
+else
+yarnInstalled=true
+fi
+
+if $pnpmInstalled == true && $yarnInstalled == true
+then
+    echo "pnpm and yarn are installed"
+else
+exit 1 # failure
+fi

--- a/scripts/update-cypress-latest-npm.sh
+++ b/scripts/update-cypress-latest-npm.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e # fail on error
 #
 # All examples using npm technology are updated to
 # Cypress latest version

--- a/scripts/update-cypress-latest-other.sh
+++ b/scripts/update-cypress-latest-other.sh
@@ -1,8 +1,11 @@
 #!/bin/bash
+set -e # fail on error
 #
 # Examples using yarn and pnpm package managers are
 # updated to Cypress latest version
 #
+# Make sure that pnpm and yarn are installed
+./scripts/check-package-managers-other.sh
 
 echo updating yarn examples to Cypress latest version
 cd examples

--- a/scripts/update-cypress-latest.sh
+++ b/scripts/update-cypress-latest.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e # fail on error
 #
 # All examples are updated to Cypress latest version
 #
@@ -8,6 +9,11 @@
 # npm install pnpm -g
 # The VScode editor is also used in the last step if available.
 #
+# First check if the required package managers are installed
+./scripts/check-package-manager-npm.sh
+./scripts/check-package-managers-other.sh
+# then proceed to updating the examples
+echo
 ./scripts/update-cypress-latest-npm.sh
 ./scripts/update-cypress-latest-other.sh
 


### PR DESCRIPTION
This PR improves the error handling for the update scripts called by

```bash
npm run update:cypress
```

It was previously possible for them to fail silently, particularly if `pnpm` or `yarn` were not installed.  This situation can occur if `nvm` is used to manage `Node.js` versions, since global installations of `pnpm` and `yarn` are tied to a specific `Node.js` version and not carried over, for instance if `Node.js` is updated to the latest LTS version.

The scripts now check that the following commands are available:

- npm
- pnpm
- yarn

and advise installation if they are missing.

## Verification

On Ubuntu and Windows 11 Pro.

1. With no `npm` available (for instance by uninstalling `nvm`). `npm -v` should produce "command not found", execute

```bash
./scripts/update-cypress-latest.sh
```

and confirm output of message to install `Node.js` or `nvm`.

2. Install [Node.js LTS](https://nodejs.org/en/) (currently 18.5.0) either directly or via `nvm`.

On Windows execute

```bash
npm config set script-shell "C:\\Program Files\\git\\bin\\bash.exe" --location user
```

Execute

```bash
npm ci
npm run update:cypress
```

Confirm that the script informs that `npm` is installed, and that `pnpm` and `yarn` are not installed.

3. Follow the instructions to install `pnpm` and execute the script again.

Confirm that the script informs that `npm` is installed, and that `yarn` is not installed.

4. Follow the instructions to install `yarn` and execute the script again.

This time the script should run to completion and update all examples to use `cypress@12.8.0` (excepting those in the [examples/v9](https://github.com/cypress-io/github-action/tree/master/examples/v9) directory).
