### PR TITLE
misc: use lower case for references to npm package manager

### DIFF
--- a/.github/workflows/example-install-only.yml
+++ b/.github/workflows/example-install-only.yml
@@ -17,12 +17,12 @@ jobs:
       - name: Checkout 🛎
         uses: actions/checkout@v3
 
-      # cache NPM modules and Cypress binary folder
+      # cache npm modules and Cypress binary folder
       # we can use "package-lock.json" as the key file
       # to make sure we use the precise Cypress version
       # (which is important when using ^ version in package.json)
       # see https://github.com/actions/cache
-      - name: Cache NPM and Cypress 📦
+      - name: Cache npm and Cypress 📦
         uses: actions/cache@v3
         with:
           path: |
@@ -49,12 +49,12 @@ jobs:
       - name: Checkout 🛎
         uses: actions/checkout@v3
 
-      # cache NPM modules and Cypress binary folder
+      # cache npm modules and Cypress binary folder
       # we can use "package-lock.json" as the key file
       # to make sure we use the precise Cypress version
       # (which is important when using ^ version in package.json)
       # see https://github.com/actions/cache
-      - name: Cache NPM and Cypress 📦
+      - name: Cache npm and Cypress 📦
         uses: actions/cache@v3
         with:
           path: |

--- a/.github/workflows/example-quiet.yml
+++ b/.github/workflows/example-quiet.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      # Install NPM dependencies, cache them correctly
+      # Install npm dependencies, cache them correctly
       # and run all Cypress tests with `quiet` parameter
       - name: Cypress run
         uses: ./
@@ -30,7 +30,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      # Install NPM dependencies, cache them correctly
+      # Install npm dependencies, cache them correctly
       # and run all Cypress tests with `quiet` parameter
       - name: Cypress run
         uses: ./

--- a/.github/workflows/example-wait-on.yml
+++ b/.github/workflows/example-wait-on.yml
@@ -156,7 +156,7 @@ jobs:
         with:
           working-directory: examples/v9/react-scripts
           start: npm start
-          # let's use wait-on NPM package to check the URL
+          # let's use the wait-on npm package to check the URL
           wait-on: 'npx wait-on --timeout 60000 http://127.0.0.1:3000'
 
   ping-cli-v9:
@@ -329,7 +329,7 @@ jobs:
         with:
           working-directory: examples/nextjs
           start: npm run dev
-          # let's use wait-on NPM package to check the URL
+          # let's use the wait-on npm package to check the URL
           wait-on: 'npx wait-on --timeout 60000 http://localhost:3000'
 
   ping-cli:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,7 +60,7 @@ The repository is set up with a `git` / `Husky` pre-commit hook which ensures th
 
 ### Adding a new example
 
-1. If you are creating a new example, add this as a new project in the `examples` directory. An example project is a regular NPM package with its own `package.json` and Cypress dev dependency. (Note: Legacy `examples/v9` should not be extended.)
+1. If you are creating a new example, add this as a new project in the `examples` directory. An example project is a regular npm package with its own `package.json` and Cypress dev dependency. (Note: Legacy `examples/v9` should not be extended.)
 1. Add a corresponding `.github/workflows` YAML file that uses this action and runs using your new `examples/X` through the `working-directory` parameter. The example should demonstrate any new feature.
 1. Add a workflow status badge to the [README.md](README.md) file (see [Adding a workflow status badge](https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/adding-a-workflow-status-badge)), like the following:
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # cypress-io/github-action [![Action status][ci-badge]][ci-workflow] [![cypress][cloud-badge]][cloud-project] [![renovate-app badge][renovate-badge]][renovate-bot]
 
- > [GitHub Action](https://docs.github.com/en/actions) for running [Cypress](https://www.cypress.io) end-to-end and component tests. Includes NPM installation, custom caching and lots of configuration options.
+ > [GitHub Action](https://docs.github.com/en/actions) for running [Cypress](https://www.cypress.io) end-to-end and component tests. Includes npm installation, custom caching and lots of configuration options.
 
 ## Examples
 
@@ -65,7 +65,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      # Install NPM dependencies, cache them correctly
+      # Install npm dependencies, cache them correctly
       # and run all Cypress tests
       - name: Cypress run
         uses: cypress-io/github-action@v5
@@ -492,7 +492,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      # Install NPM dependencies, cache them correctly
+      # Install npm dependencies, cache them correctly
       # and run all Cypress tests with `quiet` parameter
       - name: Cypress run
         uses: ./
@@ -1186,7 +1186,7 @@ See [cypress-gh-action-monorepo](https://github.com/bahmutov/cypress-gh-action-m
 
 ### Custom install
 
-Finally, you might not need this GH Action at all. For example, if you want to split the NPM dependencies installation from the Cypress binary installation, then it makes no sense to use this action. Instead you can install and cache Cypress yourself. See [cypress-gh-action-split-install](https://github.com/bahmutov/cypress-gh-action-split-install) (legacy) for a working example.
+Finally, you might not need this GH Action at all. For example, if you want to split the npm dependencies installation from the Cypress binary installation, then it makes no sense to use this action. Instead you can install and cache Cypress yourself. See [cypress-gh-action-split-install](https://github.com/bahmutov/cypress-gh-action-split-install) (legacy) for a working example.
 
 ### Install Cypress only
 
@@ -1239,7 +1239,7 @@ See [cypress-gh-action-example](https://github.com/bahmutov/cypress-gh-action-ex
 | [cypress-gh-action-example](https://github.com/bahmutov/cypress-gh-action-example)  (legacy)            | Uses Yarn, and runs in parallel on several versions of Node, different browsers, and more |
 | [cypress-gh-action-monorepo](https://github.com/bahmutov/cypress-gh-action-monorepo)                    | Splits install and running tests commands, runs Cypress from sub-folder                   |
 | [cypress-gh-action-subfolders](https://github.com/bahmutov/cypress-gh-action-subfolders) (legacy)       | Has separate folder for Cypress dependencies                                              |
-| [cypress-gh-action-split-install](https://github.com/bahmutov/cypress-gh-action-split-install) (legacy) | Only install NPM dependencies, then install and cache Cypress binary yourself             |
+| [cypress-gh-action-split-install](https://github.com/bahmutov/cypress-gh-action-split-install) (legacy) | Only install npm dependencies, then install and cache Cypress binary yourself             |
 | [cypress-gh-action-changed-files](https://github.com/bahmutov/cypress-gh-action-changed-files) (legacy) | Shows how to run different Cypress projects depending on changed files                    |
 | [cypress-examples](https://github.com/bahmutov/cypress-examples)                                        | Shows separate install job from parallel test jobs                                        |
 | [cypress-gh-action-split-jobs](https://github.com/bahmutov/cypress-gh-action-split-jobs) (legacy)       | Shows a separate install job with the build step, and another job that runs the tests     |


### PR DESCRIPTION
This PR modifies the:

- [README](https://github.com/cypress-io/github-action/blob/master/README.md) file
- [CONTRIBUTING](https://github.com/cypress-io/github-action/blob/master/CONTRIBUTING.md) file
- `*.yml` workflows in the [.github/workflows](https://github.com/cypress-io/github-action/tree/master/.github/workflows) directory

causing:

- references to `NPM` to be changed to lowercase `npm` in conformance with its documentation under [About npm](https://docs.npmjs.com/about-npm).
