### PR TITLE
docs: add CODE_OF_CONDUCT.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,2 @@
+Please review our
+[Code of Conduct](https://github.com/cypress-io/cypress/blob/develop/CODE_OF_CONDUCT.md).


### PR DESCRIPTION
This PR adds a link to the [CODE_OF_CONDUCT.md](https://github.com/cypress-io/cypress/blob/develop/CODE_OF_CONDUCT.md) on the main [cypress-io/cypress](https://github.com/cypress-io/cypress) repository into this repository.

This is needed so it can be referred to from a `CONTRIBUTING.md` document, when this is renamed from [DEVELOPMENT.md](https://github.com/cypress-io/github-action/blob/master/DEVELOPMENT.md) as suggested by @emilyrohrbough in https://github.com/cypress-io/github-action/pull/853#discussion_r1157814238.