### PR TITLE
ci: update to husky 8.0.3 and reactivate hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,12 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+echo action source code is being reformatted and recompiled
+npm run format
+npm run build
+if [ "$(git diff --ignore-space-at-eol dist/ | wc -l)" -gt "0" ]; then
+    echo
+    echo changes to action source code were detected
+    echo action source code changes are added to this commit
+    git add index.js src/ping.js dist
+fi

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
       "devDependencies": {
         "@types/node": "18.15.3",
         "@vercel/ncc": "0.36.1",
-        "husky": "7.0.4",
+        "husky": "8.0.3",
         "markdown-link-check": "3.11.0",
         "prettier": "2.8.4"
       }
@@ -996,15 +996,15 @@
       }
     },
     "node_modules/husky": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-7.0.4.tgz",
-      "integrity": "sha512-vbaCKN2QLtP/vD4yvs6iz6hBEo6wkSzs8HpRah1Z6aGmF2KW5PdYuAd7uX5a+OyBZHBhd+TFLqgjUgytQr4RvQ==",
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.3.tgz",
+      "integrity": "sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==",
       "dev": true,
       "bin": {
         "husky": "lib/bin.js"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=14"
       },
       "funding": {
         "url": "https://github.com/sponsors/typicode"
@@ -2335,9 +2335,9 @@
       }
     },
     "husky": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-7.0.4.tgz",
-      "integrity": "sha512-vbaCKN2QLtP/vD4yvs6iz6hBEo6wkSzs8HpRah1Z6aGmF2KW5PdYuAd7uX5a+OyBZHBhd+TFLqgjUgytQr4RvQ==",
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.3.tgz",
+      "integrity": "sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==",
       "dev": true
     },
     "iconv-lite": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "build": "ncc build -o dist index.js",
     "format": "prettier --write index.js src/ping.js",
     "check:markdown": "find *.md docs/*.md -print0 | xargs -0 -n1 markdown-link-check -c md-linkcheck.json",
-    "update:cypress": "./scripts/update-cypress-latest.sh"
+    "update:cypress": "./scripts/update-cypress-latest.sh",
+    "prepare": "husky install"
   },
   "repository": {
     "type": "git",
@@ -47,16 +48,11 @@
   "devDependencies": {
     "@types/node": "18.15.3",
     "@vercel/ncc": "0.36.1",
-    "husky": "7.0.4",
+    "husky": "8.0.3",
     "markdown-link-check": "3.11.0",
     "prettier": "2.8.4"
   },
   "publishConfig": {
     "access": "public"
-  },
-  "husky": {
-    "hooks": {
-      "pre-commit": "npm run format && npm run build && git add index.js dist"
-    }
   }
 }


### PR DESCRIPTION
This PR resolves https://github.com/cypress-io/github-action/issues/743 "Inactive git pre-commit Husky hook" by reactivating the [husky](https://www.npmjs.com/package/husky) hook.

It should also resolve an issue with Renovate. If dependencies which are used in the action are bumped by Renovate and they need to be compiled, Renovate does not know about this step and a PR it produces may be incomplete and fail the CI test [.github/workflows/check-dist.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/check-dist.yml).

## Changes

- [husky](https://www.npmjs.com/package/husky) is updated to the latest version [husky v8.0.3](https://github.com/typicode/husky/releases/tag/v8.0.3).
- The inactive hook `"pre-commit": "npm run format && npm run build && git add index.js dist"` is migrated to `.husky` for v8 usage.

The scripts

- `npm run format`
- `npm run build`

are executed to determine if changes to the core of the action located in

- `index.js`
- `dist/`

need to be committed.

When running on Ubuntu the following will be observed:

## Incomplete change made

If `index.js` was changed and the `format` and `build` scripts were not manually run, then a user would see the following as an example when committing through `git`. The following log output informs of the actions taken:

```text
changes to action source code were detected
action source code changes are added to this commit
```

The full log is as follows:

```text
git commit -a -m "demo change to index.js source"
action source code is being reformatted and rebuilt

> @cypress/github-action@0.0.0-development format
> prettier --write index.js

index.js 180ms

> @cypress/github-action@0.0.0-development build
> ncc build -o dist index.js

ncc: Version 0.36.1
ncc: Compiling file index.js into CJS
   1kB  dist/thread.js
2820kB  dist/index.js
2821kB  [2850ms] - ncc 0.36.1

changes to action source code were detected
action source code changes are added to this commit
[test/reactivate-husky 2a79b52] demo change to index.js source
 2 files changed, 2 insertions(+)
```

## Complete change made

If `index.js` was changed and the `format` and `build` scripts **were** manually run by the user, then they would see the following as an example when committing through `git`:

```text
git commit -a -m "demo change to index.js source"
action source code is being reformatted and rebuilt

> @cypress/github-action@0.0.0-development format
> prettier --write index.js

index.js 184ms

> @cypress/github-action@0.0.0-development build
> ncc build -o dist index.js

ncc: Version 0.36.1
ncc: Compiling file index.js into CJS
   1kB  dist/thread.js
2820kB  dist/index.js
2821kB  [2717ms] - ncc 0.36.1
[test/reactivate-husky 3576b0f] demo change to index.js source
 2 files changed, 2 insertions(+)
```

Similar output is shown also if files other than `index.js` are committed. The test is always done and the commit is only modified if necessary.

## Windows

When committing on Microsoft Windows there will be additional warnings from `git` such as
"warning: in the working copy of 'index.js', LF will be replaced by CRLF the next time Git touches it" if the user has modified `index.js` and has **not** previously manually executed `npm run format` and `npm run build`.

## Husky with GitHub Desktop on Windows

There have been multiple issues reported when attempting to use GitHub Desktop with Husky hooks enabled.

Workaround

Create an environment variable
Windows Settings > About > Advanced system settings > Environment Variables

```text
HUSKY=0
```

to disable Husky if you are using GitHub Desktop on Microsoft Windows. If you are modifying `index.js`, then reset the environment variable in a terminal window session `export HUSKY=""` and commit using `git commit` at the CLI level.
