### PR TITLE
misc: set author to Cypress-io

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,6 @@
 # https://help.github.com/en/actions/automating-your-workflow-with-github-actions/metadata-syntax-for-github-actions
 name: 'Cypress.io'
-description: 'GitHub Action for running Cypress end-to-end tests'
+description: 'GitHub Action for running Cypress end-to-end and component tests'
 author: 'Cypress-io'
 inputs:
   record:

--- a/action.yml
+++ b/action.yml
@@ -1,7 +1,7 @@
 # https://help.github.com/en/actions/automating-your-workflow-with-github-actions/metadata-syntax-for-github-actions
 name: 'Cypress.io'
 description: 'GitHub Action for running Cypress end-to-end tests'
-author: 'Gleb Bahmutov'
+author: 'Cypress-io'
 inputs:
   record:
     description: 'Sends test results to Cypress Dashboard'

--- a/examples/basic-pnpm/package.json
+++ b/examples/basic-pnpm/package.json
@@ -6,7 +6,6 @@
   "scripts": {
     "test": "cypress run"
   },
-  "author": "",
   "license": "ISC",
   "private": true,
   "devDependencies": {

--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -6,7 +6,6 @@
   "scripts": {
     "test": "cypress run"
   },
-  "author": "",
   "license": "ISC",
   "private": true,
   "devDependencies": {

--- a/examples/browser/package.json
+++ b/examples/browser/package.json
@@ -10,7 +10,6 @@
     "cy:run:chrome": "cypress run --browser chrome",
     "cy:run:edge": "cypress run --browser edge"
   },
-  "author": "",
   "license": "ISC",
   "private": true,
   "devDependencies": {

--- a/examples/config/package.json
+++ b/examples/config/package.json
@@ -10,7 +10,6 @@
     "cy:open": "cypress open",
     "dev": "CYPRESS_baseUrl=http://localhost:3333 start-test 3333 cy:open"
   },
-  "author": "Gleb Bahmutov <gleb.bahmutov@gmail.com>",
   "license": "ISC",
   "private": true,
   "devDependencies": {

--- a/examples/custom-command/package.json
+++ b/examples/custom-command/package.json
@@ -7,7 +7,6 @@
     "test": "cypress run",
     "custom-test": "node ."
   },
-  "author": "",
   "license": "ISC",
   "private": true,
   "devDependencies": {

--- a/examples/env/package.json
+++ b/examples/env/package.json
@@ -6,7 +6,6 @@
   "scripts": {
     "test": "cypress run"
   },
-  "author": "",
   "license": "ISC",
   "private": true,
   "devDependencies": {

--- a/examples/firefox/package.json
+++ b/examples/firefox/package.json
@@ -9,7 +9,6 @@
     "cy:run": "cypress run",
     "cy:run:firefox": "cypress run --browser firefox"
   },
-  "author": "",
   "license": "ISC",
   "private": true,
   "devDependencies": {

--- a/examples/install-command/package.json
+++ b/examples/install-command/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "test": "cypress run"
   },
-  "author": "Gleb Bahmutov <gleb.bahmutov@gmail.com>",
   "license": "MIT",
   "private": true,
   "devDependencies": {

--- a/examples/install-only/package.json
+++ b/examples/install-only/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "test": "cypress run"
   },
-  "author": "Gleb Bahmutov <gleb.bahmutov@gmail.com>",
   "license": "MIT",
   "private": true,
   "dependencies": {

--- a/examples/node-versions/package.json
+++ b/examples/node-versions/package.json
@@ -6,7 +6,6 @@
   "scripts": {
     "test": "cypress run"
   },
-  "author": "",
   "license": "ISC",
   "private": true,
   "devDependencies": {

--- a/examples/quiet/package.json
+++ b/examples/quiet/package.json
@@ -7,7 +7,6 @@
     "test": "cypress run",
     "info": "cypress info"
   },
-  "author": "",
   "license": "ISC",
   "private": true,
   "devDependencies": {

--- a/examples/recording/package.json
+++ b/examples/recording/package.json
@@ -7,7 +7,6 @@
     "test": "cypress run",
     "cy:open": "cypress open"
   },
-  "author": "",
   "license": "ISC",
   "private": true,
   "devDependencies": {

--- a/examples/start-and-yarn-workspaces/workspace-1/package.json
+++ b/examples/start-and-yarn-workspaces/workspace-1/package.json
@@ -8,7 +8,6 @@
     "build": "echo building ... server ... done!",
     "start": "serve -p 5000 public"
   },
-  "author": "",
   "license": "ISC",
   "private": true,
   "devDependencies": {

--- a/examples/start-and-yarn-workspaces/workspace-2/package.json
+++ b/examples/start-and-yarn-workspaces/workspace-2/package.json
@@ -8,7 +8,6 @@
     "build": "echo building ... server ... done!",
     "start": "serve -p 5000 public"
   },
-  "author": "",
   "license": "ISC",
   "private": true,
   "devDependencies": {

--- a/examples/start/package.json
+++ b/examples/start/package.json
@@ -9,7 +9,6 @@
     "start": "serve public",
     "start2": "serve -p 8000 public"
   },
-  "author": "",
   "license": "ISC",
   "private": true,
   "devDependencies": {

--- a/examples/v9/basic-pnpm/package.json
+++ b/examples/v9/basic-pnpm/package.json
@@ -6,7 +6,6 @@
   "scripts": {
     "test": "cypress run"
   },
-  "author": "",
   "license": "ISC",
   "private": true,
   "devDependencies": {

--- a/examples/v9/basic/package.json
+++ b/examples/v9/basic/package.json
@@ -6,7 +6,6 @@
   "scripts": {
     "test": "cypress run"
   },
-  "author": "",
   "license": "ISC",
   "private": true,
   "devDependencies": {

--- a/examples/v9/browser/package.json
+++ b/examples/v9/browser/package.json
@@ -10,7 +10,6 @@
     "cy:run:chrome": "cypress run --browser chrome",
     "cy:run:edge": "cypress run --browser edge"
   },
-  "author": "",
   "license": "ISC",
   "private": true,
   "devDependencies": {

--- a/examples/v9/config/package.json
+++ b/examples/v9/config/package.json
@@ -10,7 +10,6 @@
     "cy:open": "cypress open",
     "dev": "CYPRESS_baseUrl=http://localhost:3333 start-test 3333 cy:open"
   },
-  "author": "Gleb Bahmutov <gleb.bahmutov@gmail.com>",
   "license": "ISC",
   "private": true,
   "devDependencies": {

--- a/examples/v9/custom-command/package.json
+++ b/examples/v9/custom-command/package.json
@@ -7,7 +7,6 @@
     "test": "cypress run",
     "custom-test": "node ."
   },
-  "author": "",
   "license": "ISC",
   "private": true,
   "devDependencies": {

--- a/examples/v9/env/package.json
+++ b/examples/v9/env/package.json
@@ -6,7 +6,6 @@
   "scripts": {
     "test": "cypress run"
   },
-  "author": "",
   "license": "ISC",
   "private": true,
   "devDependencies": {

--- a/examples/v9/install-command/package.json
+++ b/examples/v9/install-command/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "test": "cypress run"
   },
-  "author": "Gleb Bahmutov <gleb.bahmutov@gmail.com>",
   "license": "MIT",
   "private": true,
   "devDependencies": {

--- a/examples/v9/install-only/package.json
+++ b/examples/v9/install-only/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "test": "cypress run"
   },
-  "author": "Gleb Bahmutov <gleb.bahmutov@gmail.com>",
   "license": "MIT",
   "private": true,
   "devDependencies": {

--- a/examples/v9/node-versions/package.json
+++ b/examples/v9/node-versions/package.json
@@ -6,7 +6,6 @@
   "scripts": {
     "test": "cypress run"
   },
-  "author": "",
   "license": "ISC",
   "private": true,
   "devDependencies": {

--- a/examples/v9/quiet/package.json
+++ b/examples/v9/quiet/package.json
@@ -7,7 +7,6 @@
     "test": "cypress run",
     "info": "cypress info"
   },
-  "author": "",
   "license": "ISC",
   "private": true,
   "devDependencies": {

--- a/examples/v9/recording/package.json
+++ b/examples/v9/recording/package.json
@@ -7,7 +7,6 @@
     "test": "cypress run",
     "cy:open": "cypress open"
   },
-  "author": "",
   "license": "ISC",
   "private": true,
   "devDependencies": {

--- a/examples/v9/start-and-yarn-workspaces/workspace-1/package.json
+++ b/examples/v9/start-and-yarn-workspaces/workspace-1/package.json
@@ -8,7 +8,6 @@
     "build": "echo building ... server ... done!",
     "start": "serve -p 5000 public"
   },
-  "author": "",
   "license": "ISC",
   "private": true,
   "devDependencies": {

--- a/examples/v9/start-and-yarn-workspaces/workspace-2/package.json
+++ b/examples/v9/start-and-yarn-workspaces/workspace-2/package.json
@@ -8,7 +8,6 @@
     "build": "echo building ... server ... done!",
     "start": "serve -p 5000 public"
   },
-  "author": "",
   "license": "ISC",
   "private": true,
   "devDependencies": {

--- a/examples/v9/start/package.json
+++ b/examples/v9/start/package.json
@@ -9,7 +9,6 @@
     "start": "serve public",
     "start2": "serve -p 8000 public"
   },
-  "author": "",
   "license": "ISC",
   "private": true,
   "devDependencies": {

--- a/examples/v9/wait-on-vite/package.json
+++ b/examples/v9/wait-on-vite/package.json
@@ -8,7 +8,6 @@
     "build": "vite build",
     "preview": "vite preview"
   },
-  "author": "",
   "license": "ISC",
   "private": true,
   "devDependencies": {

--- a/examples/v9/wait-on/package.json
+++ b/examples/v9/wait-on/package.json
@@ -14,7 +14,6 @@
     "start3-after-200-seconds": "node ./index3 --delay 200",
     "start4": "node ./index4"
   },
-  "author": "",
   "license": "ISC",
   "private": true,
   "devDependencies": {

--- a/examples/wait-on-vite/package.json
+++ b/examples/wait-on-vite/package.json
@@ -8,7 +8,6 @@
     "build": "vite build",
     "preview": "vite preview"
   },
-  "author": "",
   "license": "ISC",
   "private": true,
   "devDependencies": {

--- a/examples/wait-on/package.json
+++ b/examples/wait-on/package.json
@@ -14,7 +14,6 @@
     "start3-after-200-seconds": "node ./index3 --delay 200",
     "start4": "node ./index4"
   },
-  "author": "",
   "license": "ISC",
   "private": true,
   "dependencies": {


### PR DESCRIPTION
This PR sets the `author` in [action.yml](https://github.com/cypress-io/github-action/blob/master/action.yml) to `Cypress-io` to match the `author` defined in https://github.com/cypress-io/github-action/blob/ed0e96d54f2fb0f0d95cdff0f63f12f1426219e1/package.json#L28

It removes any

- [author field](https://docs.npmjs.com/cli/v9/configuring-npm/package-json#people-fields-author-contributors)

from `package.json` files in the [examples](https://github.com/cypress-io/github-action/tree/master/examples) sub-directories.

The `author` field is defined at the top-level and applies to the whole repository, including the [examples](https://github.com/cypress-io/github-action/tree/master/examples) sub-directories.

The `package.json` files for each of the examples, for instance [examples/basic/package.json](https://github.com/cypress-io/github-action/blob/master/examples/basic/package.json), are set with `"private": true` indicating that they are not intended for publication.

In some cases the `author` field in the [examples](https://github.com/cypress-io/github-action/tree/master/examples) sub-directories contained conflicting information compared to the top-level `author` field, or the field was defined in an individual examples' `package.json` and left empty. This PR ensures consistency throughout the repository.
