### PR TITLE
docs: add pnpm and Yarn to intro

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # cypress-io/github-action [![Action status][ci-badge]][ci-workflow] [![cypress][cloud-badge]][cloud-project] [![renovate-app badge][renovate-badge]][renovate-bot]
 
- > [GitHub Action](https://docs.github.com/en/actions) for running [Cypress](https://www.cypress.io) end-to-end and component tests. Includes npm installation, custom caching and lots of configuration options.
+ > [GitHub Action](https://docs.github.com/en/actions) for running [Cypress](https://www.cypress.io) end-to-end and component tests. Includes npm, pnpm and Yarn installation, custom caching and lots of configuration options.
 
 ## Examples
 


### PR DESCRIPTION
This PR adds [pnpm](https://pnpm.io/) and [Yarn](https://classic.yarnpkg.com/) to the introduction in the [README](https://github.com/cypress-io/github-action/blob/master/README.md) file.

It respects the product naming (lower case / mixed case) as defined by the products themselves:

- [npm](https://docs.npmjs.com/)
- [pnpm](https://pnpm.io/)
- [Yarn](https://classic.yarnpkg.com/)

The PR replaces the previous https://github.com/cypress-io/github-action/pull/880 which I closed after realizing that there were some other documentation prerequisites necessary for consistency which have now been dealt with by:

- #881
- #885
