### PR TITLE
build: automate update of examples/yarn-modern to yarn latest

### DIFF
--- a/scripts/update-cypress-latest-other.sh
+++ b/scripts/update-cypress-latest-other.sh
@@ -44,6 +44,7 @@ cd ..
 echo
 echo updating examples/yarn-modern to cypress@latest
 cd yarn-modern
+yarn set version latest
 yarn add cypress --dev --exact
 cd ..
 


### PR DESCRIPTION
This PR updates [scripts/update-cypress-latest-other.sh](https://github.com/cypress-io/github-action/blob/master/scripts/update-cypress-latest-other.sh) so that [examples/yarn-modern](https://github.com/cypress-io/github-action/tree/master/examples/yarn-modern) uses the latest version of `yarn` from the package manager Yarn Modern after running `npm run update:cypress`.

GitHub only includes Yarn Classic in its standard runners, so there is otherwise no mechanism to update the version of Yarn Modern.

Yarn Modern is updated only for [examples/yarn-modern](https://github.com/cypress-io/github-action/tree/master/examples/yarn-modern).

[examples/v9/yarn-modern](https://github.com/cypress-io/github-action/tree/master/examples/v9/yarn-modern) for legacy Cypress is untouched by this change.

Similarly [examples/yarn-classic](https://github.com/cypress-io/github-action/tree/master/examples/yarn-classic) and [examples/v9/yarn-classic](https://github.com/cypress-io/github-action/tree/master/examples/v9/yarn-classic) are left unchanged.

This script will be applied for the next release of Cypress. It is not necessary to update [examples/yarn-modern](https://github.com/cypress-io/github-action/tree/master/examples/yarn-modern) in the interim.

## Verification

Execute

```bash
npm run update:cypress
cd examples/yarn-modern
yarn -v
```

and confirm yarn version is showing `3.5.0` (or higher). Then execute

```bash
yarn
npx cypress run
```
and ensure that Cypress reports a successful run.
