### PR TITLE
If there is a custom command, then don't continue doing extra work

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -74987,10 +74987,9 @@ const runTestsUsingCommandLine = async () => {
 
   debug(`in working directory "${cypressCommandOptions.cwd}"`)
 
-  const npxPath = await io.which('npx', true)
-  debug(`npx path: ${npxPath}`)
+  const bin = cmd[0]
 
-  return exec.exec(quote(npxPath), cmd, opts)
+  return exec.exec(bin, cmd.slice(1), opts)
 }
 
 /**

--- a/dist/index.js
+++ b/dist/index.js
@@ -75000,6 +75000,11 @@ const runTestsUsingCommandLine = async () => {
  */
 const runTests = async () => {
   const commandPrefix = core.getInput('command-prefix')
+
+  if (commandPrefix) {
+    return runTestsUsingCommandLine()
+  }
+
   const customCommand = core.getInput('command')
   const cypressOptions = {
     headed: getInputBool('headed'),
@@ -75027,10 +75032,6 @@ const runTests = async () => {
   if (customCommand) {
     console.log('Using custom test command: %s', customCommand)
     return execCommand(customCommand, true, 'run tests')
-  }
-
-  if (commandPrefix) {
-    return runTestsUsingCommandLine()
   }
 
   debug('Running Cypress tests using NPM module API')

--- a/dist/index.js
+++ b/dist/index.js
@@ -74977,7 +74977,7 @@ const runTestsUsingCommandLine = async () => {
     cmd.push('--quiet')
   }
 
-  console.log('Cypress test command: npx %s', cmd.join(' '))
+  console.log('Cypress test command: %s', cmd.join(' '))
 
   // since we have quoted arguments ourselves, do not double quote them
   const opts = {

--- a/index.js
+++ b/index.js
@@ -636,10 +636,9 @@ const runTestsUsingCommandLine = async () => {
 
   debug(`in working directory "${cypressCommandOptions.cwd}"`)
 
-  const npxPath = await io.which('npx', true)
-  debug(`npx path: ${npxPath}`)
+  const bin = cmd[0]
 
-  return exec.exec(quote(npxPath), cmd, opts)
+  return exec.exec(bin, cmd.slice(1), opts)
 }
 
 /**

--- a/index.js
+++ b/index.js
@@ -626,7 +626,7 @@ const runTestsUsingCommandLine = async () => {
     cmd.push('--quiet')
   }
 
-  console.log('Cypress test command: npx %s', cmd.join(' '))
+  console.log('Cypress test command: %s', cmd.join(' '))
 
   // since we have quoted arguments ourselves, do not double quote them
   const opts = {

--- a/index.js
+++ b/index.js
@@ -649,6 +649,11 @@ const runTestsUsingCommandLine = async () => {
  */
 const runTests = async () => {
   const commandPrefix = core.getInput('command-prefix')
+
+  if (commandPrefix) {
+    return runTestsUsingCommandLine()
+  }
+
   const customCommand = core.getInput('command')
   const cypressOptions = {
     headed: getInputBool('headed'),
@@ -676,10 +681,6 @@ const runTests = async () => {
   if (customCommand) {
     console.log('Using custom test command: %s', customCommand)
     return execCommand(customCommand, true, 'run tests')
-  }
-
-  if (commandPrefix) {
-    return runTestsUsingCommandLine()
   }
 
   debug('Running Cypress tests using NPM module API')


### PR DESCRIPTION
In the situation where a user is supplying a `command-prefix` cypress is executed in the command line. However the decision to execute in the CLI is made after doing work which expects cypress and other tools to be present in the current working directory. 

In our situation we share cypress tests in another repo and execute those in a sub directory of our current project during CI, so we supply a `yarn --cwd e2e-testing` `command-prefix` argument. However, because the github-actions attempts to resolve `cypress` as a module in the current process, the action throws an error. 

This PR moves the logic for executing via the CLI to the determining point in the action, skipping any unnecessary work that is being done before executing the CLI options. 