### PR TITLE
chore(deps): update examples/custom-command dependencies

### DIFF
--- a/examples/custom-command/package-lock.json
+++ b/examples/custom-command/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "devDependencies": {
         "cypress": "12.11.0",
-        "lodash": "4.17.15"
+        "lodash": "4.17.21"
       }
     },
     "node_modules/@colors/colors": {
@@ -601,12 +601,6 @@
       "engines": {
         "node": "^14.0.0 || ^16.0.0 || >=18.0.0"
       }
-    },
-    "node_modules/cypress/node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
     },
     "node_modules/dashdash": {
       "version": "1.14.1",
@@ -1216,9 +1210,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
     "node_modules/lodash.once": {
@@ -2364,14 +2358,6 @@
         "tmp": "~0.2.1",
         "untildify": "^4.0.0",
         "yauzl": "^2.10.0"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.21",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-          "dev": true
-        }
       }
     },
     "dashdash": {
@@ -2822,9 +2808,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
     "lodash.once": {

--- a/examples/custom-command/package.json
+++ b/examples/custom-command/package.json
@@ -12,6 +12,6 @@
   "private": true,
   "devDependencies": {
     "cypress": "12.11.0",
-    "lodash": "4.17.15"
+    "lodash": "4.17.21"
   }
 }


### PR DESCRIPTION
This PR updates [lodash](https://www.npmjs.com/package/lodash) to [v4.17.21](https://github.com/lodash/lodash/wiki/Changelog#v41721) in [examples/custom-command](https://github.com/cypress-io/github-action/tree/master/examples/custom-command).

## Issue

The current configuration reports a vulnerability. To reproduce:

```text
$ cd examples/config
$ npm ci

added 173 packages, and audited 174 packages in 7s

35 packages are looking for funding
  run `npm fund` for details

1 high severity vulnerability

To address all issues, run:
  npm audit fix --force

```

## Verification

After applying the changes from this PR:

### Local verification

Execute:

```bash
npm ci
```

and confirm that 0 vulnerabilities are reported. Then execute

```bash
npm run custom-test
```

and confirm that the Cypress test completes successfully.

### GitHub verification

Confirm that

https://github.com/cypress-io/github-action/actions/workflows/example-custom-command.yml

reports success.
