### PR TITLE
fix(deps): use pnpm 7 not pnpm 8 (new latest)

### DIFF
--- a/.github/workflows/example-basic-pnpm.yml
+++ b/.github/workflows/example-basic-pnpm.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v2
         with:
-          version: latest
+          version: 7
 
       - name: Cypress tests
         # normally you would write
@@ -42,7 +42,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v2
         with:
-          version: latest
+          version: 7
 
       - name: Cypress tests
         uses: ./
@@ -59,7 +59,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v2
         with:
-          version: latest
+          version: 7
 
       - name: Cypress tests
         uses: ./
@@ -76,7 +76,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v2
         with:
-          version: latest
+          version: 7
 
       - name: Cypress tests
         uses: ./
@@ -96,7 +96,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v2
         with:
-          version: latest
+          version: 7
 
       - name: Cypress tests
         uses: ./
@@ -120,7 +120,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v2
         with:
-          version: latest
+          version: 7
 
       - name: Cypress tests
         # normally you would write
@@ -144,7 +144,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v2
         with:
-          version: latest
+          version: 7
 
       - name: Cypress tests
         uses: ./
@@ -161,7 +161,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v2
         with:
-          version: latest
+          version: 7
 
       - name: Cypress tests
         uses: ./
@@ -178,7 +178,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v2
         with:
-          version: latest
+          version: 7
 
       - name: Cypress tests
         uses: ./
@@ -198,7 +198,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v2
         with:
-          version: latest
+          version: 7
 
       - name: Cypress tests
         uses: ./

--- a/README.md
+++ b/README.md
@@ -1013,7 +1013,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v2
         with:
-          version: latest
+          version: 7
       - name: Cypress run
         uses: cypress-io/github-action@v5
         with:


### PR DESCRIPTION
This PR remediates a breaking change caused by the release of [pnpm 8.0.0](https://github.com/pnpm/pnpm/releases/tag/v8.0.0) on March 28, 2023.

## Problem

`pnpm install --frozen-lockfile` does not accept `pnpm-lock.yaml` with `lockfileVersion: 5.4` generated by [pnpm v7.30.5](https://github.com/pnpm/pnpm/releases/tag/v7.30.5).

[pnpm 8.0.0](https://github.com/pnpm/pnpm/releases/tag/v8.0.0) is a breaking change. Apart from the compatibility issue with `lockfileVersion: 5.4` it also removes support for Node.js 14.

[.github/workflows/example-basic-pnpm.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-basic-pnpm.yml) uses [pnpm/action-setup](https://github.com/pnpm/action-setup)@v2  `with: version: latest`

## Workaround

Bind [pnpm/action-setup](https://github.com/pnpm/action-setup)@v2 using `with: version: 7`.

## Related

- See also issue https://github.com/pnpm/pnpm/issues/6307