### PR TITLE
chore(deps): update cypress to 12.11.0

### DIFF
--- a/.github/workflows/example-install-only.yml
+++ b/.github/workflows/example-install-only.yml
@@ -63,7 +63,7 @@ jobs:
           key: my-cache-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
 
       - name: Install Cypress 📥
-        run: npm i cypress@12.10.0
+        run: npm i cypress@12.11.0
 
       - name: Cypress tests 🧪
         uses: ./

--- a/examples/basic-pnpm/package.json
+++ b/examples/basic-pnpm/package.json
@@ -10,6 +10,6 @@
   "license": "ISC",
   "private": true,
   "devDependencies": {
-    "cypress": "12.10.0"
+    "cypress": "12.11.0"
   }
 }

--- a/examples/basic-pnpm/pnpm-lock.yaml
+++ b/examples/basic-pnpm/pnpm-lock.yaml
@@ -2,8 +2,8 @@ lockfileVersion: '6.0'
 
 devDependencies:
   cypress:
-    specifier: 12.10.0
-    version: 12.10.0
+    specifier: 12.11.0
+    version: 12.11.0
 
 packages:
 
@@ -292,8 +292,8 @@ packages:
       which: 2.0.2
     dev: true
 
-  /cypress@12.10.0:
-    resolution: {integrity: sha512-Y0wPc221xKKW1/4iAFCphkrG2jNR4MjOne3iGn4mcuCaE7Y5EtXL83N8BzRsAht7GYfWVjJ/UeTqEdDKHz39HQ==}
+  /cypress@12.11.0:
+    resolution: {integrity: sha512-TJE+CCWI26Hwr5Msb9GpQhFLubdYooW0fmlPwTsfiyxmngqc7+SZGLPeIkj2dTSSZSEtpQVzOzvcnzH0o8G7Vw==}
     engines: {node: ^14.0.0 || ^16.0.0 || >=18.0.0}
     hasBin: true
     requiresBuild: true

--- a/examples/basic/package-lock.json
+++ b/examples/basic/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {
-        "cypress": "12.10.0"
+        "cypress": "12.11.0"
       }
     },
     "node_modules/@colors/colors": {
@@ -545,9 +545,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "12.10.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.10.0.tgz",
-      "integrity": "sha512-Y0wPc221xKKW1/4iAFCphkrG2jNR4MjOne3iGn4mcuCaE7Y5EtXL83N8BzRsAht7GYfWVjJ/UeTqEdDKHz39HQ==",
+      "version": "12.11.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.11.0.tgz",
+      "integrity": "sha512-TJE+CCWI26Hwr5Msb9GpQhFLubdYooW0fmlPwTsfiyxmngqc7+SZGLPeIkj2dTSSZSEtpQVzOzvcnzH0o8G7Vw==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -2310,9 +2310,9 @@
       }
     },
     "cypress": {
-      "version": "12.10.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.10.0.tgz",
-      "integrity": "sha512-Y0wPc221xKKW1/4iAFCphkrG2jNR4MjOne3iGn4mcuCaE7Y5EtXL83N8BzRsAht7GYfWVjJ/UeTqEdDKHz39HQ==",
+      "version": "12.11.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.11.0.tgz",
+      "integrity": "sha512-TJE+CCWI26Hwr5Msb9GpQhFLubdYooW0fmlPwTsfiyxmngqc7+SZGLPeIkj2dTSSZSEtpQVzOzvcnzH0o8G7Vw==",
       "dev": true,
       "requires": {
         "@cypress/request": "^2.88.10",

--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -10,6 +10,6 @@
   "license": "ISC",
   "private": true,
   "devDependencies": {
-    "cypress": "12.10.0"
+    "cypress": "12.11.0"
   }
 }

--- a/examples/browser/package-lock.json
+++ b/examples/browser/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.1.0",
       "license": "ISC",
       "devDependencies": {
-        "cypress": "12.10.0",
+        "cypress": "12.11.0",
         "image-size": "^1.0.2"
       }
     },
@@ -546,9 +546,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "12.10.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.10.0.tgz",
-      "integrity": "sha512-Y0wPc221xKKW1/4iAFCphkrG2jNR4MjOne3iGn4mcuCaE7Y5EtXL83N8BzRsAht7GYfWVjJ/UeTqEdDKHz39HQ==",
+      "version": "12.11.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.11.0.tgz",
+      "integrity": "sha512-TJE+CCWI26Hwr5Msb9GpQhFLubdYooW0fmlPwTsfiyxmngqc7+SZGLPeIkj2dTSSZSEtpQVzOzvcnzH0o8G7Vw==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -2335,9 +2335,9 @@
       }
     },
     "cypress": {
-      "version": "12.10.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.10.0.tgz",
-      "integrity": "sha512-Y0wPc221xKKW1/4iAFCphkrG2jNR4MjOne3iGn4mcuCaE7Y5EtXL83N8BzRsAht7GYfWVjJ/UeTqEdDKHz39HQ==",
+      "version": "12.11.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.11.0.tgz",
+      "integrity": "sha512-TJE+CCWI26Hwr5Msb9GpQhFLubdYooW0fmlPwTsfiyxmngqc7+SZGLPeIkj2dTSSZSEtpQVzOzvcnzH0o8G7Vw==",
       "dev": true,
       "requires": {
         "@cypress/request": "^2.88.10",

--- a/examples/browser/package.json
+++ b/examples/browser/package.json
@@ -14,7 +14,7 @@
   "license": "ISC",
   "private": true,
   "devDependencies": {
-    "cypress": "12.10.0",
+    "cypress": "12.11.0",
     "image-size": "^1.0.2"
   }
 }

--- a/examples/component-tests/package-lock.json
+++ b/examples/component-tests/package-lock.json
@@ -15,7 +15,7 @@
         "@types/react": "^18.0.26",
         "@types/react-dom": "^18.0.9",
         "@vitejs/plugin-react": "^3.0.0",
-        "cypress": "12.10.0",
+        "cypress": "12.11.0",
         "vite": "^4.0.0"
       }
     },
@@ -1393,9 +1393,9 @@
       "dev": true
     },
     "node_modules/cypress": {
-      "version": "12.10.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.10.0.tgz",
-      "integrity": "sha512-Y0wPc221xKKW1/4iAFCphkrG2jNR4MjOne3iGn4mcuCaE7Y5EtXL83N8BzRsAht7GYfWVjJ/UeTqEdDKHz39HQ==",
+      "version": "12.11.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.11.0.tgz",
+      "integrity": "sha512-TJE+CCWI26Hwr5Msb9GpQhFLubdYooW0fmlPwTsfiyxmngqc7+SZGLPeIkj2dTSSZSEtpQVzOzvcnzH0o8G7Vw==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -4333,9 +4333,9 @@
       "dev": true
     },
     "cypress": {
-      "version": "12.10.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.10.0.tgz",
-      "integrity": "sha512-Y0wPc221xKKW1/4iAFCphkrG2jNR4MjOne3iGn4mcuCaE7Y5EtXL83N8BzRsAht7GYfWVjJ/UeTqEdDKHz39HQ==",
+      "version": "12.11.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.11.0.tgz",
+      "integrity": "sha512-TJE+CCWI26Hwr5Msb9GpQhFLubdYooW0fmlPwTsfiyxmngqc7+SZGLPeIkj2dTSSZSEtpQVzOzvcnzH0o8G7Vw==",
       "dev": true,
       "requires": {
         "@cypress/request": "^2.88.10",

--- a/examples/component-tests/package.json
+++ b/examples/component-tests/package.json
@@ -17,7 +17,7 @@
     "@types/react": "^18.0.26",
     "@types/react-dom": "^18.0.9",
     "@vitejs/plugin-react": "^3.0.0",
-    "cypress": "12.10.0",
+    "cypress": "12.11.0",
     "vite": "^4.0.0"
   }
 }

--- a/examples/config/package-lock.json
+++ b/examples/config/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {
-        "cypress": "12.10.0",
+        "cypress": "12.11.0",
         "serve": "^14.2.0",
         "start-server-and-test": "1.11.5"
       }
@@ -922,9 +922,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "12.10.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.10.0.tgz",
-      "integrity": "sha512-Y0wPc221xKKW1/4iAFCphkrG2jNR4MjOne3iGn4mcuCaE7Y5EtXL83N8BzRsAht7GYfWVjJ/UeTqEdDKHz39HQ==",
+      "version": "12.11.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.11.0.tgz",
+      "integrity": "sha512-TJE+CCWI26Hwr5Msb9GpQhFLubdYooW0fmlPwTsfiyxmngqc7+SZGLPeIkj2dTSSZSEtpQVzOzvcnzH0o8G7Vw==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -3528,9 +3528,9 @@
       }
     },
     "cypress": {
-      "version": "12.10.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.10.0.tgz",
-      "integrity": "sha512-Y0wPc221xKKW1/4iAFCphkrG2jNR4MjOne3iGn4mcuCaE7Y5EtXL83N8BzRsAht7GYfWVjJ/UeTqEdDKHz39HQ==",
+      "version": "12.11.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.11.0.tgz",
+      "integrity": "sha512-TJE+CCWI26Hwr5Msb9GpQhFLubdYooW0fmlPwTsfiyxmngqc7+SZGLPeIkj2dTSSZSEtpQVzOzvcnzH0o8G7Vw==",
       "dev": true,
       "requires": {
         "@cypress/request": "^2.88.10",

--- a/examples/config/package.json
+++ b/examples/config/package.json
@@ -14,7 +14,7 @@
   "license": "ISC",
   "private": true,
   "devDependencies": {
-    "cypress": "12.10.0",
+    "cypress": "12.11.0",
     "serve": "^14.2.0",
     "start-server-and-test": "1.11.5"
   }

--- a/examples/custom-command/package-lock.json
+++ b/examples/custom-command/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {
-        "cypress": "12.10.0",
+        "cypress": "12.11.0",
         "lodash": "4.17.15"
       }
     },
@@ -546,9 +546,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "12.10.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.10.0.tgz",
-      "integrity": "sha512-Y0wPc221xKKW1/4iAFCphkrG2jNR4MjOne3iGn4mcuCaE7Y5EtXL83N8BzRsAht7GYfWVjJ/UeTqEdDKHz39HQ==",
+      "version": "12.11.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.11.0.tgz",
+      "integrity": "sha512-TJE+CCWI26Hwr5Msb9GpQhFLubdYooW0fmlPwTsfiyxmngqc7+SZGLPeIkj2dTSSZSEtpQVzOzvcnzH0o8G7Vw==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -2317,9 +2317,9 @@
       }
     },
     "cypress": {
-      "version": "12.10.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.10.0.tgz",
-      "integrity": "sha512-Y0wPc221xKKW1/4iAFCphkrG2jNR4MjOne3iGn4mcuCaE7Y5EtXL83N8BzRsAht7GYfWVjJ/UeTqEdDKHz39HQ==",
+      "version": "12.11.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.11.0.tgz",
+      "integrity": "sha512-TJE+CCWI26Hwr5Msb9GpQhFLubdYooW0fmlPwTsfiyxmngqc7+SZGLPeIkj2dTSSZSEtpQVzOzvcnzH0o8G7Vw==",
       "dev": true,
       "requires": {
         "@cypress/request": "^2.88.10",

--- a/examples/custom-command/package.json
+++ b/examples/custom-command/package.json
@@ -11,7 +11,7 @@
   "license": "ISC",
   "private": true,
   "devDependencies": {
-    "cypress": "12.10.0",
+    "cypress": "12.11.0",
     "lodash": "4.17.15"
   }
 }

--- a/examples/env/package-lock.json
+++ b/examples/env/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {
-        "cypress": "12.10.0"
+        "cypress": "12.11.0"
       }
     },
     "node_modules/@colors/colors": {
@@ -545,9 +545,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "12.10.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.10.0.tgz",
-      "integrity": "sha512-Y0wPc221xKKW1/4iAFCphkrG2jNR4MjOne3iGn4mcuCaE7Y5EtXL83N8BzRsAht7GYfWVjJ/UeTqEdDKHz39HQ==",
+      "version": "12.11.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.11.0.tgz",
+      "integrity": "sha512-TJE+CCWI26Hwr5Msb9GpQhFLubdYooW0fmlPwTsfiyxmngqc7+SZGLPeIkj2dTSSZSEtpQVzOzvcnzH0o8G7Vw==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -2310,9 +2310,9 @@
       }
     },
     "cypress": {
-      "version": "12.10.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.10.0.tgz",
-      "integrity": "sha512-Y0wPc221xKKW1/4iAFCphkrG2jNR4MjOne3iGn4mcuCaE7Y5EtXL83N8BzRsAht7GYfWVjJ/UeTqEdDKHz39HQ==",
+      "version": "12.11.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.11.0.tgz",
+      "integrity": "sha512-TJE+CCWI26Hwr5Msb9GpQhFLubdYooW0fmlPwTsfiyxmngqc7+SZGLPeIkj2dTSSZSEtpQVzOzvcnzH0o8G7Vw==",
       "dev": true,
       "requires": {
         "@cypress/request": "^2.88.10",

--- a/examples/env/package.json
+++ b/examples/env/package.json
@@ -10,6 +10,6 @@
   "license": "ISC",
   "private": true,
   "devDependencies": {
-    "cypress": "12.10.0"
+    "cypress": "12.11.0"
   }
 }

--- a/examples/firefox/package-lock.json
+++ b/examples/firefox/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.1.0",
       "license": "ISC",
       "devDependencies": {
-        "cypress": "12.10.0",
+        "cypress": "12.11.0",
         "image-size": "^1.0.2"
       }
     },
@@ -546,9 +546,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "12.10.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.10.0.tgz",
-      "integrity": "sha512-Y0wPc221xKKW1/4iAFCphkrG2jNR4MjOne3iGn4mcuCaE7Y5EtXL83N8BzRsAht7GYfWVjJ/UeTqEdDKHz39HQ==",
+      "version": "12.11.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.11.0.tgz",
+      "integrity": "sha512-TJE+CCWI26Hwr5Msb9GpQhFLubdYooW0fmlPwTsfiyxmngqc7+SZGLPeIkj2dTSSZSEtpQVzOzvcnzH0o8G7Vw==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -2335,9 +2335,9 @@
       }
     },
     "cypress": {
-      "version": "12.10.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.10.0.tgz",
-      "integrity": "sha512-Y0wPc221xKKW1/4iAFCphkrG2jNR4MjOne3iGn4mcuCaE7Y5EtXL83N8BzRsAht7GYfWVjJ/UeTqEdDKHz39HQ==",
+      "version": "12.11.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.11.0.tgz",
+      "integrity": "sha512-TJE+CCWI26Hwr5Msb9GpQhFLubdYooW0fmlPwTsfiyxmngqc7+SZGLPeIkj2dTSSZSEtpQVzOzvcnzH0o8G7Vw==",
       "dev": true,
       "requires": {
         "@cypress/request": "^2.88.10",

--- a/examples/firefox/package.json
+++ b/examples/firefox/package.json
@@ -13,7 +13,7 @@
   "license": "ISC",
   "private": true,
   "devDependencies": {
-    "cypress": "12.10.0",
+    "cypress": "12.11.0",
     "image-size": "^1.0.2"
   }
 }

--- a/examples/install-command/package.json
+++ b/examples/install-command/package.json
@@ -9,7 +9,7 @@
   "license": "MIT",
   "private": true,
   "devDependencies": {
-    "cypress": "12.10.0"
+    "cypress": "12.11.0"
   },
   "dependencies": {
     "arg": "5.0.0",

--- a/examples/install-command/yarn.lock
+++ b/examples/install-command/yarn.lock
@@ -308,10 +308,10 @@ cross-spawn@^7.0.0:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
-cypress@12.10.0:
-  version "12.10.0"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-12.10.0.tgz#b6264f77c214d63530ebac2b33c4d099bd40b715"
-  integrity sha512-Y0wPc221xKKW1/4iAFCphkrG2jNR4MjOne3iGn4mcuCaE7Y5EtXL83N8BzRsAht7GYfWVjJ/UeTqEdDKHz39HQ==
+cypress@12.11.0:
+  version "12.11.0"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-12.11.0.tgz#b46dc6a1d0387f59a4b5c6a18cc03884fd61876e"
+  integrity sha512-TJE+CCWI26Hwr5Msb9GpQhFLubdYooW0fmlPwTsfiyxmngqc7+SZGLPeIkj2dTSSZSEtpQVzOzvcnzH0o8G7Vw==
   dependencies:
     "@cypress/request" "^2.88.10"
     "@cypress/xvfb" "^1.2.4"

--- a/examples/install-only/package-lock.json
+++ b/examples/install-only/package-lock.json
@@ -13,7 +13,7 @@
         "debug": "4.2.0"
       },
       "devDependencies": {
-        "cypress": "12.10.0"
+        "cypress": "12.11.0"
       }
     },
     "node_modules/@colors/colors": {
@@ -554,9 +554,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "12.10.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.10.0.tgz",
-      "integrity": "sha512-Y0wPc221xKKW1/4iAFCphkrG2jNR4MjOne3iGn4mcuCaE7Y5EtXL83N8BzRsAht7GYfWVjJ/UeTqEdDKHz39HQ==",
+      "version": "12.11.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.11.0.tgz",
+      "integrity": "sha512-TJE+CCWI26Hwr5Msb9GpQhFLubdYooW0fmlPwTsfiyxmngqc7+SZGLPeIkj2dTSSZSEtpQVzOzvcnzH0o8G7Vw==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -2340,9 +2340,9 @@
       }
     },
     "cypress": {
-      "version": "12.10.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.10.0.tgz",
-      "integrity": "sha512-Y0wPc221xKKW1/4iAFCphkrG2jNR4MjOne3iGn4mcuCaE7Y5EtXL83N8BzRsAht7GYfWVjJ/UeTqEdDKHz39HQ==",
+      "version": "12.11.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.11.0.tgz",
+      "integrity": "sha512-TJE+CCWI26Hwr5Msb9GpQhFLubdYooW0fmlPwTsfiyxmngqc7+SZGLPeIkj2dTSSZSEtpQVzOzvcnzH0o8G7Vw==",
       "dev": true,
       "requires": {
         "@cypress/request": "^2.88.10",

--- a/examples/install-only/package.json
+++ b/examples/install-only/package.json
@@ -13,6 +13,6 @@
     "debug": "4.2.0"
   },
   "devDependencies": {
-    "cypress": "12.10.0"
+    "cypress": "12.11.0"
   }
 }

--- a/examples/nextjs/package-lock.json
+++ b/examples/nextjs/package-lock.json
@@ -13,7 +13,7 @@
         "react-dom": "18.2.0"
       },
       "devDependencies": {
-        "cypress": "12.10.0"
+        "cypress": "12.11.0"
       }
     },
     "node_modules/@colors/colors": {
@@ -732,9 +732,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "12.10.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.10.0.tgz",
-      "integrity": "sha512-Y0wPc221xKKW1/4iAFCphkrG2jNR4MjOne3iGn4mcuCaE7Y5EtXL83N8BzRsAht7GYfWVjJ/UeTqEdDKHz39HQ==",
+      "version": "12.11.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.11.0.tgz",
+      "integrity": "sha512-TJE+CCWI26Hwr5Msb9GpQhFLubdYooW0fmlPwTsfiyxmngqc7+SZGLPeIkj2dTSSZSEtpQVzOzvcnzH0o8G7Vw==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {

--- a/examples/nextjs/package.json
+++ b/examples/nextjs/package.json
@@ -15,6 +15,6 @@
     "react-dom": "18.2.0"
   },
   "devDependencies": {
-    "cypress": "12.10.0"
+    "cypress": "12.11.0"
   }
 }

--- a/examples/node-versions/package-lock.json
+++ b/examples/node-versions/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {
-        "cypress": "12.10.0"
+        "cypress": "12.11.0"
       }
     },
     "node_modules/@colors/colors": {
@@ -545,9 +545,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "12.10.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.10.0.tgz",
-      "integrity": "sha512-Y0wPc221xKKW1/4iAFCphkrG2jNR4MjOne3iGn4mcuCaE7Y5EtXL83N8BzRsAht7GYfWVjJ/UeTqEdDKHz39HQ==",
+      "version": "12.11.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.11.0.tgz",
+      "integrity": "sha512-TJE+CCWI26Hwr5Msb9GpQhFLubdYooW0fmlPwTsfiyxmngqc7+SZGLPeIkj2dTSSZSEtpQVzOzvcnzH0o8G7Vw==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -2310,9 +2310,9 @@
       }
     },
     "cypress": {
-      "version": "12.10.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.10.0.tgz",
-      "integrity": "sha512-Y0wPc221xKKW1/4iAFCphkrG2jNR4MjOne3iGn4mcuCaE7Y5EtXL83N8BzRsAht7GYfWVjJ/UeTqEdDKHz39HQ==",
+      "version": "12.11.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.11.0.tgz",
+      "integrity": "sha512-TJE+CCWI26Hwr5Msb9GpQhFLubdYooW0fmlPwTsfiyxmngqc7+SZGLPeIkj2dTSSZSEtpQVzOzvcnzH0o8G7Vw==",
       "dev": true,
       "requires": {
         "@cypress/request": "^2.88.10",

--- a/examples/node-versions/package.json
+++ b/examples/node-versions/package.json
@@ -10,6 +10,6 @@
   "license": "ISC",
   "private": true,
   "devDependencies": {
-    "cypress": "12.10.0"
+    "cypress": "12.11.0"
   }
 }

--- a/examples/quiet/package-lock.json
+++ b/examples/quiet/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {
-        "cypress": "12.10.0",
+        "cypress": "12.11.0",
         "image-size": "0.8.3"
       }
     },
@@ -546,9 +546,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "12.10.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.10.0.tgz",
-      "integrity": "sha512-Y0wPc221xKKW1/4iAFCphkrG2jNR4MjOne3iGn4mcuCaE7Y5EtXL83N8BzRsAht7GYfWVjJ/UeTqEdDKHz39HQ==",
+      "version": "12.11.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.11.0.tgz",
+      "integrity": "sha512-TJE+CCWI26Hwr5Msb9GpQhFLubdYooW0fmlPwTsfiyxmngqc7+SZGLPeIkj2dTSSZSEtpQVzOzvcnzH0o8G7Vw==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -2335,9 +2335,9 @@
       }
     },
     "cypress": {
-      "version": "12.10.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.10.0.tgz",
-      "integrity": "sha512-Y0wPc221xKKW1/4iAFCphkrG2jNR4MjOne3iGn4mcuCaE7Y5EtXL83N8BzRsAht7GYfWVjJ/UeTqEdDKHz39HQ==",
+      "version": "12.11.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.11.0.tgz",
+      "integrity": "sha512-TJE+CCWI26Hwr5Msb9GpQhFLubdYooW0fmlPwTsfiyxmngqc7+SZGLPeIkj2dTSSZSEtpQVzOzvcnzH0o8G7Vw==",
       "dev": true,
       "requires": {
         "@cypress/request": "^2.88.10",

--- a/examples/quiet/package.json
+++ b/examples/quiet/package.json
@@ -11,7 +11,7 @@
   "license": "ISC",
   "private": true,
   "devDependencies": {
-    "cypress": "12.10.0",
+    "cypress": "12.11.0",
     "image-size": "0.8.3"
   }
 }

--- a/examples/recording/package-lock.json
+++ b/examples/recording/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {
-        "cypress": "12.10.0"
+        "cypress": "12.11.0"
       }
     },
     "node_modules/@colors/colors": {
@@ -545,9 +545,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "12.10.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.10.0.tgz",
-      "integrity": "sha512-Y0wPc221xKKW1/4iAFCphkrG2jNR4MjOne3iGn4mcuCaE7Y5EtXL83N8BzRsAht7GYfWVjJ/UeTqEdDKHz39HQ==",
+      "version": "12.11.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.11.0.tgz",
+      "integrity": "sha512-TJE+CCWI26Hwr5Msb9GpQhFLubdYooW0fmlPwTsfiyxmngqc7+SZGLPeIkj2dTSSZSEtpQVzOzvcnzH0o8G7Vw==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -2310,9 +2310,9 @@
       }
     },
     "cypress": {
-      "version": "12.10.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.10.0.tgz",
-      "integrity": "sha512-Y0wPc221xKKW1/4iAFCphkrG2jNR4MjOne3iGn4mcuCaE7Y5EtXL83N8BzRsAht7GYfWVjJ/UeTqEdDKHz39HQ==",
+      "version": "12.11.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.11.0.tgz",
+      "integrity": "sha512-TJE+CCWI26Hwr5Msb9GpQhFLubdYooW0fmlPwTsfiyxmngqc7+SZGLPeIkj2dTSSZSEtpQVzOzvcnzH0o8G7Vw==",
       "dev": true,
       "requires": {
         "@cypress/request": "^2.88.10",

--- a/examples/recording/package.json
+++ b/examples/recording/package.json
@@ -11,6 +11,6 @@
   "license": "ISC",
   "private": true,
   "devDependencies": {
-    "cypress": "12.10.0"
+    "cypress": "12.11.0"
   }
 }

--- a/examples/start-and-yarn-workspaces/workspace-1/package.json
+++ b/examples/start-and-yarn-workspaces/workspace-1/package.json
@@ -12,7 +12,7 @@
   "license": "ISC",
   "private": true,
   "devDependencies": {
-    "cypress": "12.10.0",
+    "cypress": "12.11.0",
     "serve": "^14.2.0"
   }
 }

--- a/examples/start-and-yarn-workspaces/workspace-2/package.json
+++ b/examples/start-and-yarn-workspaces/workspace-2/package.json
@@ -12,7 +12,7 @@
   "license": "ISC",
   "private": true,
   "devDependencies": {
-    "cypress": "12.10.0",
+    "cypress": "12.11.0",
     "serve": "^14.2.0"
   }
 }

--- a/examples/start-and-yarn-workspaces/yarn.lock
+++ b/examples/start-and-yarn-workspaces/yarn.lock
@@ -436,10 +436,10 @@ cross-spawn@^7.0.0, cross-spawn@^7.0.3:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
-cypress@12.10.0:
-  version "12.10.0"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-12.10.0.tgz#b6264f77c214d63530ebac2b33c4d099bd40b715"
-  integrity sha512-Y0wPc221xKKW1/4iAFCphkrG2jNR4MjOne3iGn4mcuCaE7Y5EtXL83N8BzRsAht7GYfWVjJ/UeTqEdDKHz39HQ==
+cypress@12.11.0:
+  version "12.11.0"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-12.11.0.tgz#b46dc6a1d0387f59a4b5c6a18cc03884fd61876e"
+  integrity sha512-TJE+CCWI26Hwr5Msb9GpQhFLubdYooW0fmlPwTsfiyxmngqc7+SZGLPeIkj2dTSSZSEtpQVzOzvcnzH0o8G7Vw==
   dependencies:
     "@cypress/request" "^2.88.10"
     "@cypress/xvfb" "^1.2.4"

--- a/examples/start/package-lock.json
+++ b/examples/start/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {
-        "cypress": "12.10.0",
+        "cypress": "12.11.0",
         "serve": "^14.2.0"
       }
     },
@@ -872,9 +872,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "12.10.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.10.0.tgz",
-      "integrity": "sha512-Y0wPc221xKKW1/4iAFCphkrG2jNR4MjOne3iGn4mcuCaE7Y5EtXL83N8BzRsAht7GYfWVjJ/UeTqEdDKHz39HQ==",
+      "version": "12.11.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.11.0.tgz",
+      "integrity": "sha512-TJE+CCWI26Hwr5Msb9GpQhFLubdYooW0fmlPwTsfiyxmngqc7+SZGLPeIkj2dTSSZSEtpQVzOzvcnzH0o8G7Vw==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -3209,9 +3209,9 @@
       }
     },
     "cypress": {
-      "version": "12.10.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.10.0.tgz",
-      "integrity": "sha512-Y0wPc221xKKW1/4iAFCphkrG2jNR4MjOne3iGn4mcuCaE7Y5EtXL83N8BzRsAht7GYfWVjJ/UeTqEdDKHz39HQ==",
+      "version": "12.11.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.11.0.tgz",
+      "integrity": "sha512-TJE+CCWI26Hwr5Msb9GpQhFLubdYooW0fmlPwTsfiyxmngqc7+SZGLPeIkj2dTSSZSEtpQVzOzvcnzH0o8G7Vw==",
       "dev": true,
       "requires": {
         "@cypress/request": "^2.88.10",

--- a/examples/start/package.json
+++ b/examples/start/package.json
@@ -13,7 +13,7 @@
   "license": "ISC",
   "private": true,
   "devDependencies": {
-    "cypress": "12.10.0",
+    "cypress": "12.11.0",
     "serve": "^14.2.0"
   }
 }

--- a/examples/wait-on-vite/package-lock.json
+++ b/examples/wait-on-vite/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.0.0",
       "license": "ISC",
       "devDependencies": {
-        "cypress": "12.10.0",
+        "cypress": "12.11.0",
         "vite": "^4.0.0"
       }
     },
@@ -898,9 +898,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "12.10.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.10.0.tgz",
-      "integrity": "sha512-Y0wPc221xKKW1/4iAFCphkrG2jNR4MjOne3iGn4mcuCaE7Y5EtXL83N8BzRsAht7GYfWVjJ/UeTqEdDKHz39HQ==",
+      "version": "12.11.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.11.0.tgz",
+      "integrity": "sha512-TJE+CCWI26Hwr5Msb9GpQhFLubdYooW0fmlPwTsfiyxmngqc7+SZGLPeIkj2dTSSZSEtpQVzOzvcnzH0o8G7Vw==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -3031,9 +3031,9 @@
       }
     },
     "cypress": {
-      "version": "12.10.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.10.0.tgz",
-      "integrity": "sha512-Y0wPc221xKKW1/4iAFCphkrG2jNR4MjOne3iGn4mcuCaE7Y5EtXL83N8BzRsAht7GYfWVjJ/UeTqEdDKHz39HQ==",
+      "version": "12.11.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.11.0.tgz",
+      "integrity": "sha512-TJE+CCWI26Hwr5Msb9GpQhFLubdYooW0fmlPwTsfiyxmngqc7+SZGLPeIkj2dTSSZSEtpQVzOzvcnzH0o8G7Vw==",
       "dev": true,
       "requires": {
         "@cypress/request": "^2.88.10",

--- a/examples/wait-on-vite/package.json
+++ b/examples/wait-on-vite/package.json
@@ -12,7 +12,7 @@
   "license": "ISC",
   "private": true,
   "devDependencies": {
-    "cypress": "12.10.0",
+    "cypress": "12.11.0",
     "vite": "^4.0.0"
   }
 }

--- a/examples/wait-on/package-lock.json
+++ b/examples/wait-on/package-lock.json
@@ -13,7 +13,7 @@
         "debug": "4.2.0"
       },
       "devDependencies": {
-        "cypress": "12.10.0"
+        "cypress": "12.11.0"
       }
     },
     "node_modules/@colors/colors": {
@@ -554,9 +554,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "12.10.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.10.0.tgz",
-      "integrity": "sha512-Y0wPc221xKKW1/4iAFCphkrG2jNR4MjOne3iGn4mcuCaE7Y5EtXL83N8BzRsAht7GYfWVjJ/UeTqEdDKHz39HQ==",
+      "version": "12.11.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.11.0.tgz",
+      "integrity": "sha512-TJE+CCWI26Hwr5Msb9GpQhFLubdYooW0fmlPwTsfiyxmngqc7+SZGLPeIkj2dTSSZSEtpQVzOzvcnzH0o8G7Vw==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -2340,9 +2340,9 @@
       }
     },
     "cypress": {
-      "version": "12.10.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.10.0.tgz",
-      "integrity": "sha512-Y0wPc221xKKW1/4iAFCphkrG2jNR4MjOne3iGn4mcuCaE7Y5EtXL83N8BzRsAht7GYfWVjJ/UeTqEdDKHz39HQ==",
+      "version": "12.11.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.11.0.tgz",
+      "integrity": "sha512-TJE+CCWI26Hwr5Msb9GpQhFLubdYooW0fmlPwTsfiyxmngqc7+SZGLPeIkj2dTSSZSEtpQVzOzvcnzH0o8G7Vw==",
       "dev": true,
       "requires": {
         "@cypress/request": "^2.88.10",

--- a/examples/wait-on/package.json
+++ b/examples/wait-on/package.json
@@ -22,6 +22,6 @@
     "debug": "4.2.0"
   },
   "devDependencies": {
-    "cypress": "12.10.0"
+    "cypress": "12.11.0"
   }
 }

--- a/examples/webpack/package-lock.json
+++ b/examples/webpack/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {
-        "cypress": "12.10.0",
+        "cypress": "12.11.0",
         "webpack": "^5.76.1",
         "webpack-cli": "^5.0.1",
         "webpack-dev-server": "^4.12.0"
@@ -1428,9 +1428,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "12.10.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.10.0.tgz",
-      "integrity": "sha512-Y0wPc221xKKW1/4iAFCphkrG2jNR4MjOne3iGn4mcuCaE7Y5EtXL83N8BzRsAht7GYfWVjJ/UeTqEdDKHz39HQ==",
+      "version": "12.11.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.11.0.tgz",
+      "integrity": "sha512-TJE+CCWI26Hwr5Msb9GpQhFLubdYooW0fmlPwTsfiyxmngqc7+SZGLPeIkj2dTSSZSEtpQVzOzvcnzH0o8G7Vw==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -6097,9 +6097,9 @@
       }
     },
     "cypress": {
-      "version": "12.10.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.10.0.tgz",
-      "integrity": "sha512-Y0wPc221xKKW1/4iAFCphkrG2jNR4MjOne3iGn4mcuCaE7Y5EtXL83N8BzRsAht7GYfWVjJ/UeTqEdDKHz39HQ==",
+      "version": "12.11.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.11.0.tgz",
+      "integrity": "sha512-TJE+CCWI26Hwr5Msb9GpQhFLubdYooW0fmlPwTsfiyxmngqc7+SZGLPeIkj2dTSSZSEtpQVzOzvcnzH0o8G7Vw==",
       "dev": true,
       "requires": {
         "@cypress/request": "^2.88.10",

--- a/examples/webpack/package.json
+++ b/examples/webpack/package.json
@@ -9,7 +9,7 @@
   "license": "ISC",
   "private": true,
   "devDependencies": {
-    "cypress": "12.10.0",
+    "cypress": "12.11.0",
     "webpack": "^5.76.1",
     "webpack-cli": "^5.0.1",
     "webpack-dev-server": "^4.12.0"

--- a/examples/yarn-classic/package.json
+++ b/examples/yarn-classic/package.json
@@ -8,6 +8,6 @@
   "license": "MIT",
   "private": true,
   "devDependencies": {
-    "cypress": "12.10.0"
+    "cypress": "12.11.0"
   }
 }

--- a/examples/yarn-classic/yarn.lock
+++ b/examples/yarn-classic/yarn.lock
@@ -303,10 +303,10 @@ cross-spawn@^7.0.0:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
-cypress@12.10.0:
-  version "12.10.0"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-12.10.0.tgz#b6264f77c214d63530ebac2b33c4d099bd40b715"
-  integrity sha512-Y0wPc221xKKW1/4iAFCphkrG2jNR4MjOne3iGn4mcuCaE7Y5EtXL83N8BzRsAht7GYfWVjJ/UeTqEdDKHz39HQ==
+cypress@12.11.0:
+  version "12.11.0"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-12.11.0.tgz#b46dc6a1d0387f59a4b5c6a18cc03884fd61876e"
+  integrity sha512-TJE+CCWI26Hwr5Msb9GpQhFLubdYooW0fmlPwTsfiyxmngqc7+SZGLPeIkj2dTSSZSEtpQVzOzvcnzH0o8G7Vw==
   dependencies:
     "@cypress/request" "^2.88.10"
     "@cypress/xvfb" "^1.2.4"

--- a/examples/yarn-modern/package.json
+++ b/examples/yarn-modern/package.json
@@ -8,7 +8,7 @@
   "license": "MIT",
   "private": true,
   "devDependencies": {
-    "cypress": "12.10.0"
+    "cypress": "12.11.0"
   },
   "packageManager": "yarn@3.5.0"
 }

--- a/examples/yarn-modern/yarn.lock
+++ b/examples/yarn-modern/yarn.lock
@@ -414,9 +414,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cypress@npm:12.10.0":
-  version: 12.10.0
-  resolution: "cypress@npm:12.10.0"
+"cypress@npm:12.11.0":
+  version: 12.11.0
+  resolution: "cypress@npm:12.11.0"
   dependencies:
     "@cypress/request": ^2.88.10
     "@cypress/xvfb": ^1.2.4
@@ -462,7 +462,7 @@ __metadata:
     yauzl: ^2.10.0
   bin:
     cypress: bin/cypress
-  checksum: 50eaae129df3bd15416113105a6f04d13949859af4cca7f0fc36c8b0e756bf3f6e058f43df574d92abe350c282872dec62ea22da8dc9b6528c827c0976fb14e0
+  checksum: 56e5ebaec59dffca5d19704f2b2674cbb0002f20050c1d624217ede157c528757f58ad42f0899fc67c32c61d5461eef5e2a3a99a6a52b77b152362a025a22599
   languageName: node
   linkType: hard
 
@@ -563,7 +563,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "example-yarn-modern@workspace:."
   dependencies:
-    cypress: 12.10.0
+    cypress: 12.11.0
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
This PR updates the Cypress 12.x [examples](https://github.com/cypress-io/github-action/tree/master/examples) to [Cypress 12.11.0](https://docs.cypress.io/guides/references/changelog#12-11-0) released Apr 26, 2023.