### PR TITLE
test: add matrix to parallel recording

### DIFF
--- a/.github/workflows/example-recording.yml
+++ b/.github/workflows/example-recording.yml
@@ -40,6 +40,11 @@ jobs:
   parallel-v9:
     runs-on: ubuntu-22.04
     needs: [check-record-key]
+    strategy:
+      fail-fast: false
+      matrix:
+        # run copies of the current job in parallel
+        containers: [1, 2]
     if: needs.check-record-key.outputs.record-key-exists == 'true'
     steps:
       - name: Checkout
@@ -93,6 +98,11 @@ jobs:
   parallel:
     runs-on: ubuntu-22.04
     needs: [check-record-key]
+    strategy:
+      fail-fast: false
+      matrix:
+        # run copies of the current job in parallel
+        containers: [1, 2]
     if: needs.check-record-key.outputs.record-key-exists == 'true'
     steps:
       - name: Checkout


### PR DESCRIPTION
This PR adds a 2-container matrix to the `parallel-v9` and `parallel` jobs of [.github/workflows/example-recording.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-recording.yml).

```yml
    strategy:
      fail-fast: false
      matrix:
        # run copies of the current job in parallel
        containers: [1, 2]
```

To gain benefit from the `record` & `parallel` parameters there must be more than one container running, otherwise no load-balancing can take place.

```yml
        with:
          record: true
          parallel: true
```

This PR therefore improves the example workflow by making it better mirror practical usage of the `record` & `parallel` parameters.