### PR TITLE
feat: user-friendly error if lock file missing

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -74454,18 +74454,29 @@ const packageLockFilename = path.join(
 )
 
 const useYarn = () => fs.existsSync(yarnFilename)
-
 const usePnpm = () => fs.existsSync(pnpmLockFilename)
+const useNpm = () => fs.existsSync(packageLockFilename)
 
 const lockHash = () => {
   const lockFilename = useYarn()
     ? yarnFilename
     : usePnpm()
     ? pnpmLockFilename
-    : packageLockFilename
+    : useNpm()
+    ? packageLockFilename
+    : noLockFile()
   const fileHash = hasha.fromFileSync(lockFilename)
   debug(`Hash from file ${lockFilename} is ${fileHash}`)
   return fileHash
+}
+
+const noLockFile = () => {
+  core.error(
+    `Action failed. Missing package manager lockfile. ` +
+      `Expecting one of package-lock.json (npm), pnpm-lock.yaml (pnpm) or yarn.lock (yarn) in working-directory ` +
+      workingDirectory
+  )
+  process.exit(1)
 }
 
 // enforce the same NPM cache folder across different operating systems

--- a/index.js
+++ b/index.js
@@ -103,18 +103,29 @@ const packageLockFilename = path.join(
 )
 
 const useYarn = () => fs.existsSync(yarnFilename)
-
 const usePnpm = () => fs.existsSync(pnpmLockFilename)
+const useNpm = () => fs.existsSync(packageLockFilename)
 
 const lockHash = () => {
   const lockFilename = useYarn()
     ? yarnFilename
     : usePnpm()
     ? pnpmLockFilename
-    : packageLockFilename
+    : useNpm()
+    ? packageLockFilename
+    : noLockFile()
   const fileHash = hasha.fromFileSync(lockFilename)
   debug(`Hash from file ${lockFilename} is ${fileHash}`)
   return fileHash
+}
+
+const noLockFile = () => {
+  core.error(
+    `Action failed. Missing package manager lockfile. ` +
+      `Expecting one of package-lock.json (npm), pnpm-lock.yaml (pnpm) or yarn.lock (yarn) in working-directory ` +
+      workingDirectory
+  )
+  process.exit(1)
 }
 
 // enforce the same NPM cache folder across different operating systems


### PR DESCRIPTION
This PR catches the error condition of a missing package manager lock file and displays a user-friendly error message.

The action requires a lock file from `npm`, `pnpm` or `yarn` in order to install dependencies and store the cache.

---
BEFORE

The action fails showing an error message similar to the following:

```text
@cypress/github-action trying to restore cached NPM modules
node:internal/fs/utils:345
    throw err;
    ^

Error: ENOENT: no such file or directory, open '/home/runner/work/github-action/github-action/examples/yarn-classic/package-lock.json'
```

This error message only mentions `package-lock.json` (npm). It does not mention lock file names from `pnpm` or `yarn`, which are also supported.

---
AFTER

An error message is shown in the action logs summary and action logs details similar to the following. This makes the error condition clearer and provides the hints necessary to remediate the error.

"Action failed. Missing package manager lockfile. Expecting one of package-lock.json (npm), pnpm-lock.yaml (pnpm) or yarn.lock (yarn) in working-directory /home/runner/work/github-action/github-action/examples/yarn-classic"

## Summary

![yarn-no-lock-summary](https://user-images.githubusercontent.com/66998419/227199302-787f09a5-54f8-4403-a765-7d6d040e9cf8.jpg)

## Detail

![yarn-no-lock-detail](https://user-images.githubusercontent.com/66998419/227199345-ae92cc97-c896-40e1-ba12-265b405ce41a.jpg)

