### PR TITLE
docs: move DEVELOPMENT.md to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,13 +1,26 @@
-# Development
+# Contributing to cypress-io/github-action
+
+Thanks for taking the time to contribute! :smile:
+
+*To contribute to the main Cypress product, please read the related [CONTRIBUTING](https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md) document, which also contains useful general tips.*
+
+To contribute to the [cypress-io/github-action](https://github.com/cypress-io/github-action) repository, please continue reading here.
+
+## Code of Conduct
+
+All contributors are expected to abide by our [Code of Conduct](./CODE_OF_CONDUCT.md).
+
+## Development
 
 This document describes topics useful to contributors to this repository. The repository's purpose is to provide a GitHub JavaScript action which is published to:
 
-1. npm's JavaScript Package Registry as [@cypress/github-action](https://www.npmjs.com/package/@cypress/github-action)
-2. GitHub's Marketplace as [cypress-io/github-action](https://github.com/marketplace/actions/cypress-io#cypress-iogithub-action--)
+1. GitHub's Marketplace as [cypress-io/github-action](https://github.com/marketplace/actions/cypress-io#cypress-iogithub-action--)
+2. npm's JavaScript Package Registry as [@cypress/github-action](https://www.npmjs.com/package/@cypress/github-action)
+
 
 You can read the GitHub document [Creating a JavaScript action](https://docs.github.com/en/actions/creating-actions/creating-a-javascript-action) for background information on how JavaScript actions for GitHub are created and how they work.
 
-## Providing fixes or features
+### Providing fixes or features
 
 If you are submitting a Pull Request (PR) to provide a fix or feature for the action, the following is relevant to you:
 
@@ -26,13 +39,13 @@ To contribute changes, follow these instructions in the order given below:
 1. Ensure you are using [Node.js LTS](https://nodejs.org/en).
 1. Execute the following in the root directory of the cloned repository
 
-```bash
-npm install
-npm run format
-npm run build
-```
+    ```bash
+    npm install
+    npm run format
+    npm run build
+    ```
 
-6. Commit the change. (If you are working on Microsoft Windows, see [Windows users](#windows-users) below.)
+1. Commit the change. (If you are working on Microsoft Windows, see [Windows users](#windows-users) below.)
 1. Push to the repository.
 1. If you are working in a fork, ensure actions are enabled.
 1. Refer to [Manually running a workflow](https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow) to use this to test any particular workflow affected by your change.
@@ -41,19 +54,19 @@ npm run build
 1. Check that all tests which are triggered by the PR were either successful or were skipped.
 1. If the PR is showing that the tests were successful mark the PR as Ready for Review.
 
-### Windows users
+#### Windows users
 
-The repository is set up with a `git` / `Husky` pre-commit hook which ensures that any changes to the core source files are formatted and built consistently before they are committed. This does not work well with [GitHub Desktop](https://docs.github.com/en/desktop). You can disable this function by setting an environment variable `HUSKY=0`. If you do this and then omit to use `npm run format` / `npm run build` before you commit any changes affecting the core source files, you will find that checks fail when you submit a PR. In this case you should run the format and build commands and amend your commit.
+The repository is set up with a `git` / `Husky` pre-commit hook which ensures that any changes to the core source files are formatted and built consistently before they are committed. This does not work well with [GitHub Desktop](https://docs.github.com/en/desktop). You can disable this function by setting an environment variable `HUSKY=0`. If you do this and then omit to use `npm run format` / `npm run build` before you commit any changes affecting the core source files, you will find that checks fail when you submit a PR. In this case you should run the `format` and `build` commands and amend your commit.
 
-## Adding a new example
+### Adding a new example
 
 1. If you are creating a new example, add this as a new project in the `examples` directory. An example project is a regular NPM package with its own `package.json` and Cypress dev dependency. (Note: Legacy `examples/v9` should not be extended.)
-2. Add a corresponding `.github/workflows` YAML file that uses this action and runs using your new `examples/X` through the `working-directory` parameter. The example should demonstrate any new feature.
-3. Add a workflow status badge to the [README.md](README.md) file (see [Adding a workflow status badge](https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/adding-a-workflow-status-badge)), like the following:
+1. Add a corresponding `.github/workflows` YAML file that uses this action and runs using your new `examples/X` through the `working-directory` parameter. The example should demonstrate any new feature.
+1. Add a workflow status badge to the [README.md](README.md) file (see [Adding a workflow status badge](https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/adding-a-workflow-status-badge)), like the following:
 
 [![Chrome example](https://github.com/cypress-io/github-action/workflows/example-chrome/badge.svg?branch=master)](.github/workflows/example-chrome.yml)
 
-## External Testing
+### External Testing
 
 The example workflows in [.github/workflows](./.github/workflows) specify
 
@@ -78,25 +91,27 @@ This information is for Cypress.io Members or Collaborators who merge pull reque
 1. When merging a pull request, use the [Squash and merge](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/about-merge-methods-on-github#squashing-your-merge-commits) option to squash all commits into one.
 1. Make sure the commit subject and body follow [semantic commit convention](https://semantic-release.gitbook.io/semantic-release/#commit-message-format), for instance:
 
-```text
-feat: added new parameter
-fix: fixed a bug
-```
+    ```text
+    feat: added new parameter
+    fix: fixed a bug
+    ```
 
-If you need to bump the major version, mark it as breaking change in the body of the commit's message like:
+    If you need to bump the major version, mark it as breaking change in the body of the commit's message like:
 
-```text
-fix: upgrade dependency X
+    ```text
+    fix: upgrade dependency X
 
-BREAKING CHANGE: requires minimum Node.js 16 to run
-```
+    BREAKING CHANGE: requires minimum Node.js 16 to run
+    ```
 
-3. New versions of this action will be released automatically by the CI when merged to master, see [.github/workflows/main.yml](.github/workflows/main.yml). This will create a new [GitHub release](https://github.com/cypress-io/github-action/releases) and will update the current `v5` branch. Thus specifying `uses: cypress-io/github-action@v5` selects the new version automatically. This **will not** push the latest release to Github Marketplace.
-4. The action's CI is configured to use the [default Angular release rules](https://github.com/semantic-release/commit-analyzer/blob/master/lib/default-release-rules.js). This means that only `feat:`, `fix:` and `perf:` trigger a new release which is then logged to the [releases](https://github.com/cypress-io/github-action/releases) page. Other Angular commit types listed on [Contributing to Angular](https://github.com/angular/angular/blob/main/CONTRIBUTING.md#-commit-message-format) can be used for documentation purposes, however they are ignored by the currently configured release process.
+1. New versions of this action will be released automatically by the CI when merged to the `master` branch, see [.github/workflows/main.yml](.github/workflows/main.yml). This will create a new [GitHub release](https://github.com/cypress-io/github-action/releases) and will update the current `v5` branch. Thus specifying `uses: cypress-io/github-action@v5` selects the new version automatically. This **will not** push the latest release to GitHub Marketplace.
+1. The action's CI is configured to use the [default Angular release rules](https://github.com/semantic-release/commit-analyzer/blob/master/lib/default-release-rules.js). This means that only `feat:`, `fix:` and `perf:` trigger a new release which is then logged to the [releases](https://github.com/cypress-io/github-action/releases) page. Other Angular commit types listed on [Contributing to Angular](https://github.com/angular/angular/blob/main/CONTRIBUTING.md#-commit-message-format) can be used for documentation purposes, however they are ignored by the currently configured release process.
 
 ## GitHub Marketplace publication
 
-Publishing a new release to the GitHub Marketplace is a manual process. After a new release has been created, go to the release and click "Edit"
+Publishing a new release to the GitHub Marketplace is a manual process.
+
+After a new release has been created, go to the release and click "Edit"
 
 ![Edit the release](images/edit-release.png)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# cypress-io/github-action [![Action status](https://github.com/cypress-io/github-action/workflows/main/badge.svg?branch=master)](https://github.com/cypress-io/github-action/actions/workflows/main.yml) [![renovate-app badge][renovate-badge]][renovate-bot]
+# cypress-io/github-action [![Action status][ci-badge]][ci-workflow] [![cypress][cloud-badge]][cloud-project] [![renovate-app badge][renovate-badge]][renovate-bot]
 
-> [GitHub Action](https://docs.github.com/en/actions) for running [Cypress](https://www.cypress.io) end-to-end and component tests. Includes NPM installation, custom caching and lots of configuration options.
+ > [GitHub Action](https://docs.github.com/en/actions) for running [Cypress](https://www.cypress.io) end-to-end and component tests. Includes NPM installation, custom caching and lots of configuration options.
 
 ## Examples
 
@@ -1471,15 +1471,20 @@ See [Releases](https://github.com/cypress-io/github-action/releases) for full de
 
 ## Contributing
 
-[![cypress](https://img.shields.io/endpoint?url=https://cloud.cypress.io/badge/simple/3tb7jn/master&style=flat&logo=cypress)](https://cloud.cypress.io/projects/3tb7jn/runs) [![Action status](https://github.com/cypress-io/github-action/workflows/main/badge.svg?branch=master)](https://github.com/cypress-io/github-action/actions/workflows/main.yml)
-
 Please see our [Contributing Guideline](./CONTRIBUTING.md) which explains how to contribute fixes or features to the repo and how to test.
 
 ## License
 
-[![license](https://img.shields.io/badge/license-MIT-green.svg)](https://github.com/cypress-io/github-action/blob/master/LICENSE.md)
+[![license][license-badge]][license-file]
 
-This project is licensed under the terms of the [MIT license](./LICENSE.md).
+This project is licensed under the terms of the [MIT license][license-file].
 
+<!-- badge links follow -->
+[ci-badge]: https://github.com/cypress-io/github-action/workflows/main/badge.svg?branch=master
+[ci-workflow]: https://github.com/cypress-io/github-action/actions/workflows/main.yml
+[cloud-badge]: https://img.shields.io/endpoint?url=https://cloud.cypress.io/badge/simple/3tb7jn/master&style=flat&logo=cypress
+[cloud-project]: https://cloud.cypress.io/projects/3tb7jn/runs
 [renovate-badge]: https://img.shields.io/badge/renovate-app-blue.svg
 [renovate-bot]: https://github.com/renovatebot
+[license-badge]: https://img.shields.io/badge/license-MIT-green.svg
+[license-file]: ./LICENSE.md

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# cypress-io/github-action [![renovate-app badge][renovate-badge]][renovate-bot] [![Action status](https://github.com/cypress-io/github-action/workflows/main/badge.svg?branch=master)](https://github.com/cypress-io/github-action/actions)
+# cypress-io/github-action [![Action status](https://github.com/cypress-io/github-action/workflows/main/badge.svg?branch=master)](https://github.com/cypress-io/github-action/actions/workflows/main.yml) [![renovate-app badge][renovate-badge]][renovate-bot]
 
 > [GitHub Action](https://docs.github.com/en/actions) for running [Cypress](https://www.cypress.io) end-to-end and component tests. Includes NPM installation, custom caching and lots of configuration options.
 
@@ -1320,10 +1320,6 @@ pinging url https://example.cypress.io for 30 seconds
 ::debug::pinging https://example.cypress.io has finished ok
 ```
 
-## Development
-
-Read [DEVELOPMENT.md](DEVELOPMENT.md)
-
 ## More information
 
 - Read our blog post [Drastically Simplify Testing on CI with Cypress GitHub Action](https://www.cypress.io/blog/2019/11/20/drastically-simplify-your-testing-with-cypress-github-action/)
@@ -1473,9 +1469,17 @@ See [Releases](https://github.com/cypress-io/github-action/releases) for full de
 
 *Note: [GitHub announced](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) their plan to disable `save-state` and `set-output` commands by May 31, 2023. This will prevent [cypress-io/github-action](https://github.com/cypress-io/github-action) version [v4.2.1](https://github.com/cypress-io/github-action/releases/tag/v4.2.1), and earlier, running after this date since they use `set-output`. Affected users should update to using `v5` of the [cypress-io/github-action](https://github.com/cypress-io/github-action) action before the deadline.*
 
+## Contributing
+
+[![cypress](https://img.shields.io/endpoint?url=https://cloud.cypress.io/badge/simple/3tb7jn/master&style=flat&logo=cypress)](https://cloud.cypress.io/projects/3tb7jn/runs) [![Action status](https://github.com/cypress-io/github-action/workflows/main/badge.svg?branch=master)](https://github.com/cypress-io/github-action/actions/workflows/main.yml)
+
+Please see our [Contributing Guideline](./CONTRIBUTING.md) which explains how to contribute fixes or features to the repo and how to test.
+
 ## License
 
-[MIT License](./LICENSE.md)
+[![license](https://img.shields.io/badge/license-MIT-green.svg)](https://github.com/cypress-io/github-action/blob/master/LICENSE.md)
+
+This project is licensed under the terms of the [MIT license](./LICENSE.md).
 
 [renovate-badge]: https://img.shields.io/badge/renovate-app-blue.svg
 [renovate-bot]: https://github.com/renovatebot


### PR DESCRIPTION
This PR renames the file [DEVELOPMENT.md](https://github.com/cypress-io/github-action/blob/master/DEVELOPMENT.md) to use the standard filename `CONTRIBUTING.md`.

This was requested by @emilyrohrbough in https://github.com/cypress-io/github-action/pull/853#discussion_r1157814238.

It also updates the [README.md](https://github.com/cypress-io/github-action/blob/master/README.md) file accordingly.

## Filename and location

According to GitHub Docs [Setting guidelines for repository contributors](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/setting-guidelines-for-repository-contributors) the `CONTRIBUTING.md` file can be in the repository's root, `docs` or `.github` directory. Given that the original [DEVELOPMENT.md](https://github.com/cypress-io/github-action/blob/master/DEVELOPMENT.md) was created in the repository's root, I have left the renamed file there as well. Also the main [cypress-io/cypress](https://github.com/cypress-io/cypress) places the document in its repository root.

## DEVELOPMENT.md Content Changes

### Introduction

The top of the document contains an introduction "Contributing to cypress-io/github-action" which mimics parts of the start of [cypress-io/cypress/CONTRIBUTING.md](https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md) for consistency.

### Body

Some minor formatting and editorial changes to the section of the document which came from the contents of `DEVELOPMENT.md` have been done.

## README.md Content Changes

### Introduction

I changed the order of the badges to show the CI status first (most important), with the renovate badge (least important) shown last. The CI badge now links directly to the [actions/workflows/main.yml](https://github.com/cypress-io/github-action/actions/workflows/main.yml) CI workflow results.

[![Action status][ci-badge]][ci-workflow] [![cypress][cloud-badge]][cloud-project] [![renovate-app badge][renovate-badge]][renovate-bot]

[ci-badge]: https://github.com/cypress-io/github-action/workflows/main/badge.svg?branch=master
[ci-workflow]: https://github.com/cypress-io/github-action/actions/workflows/main.yml
[cloud-badge]: https://img.shields.io/endpoint?url=https://cloud.cypress.io/badge/simple/3tb7jn/master&style=flat&logo=cypress
[cloud-project]: https://cloud.cypress.io/projects/3tb7jn/runs
[renovate-badge]: https://img.shields.io/badge/renovate-app-blue.svg
[renovate-bot]: https://github.com/renovatebot


### Development

The "Development" section is removed and replaced by a "Contributing" section.

### Contributing

The new "Contributing" section is modeled on the [cypress-io/cypress/README: Contributing](https://github.com/cypress-io/cypress/blob/develop/README.md#contributing) section.

### License

The existing "License" section is remodeled to display exactly like the [cypress-io/cypress/README: License](https://github.com/cypress-io/cypress/blob/develop/README.md#license) section.
