### PR TITLE
docs: update dashboardurl section - not set if custom command used

### DIFF
--- a/README.md
+++ b/README.md
@@ -1299,7 +1299,9 @@ If you add `workflow_dispatch` event to your workflow, you will be able to start
 
 ### Outputs
 
-This GH Action sets an output `dashboardUrl` if the run was recorded on [Cypress Cloud](https://on.cypress.io/dashboard-introduction), see [action.yml](action.yml). To use this output:
+This action sets a GitHub step output `dashboardUrl` if the run was recorded on [Cypress Cloud](https://on.cypress.io/dashboard-introduction) using the action parameter setting `record: true` (see [Record test results on Cypress Cloud](#record-test-results-on-cypress-cloud)). Note that using a [Custom test command](#custom-test-command) with the `command` parameter overrides the `record` parameter and in this case no `dashboardUrl` step output is saved.
+
+This is an example of using the step output `dashboardUrl`:
 
 ```yml
 - name: Cypress tests
@@ -1308,7 +1310,7 @@ This GH Action sets an output `dashboardUrl` if the run was recorded on [Cypress
   # to its output values later
   id: cypress
   # Continue the build in case of an error, as we need to set the
-  # commit status in the next step, both in case of success and failure
+  # commit status in the next step, both in case of success or failure
   continue-on-error: true
   with:
     record: true
@@ -1322,7 +1324,7 @@ This GH Action sets an output `dashboardUrl` if the run was recorded on [Cypress
 
 [![recording example](https://github.com/cypress-io/github-action/workflows/example-recording/badge.svg?branch=master)](.github/workflows/example-recording.yml)
 
-**Note:** every GH workflow step can have `outcome` and `conclusion` properties. See the documentation at [steps context](https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#steps-context) page. In particular, the `output` value can be `success`, `failure`, `cancelled`, or `skipped` which you can use the next steps that follow.
+**Note:** every GitHub workflow step can have `outcome` and `conclusion` properties. See the GitHub [Contexts](https://docs.github.com/en/actions/learn-github-actions/contexts) documentation section [steps context](https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#steps-context). In particular, the `outcome` or `conclusion` value can be `success`, `failure`, `cancelled`, or `skipped` which you can use in any following steps.
 
 ### Docker image
 


### PR DESCRIPTION
This PR reworks the [README: Outputs](https://github.com/cypress-io/github-action/blob/master/README.md#outputs) section to state that the `dashboardUrl` is only set if the run was recorded using the action parameter `record: true`. It warns that this is not the case if a [Custom test command](#custom-test-command) with the `command` parameter is used, since this overrides the `record` parameter.

The custom command operates independently. See
https://github.com/cypress-io/github-action/blob/96268482322bc63c76561c602a84be842c527dbc/index.js#L665-L668

The regular call, which which would use the `record` parameter, is not invoked in this case
https://github.com/cypress-io/github-action/blob/96268482322bc63c76561c602a84be842c527dbc/index.js#L501-L505

- This partially resolves issue https://github.com/cypress-io/github-action/issues/511.