### PR TITLE
misc: remove license field from examples

### DIFF
--- a/examples/basic-pnpm/package.json
+++ b/examples/basic-pnpm/package.json
@@ -6,7 +6,6 @@
   "scripts": {
     "test": "cypress run"
   },
-  "license": "ISC",
   "private": true,
   "devDependencies": {
     "cypress": "12.11.0"

--- a/examples/basic/package-lock.json
+++ b/examples/basic/package-lock.json
@@ -7,7 +7,6 @@
     "": {
       "name": "example-basic",
       "version": "1.0.0",
-      "license": "ISC",
       "devDependencies": {
         "cypress": "12.11.0"
       }

--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -6,7 +6,6 @@
   "scripts": {
     "test": "cypress run"
   },
-  "license": "ISC",
   "private": true,
   "devDependencies": {
     "cypress": "12.11.0"

--- a/examples/browser/package-lock.json
+++ b/examples/browser/package-lock.json
@@ -7,7 +7,6 @@
     "": {
       "name": "example-browser",
       "version": "1.1.0",
-      "license": "ISC",
       "devDependencies": {
         "cypress": "12.11.0",
         "image-size": "^1.0.2"

--- a/examples/browser/package.json
+++ b/examples/browser/package.json
@@ -10,7 +10,6 @@
     "cy:run:chrome": "cypress run --browser chrome",
     "cy:run:edge": "cypress run --browser edge"
   },
-  "license": "ISC",
   "private": true,
   "devDependencies": {
     "cypress": "12.11.0",

--- a/examples/config/package-lock.json
+++ b/examples/config/package-lock.json
@@ -7,7 +7,6 @@
     "": {
       "name": "example-config",
       "version": "1.0.0",
-      "license": "ISC",
       "devDependencies": {
         "cypress": "12.11.0",
         "serve": "^14.2.0",

--- a/examples/config/package.json
+++ b/examples/config/package.json
@@ -10,7 +10,6 @@
     "cy:open": "cypress open",
     "dev": "CYPRESS_baseUrl=http://localhost:3333 start-test 3333 cy:open"
   },
-  "license": "ISC",
   "private": true,
   "devDependencies": {
     "cypress": "12.11.0",

--- a/examples/custom-command/package-lock.json
+++ b/examples/custom-command/package-lock.json
@@ -7,7 +7,6 @@
     "": {
       "name": "example-custom-command",
       "version": "1.0.0",
-      "license": "ISC",
       "devDependencies": {
         "cypress": "12.11.0",
         "lodash": "4.17.21"

--- a/examples/custom-command/package.json
+++ b/examples/custom-command/package.json
@@ -7,7 +7,6 @@
     "test": "cypress run",
     "custom-test": "node ."
   },
-  "license": "ISC",
   "private": true,
   "devDependencies": {
     "cypress": "12.11.0",

--- a/examples/env/package-lock.json
+++ b/examples/env/package-lock.json
@@ -7,7 +7,6 @@
     "": {
       "name": "example-env",
       "version": "1.0.0",
-      "license": "ISC",
       "devDependencies": {
         "cypress": "12.11.0"
       }

--- a/examples/env/package.json
+++ b/examples/env/package.json
@@ -6,7 +6,6 @@
   "scripts": {
     "test": "cypress run"
   },
-  "license": "ISC",
   "private": true,
   "devDependencies": {
     "cypress": "12.11.0"

--- a/examples/firefox/package-lock.json
+++ b/examples/firefox/package-lock.json
@@ -7,7 +7,6 @@
     "": {
       "name": "example-firefox",
       "version": "1.1.0",
-      "license": "ISC",
       "devDependencies": {
         "cypress": "12.11.0",
         "image-size": "^1.0.2"

--- a/examples/firefox/package.json
+++ b/examples/firefox/package.json
@@ -9,7 +9,6 @@
     "cy:run": "cypress run",
     "cy:run:firefox": "cypress run --browser firefox"
   },
-  "license": "ISC",
   "private": true,
   "devDependencies": {
     "cypress": "12.11.0",

--- a/examples/install-command/package.json
+++ b/examples/install-command/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "test": "cypress run"
   },
-  "license": "MIT",
   "private": true,
   "devDependencies": {
     "cypress": "12.11.0"

--- a/examples/install-only/package-lock.json
+++ b/examples/install-only/package-lock.json
@@ -7,7 +7,6 @@
     "": {
       "name": "example-install-only",
       "version": "1.0.0",
-      "license": "MIT",
       "dependencies": {
         "arg": "5.0.0",
         "debug": "4.2.0"

--- a/examples/install-only/package.json
+++ b/examples/install-only/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "test": "cypress run"
   },
-  "license": "MIT",
   "private": true,
   "dependencies": {
     "arg": "5.0.0",

--- a/examples/node-versions/package-lock.json
+++ b/examples/node-versions/package-lock.json
@@ -7,7 +7,6 @@
     "": {
       "name": "example-node-versions",
       "version": "1.0.0",
-      "license": "ISC",
       "devDependencies": {
         "cypress": "12.11.0"
       }

--- a/examples/node-versions/package.json
+++ b/examples/node-versions/package.json
@@ -6,7 +6,6 @@
   "scripts": {
     "test": "cypress run"
   },
-  "license": "ISC",
   "private": true,
   "devDependencies": {
     "cypress": "12.11.0"

--- a/examples/quiet/package-lock.json
+++ b/examples/quiet/package-lock.json
@@ -7,7 +7,6 @@
     "": {
       "name": "example-quiet",
       "version": "1.0.0",
-      "license": "ISC",
       "devDependencies": {
         "cypress": "12.11.0",
         "image-size": "0.8.3"

--- a/examples/quiet/package.json
+++ b/examples/quiet/package.json
@@ -7,7 +7,6 @@
     "test": "cypress run",
     "info": "cypress info"
   },
-  "license": "ISC",
   "private": true,
   "devDependencies": {
     "cypress": "12.11.0",

--- a/examples/recording/package-lock.json
+++ b/examples/recording/package-lock.json
@@ -7,7 +7,6 @@
     "": {
       "name": "example-recording",
       "version": "1.0.0",
-      "license": "ISC",
       "devDependencies": {
         "cypress": "12.11.0"
       }

--- a/examples/recording/package.json
+++ b/examples/recording/package.json
@@ -7,7 +7,6 @@
     "test": "cypress run",
     "cy:open": "cypress open"
   },
-  "license": "ISC",
   "private": true,
   "devDependencies": {
     "cypress": "12.11.0"

--- a/examples/start-and-yarn-workspaces/workspace-1/package.json
+++ b/examples/start-and-yarn-workspaces/workspace-1/package.json
@@ -8,7 +8,6 @@
     "build": "echo building ... server ... done!",
     "start": "serve -p 5000 public"
   },
-  "license": "ISC",
   "private": true,
   "devDependencies": {
     "cypress": "12.11.0",

--- a/examples/start-and-yarn-workspaces/workspace-2/package.json
+++ b/examples/start-and-yarn-workspaces/workspace-2/package.json
@@ -8,7 +8,6 @@
     "build": "echo building ... server ... done!",
     "start": "serve -p 5000 public"
   },
-  "license": "ISC",
   "private": true,
   "devDependencies": {
     "cypress": "12.11.0",

--- a/examples/start/package-lock.json
+++ b/examples/start/package-lock.json
@@ -7,7 +7,6 @@
     "": {
       "name": "example-start",
       "version": "1.0.0",
-      "license": "ISC",
       "devDependencies": {
         "cypress": "12.11.0",
         "serve": "^14.2.0"

--- a/examples/start/package.json
+++ b/examples/start/package.json
@@ -9,7 +9,6 @@
     "start": "serve public",
     "start2": "serve -p 8000 public"
   },
-  "license": "ISC",
   "private": true,
   "devDependencies": {
     "cypress": "12.11.0",

--- a/examples/v9/basic-pnpm/package.json
+++ b/examples/v9/basic-pnpm/package.json
@@ -6,7 +6,6 @@
   "scripts": {
     "test": "cypress run"
   },
-  "license": "ISC",
   "private": true,
   "devDependencies": {
     "cypress": "9.7.0"

--- a/examples/v9/basic/package-lock.json
+++ b/examples/v9/basic/package-lock.json
@@ -7,7 +7,6 @@
     "": {
       "name": "example-basic",
       "version": "1.0.0",
-      "license": "ISC",
       "devDependencies": {
         "cypress": "9.7.0"
       }

--- a/examples/v9/basic/package.json
+++ b/examples/v9/basic/package.json
@@ -6,7 +6,6 @@
   "scripts": {
     "test": "cypress run"
   },
-  "license": "ISC",
   "private": true,
   "devDependencies": {
     "cypress": "9.7.0"

--- a/examples/v9/browser/package-lock.json
+++ b/examples/v9/browser/package-lock.json
@@ -7,7 +7,6 @@
     "": {
       "name": "example-browser",
       "version": "1.1.0",
-      "license": "ISC",
       "devDependencies": {
         "cypress": "9.7.0",
         "image-size": "^1.0.2"

--- a/examples/v9/browser/package.json
+++ b/examples/v9/browser/package.json
@@ -10,7 +10,6 @@
     "cy:run:chrome": "cypress run --browser chrome",
     "cy:run:edge": "cypress run --browser edge"
   },
-  "license": "ISC",
   "private": true,
   "devDependencies": {
     "cypress": "9.7.0",

--- a/examples/v9/config/package-lock.json
+++ b/examples/v9/config/package-lock.json
@@ -7,7 +7,6 @@
     "": {
       "name": "example-config",
       "version": "1.0.0",
-      "license": "ISC",
       "devDependencies": {
         "cypress": "9.7.0",
         "serve": "^14.2.0",

--- a/examples/v9/config/package.json
+++ b/examples/v9/config/package.json
@@ -10,7 +10,6 @@
     "cy:open": "cypress open",
     "dev": "CYPRESS_baseUrl=http://localhost:3333 start-test 3333 cy:open"
   },
-  "license": "ISC",
   "private": true,
   "devDependencies": {
     "cypress": "9.7.0",

--- a/examples/v9/custom-command/package-lock.json
+++ b/examples/v9/custom-command/package-lock.json
@@ -7,7 +7,6 @@
     "": {
       "name": "example-custom-command",
       "version": "1.0.0",
-      "license": "ISC",
       "devDependencies": {
         "cypress": "9.7.0",
         "lodash": "4.17.15"

--- a/examples/v9/custom-command/package.json
+++ b/examples/v9/custom-command/package.json
@@ -7,7 +7,6 @@
     "test": "cypress run",
     "custom-test": "node ."
   },
-  "license": "ISC",
   "private": true,
   "devDependencies": {
     "cypress": "9.7.0",

--- a/examples/v9/env/package-lock.json
+++ b/examples/v9/env/package-lock.json
@@ -7,7 +7,6 @@
     "": {
       "name": "example-env",
       "version": "1.0.0",
-      "license": "ISC",
       "devDependencies": {
         "cypress": "9.7.0"
       }

--- a/examples/v9/env/package.json
+++ b/examples/v9/env/package.json
@@ -6,7 +6,6 @@
   "scripts": {
     "test": "cypress run"
   },
-  "license": "ISC",
   "private": true,
   "devDependencies": {
     "cypress": "9.7.0"

--- a/examples/v9/install-command/package.json
+++ b/examples/v9/install-command/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "test": "cypress run"
   },
-  "license": "MIT",
   "private": true,
   "devDependencies": {
     "cypress": "9.7.0"

--- a/examples/v9/install-only/package-lock.json
+++ b/examples/v9/install-only/package-lock.json
@@ -7,7 +7,6 @@
     "": {
       "name": "example-install-only",
       "version": "1.0.0",
-      "license": "MIT",
       "dependencies": {
         "arg": "5.0.0",
         "debug": "4.2.0"

--- a/examples/v9/install-only/package.json
+++ b/examples/v9/install-only/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "test": "cypress run"
   },
-  "license": "MIT",
   "private": true,
   "devDependencies": {
     "cypress": "9.7.0"

--- a/examples/v9/node-versions/package-lock.json
+++ b/examples/v9/node-versions/package-lock.json
@@ -7,7 +7,6 @@
     "": {
       "name": "example-node-versions",
       "version": "1.0.0",
-      "license": "ISC",
       "devDependencies": {
         "cypress": "9.7.0"
       }

--- a/examples/v9/node-versions/package.json
+++ b/examples/v9/node-versions/package.json
@@ -6,7 +6,6 @@
   "scripts": {
     "test": "cypress run"
   },
-  "license": "ISC",
   "private": true,
   "devDependencies": {
     "cypress": "9.7.0"

--- a/examples/v9/quiet/package-lock.json
+++ b/examples/v9/quiet/package-lock.json
@@ -7,7 +7,6 @@
     "": {
       "name": "example-quiet",
       "version": "1.0.0",
-      "license": "ISC",
       "devDependencies": {
         "cypress": "9.7.0",
         "image-size": "0.8.3"

--- a/examples/v9/quiet/package.json
+++ b/examples/v9/quiet/package.json
@@ -7,7 +7,6 @@
     "test": "cypress run",
     "info": "cypress info"
   },
-  "license": "ISC",
   "private": true,
   "devDependencies": {
     "cypress": "9.7.0",

--- a/examples/v9/react-scripts/package-lock.json
+++ b/examples/v9/react-scripts/package-lock.json
@@ -7,7 +7,6 @@
     "": {
       "name": "example-react-scripts",
       "version": "1.0.0",
-      "license": "ISC",
       "devDependencies": {
         "cypress": "9.7.0",
         "react": "^18.2.0",

--- a/examples/v9/react-scripts/package.json
+++ b/examples/v9/react-scripts/package.json
@@ -6,7 +6,6 @@
     "test": "cypress run",
     "start": "BROWSER=none react-scripts start"
   },
-  "license": "ISC",
   "private": true,
   "devDependencies": {
     "cypress": "9.7.0",

--- a/examples/v9/recording/package-lock.json
+++ b/examples/v9/recording/package-lock.json
@@ -7,7 +7,6 @@
     "": {
       "name": "example-recording",
       "version": "1.0.0",
-      "license": "ISC",
       "devDependencies": {
         "cypress": "9.7.0"
       }

--- a/examples/v9/recording/package.json
+++ b/examples/v9/recording/package.json
@@ -7,7 +7,6 @@
     "test": "cypress run",
     "cy:open": "cypress open"
   },
-  "license": "ISC",
   "private": true,
   "devDependencies": {
     "cypress": "9.7.0"

--- a/examples/v9/start-and-yarn-workspaces/workspace-1/package.json
+++ b/examples/v9/start-and-yarn-workspaces/workspace-1/package.json
@@ -8,7 +8,6 @@
     "build": "echo building ... server ... done!",
     "start": "serve -p 5000 public"
   },
-  "license": "ISC",
   "private": true,
   "devDependencies": {
     "cypress": "9.7.0",

--- a/examples/v9/start-and-yarn-workspaces/workspace-2/package.json
+++ b/examples/v9/start-and-yarn-workspaces/workspace-2/package.json
@@ -8,7 +8,6 @@
     "build": "echo building ... server ... done!",
     "start": "serve -p 5000 public"
   },
-  "license": "ISC",
   "private": true,
   "devDependencies": {
     "cypress": "9.7.0",

--- a/examples/v9/start/package-lock.json
+++ b/examples/v9/start/package-lock.json
@@ -7,7 +7,6 @@
     "": {
       "name": "example-start",
       "version": "1.0.0",
-      "license": "ISC",
       "devDependencies": {
         "cypress": "9.7.0",
         "serve": "^14.2.0"

--- a/examples/v9/start/package.json
+++ b/examples/v9/start/package.json
@@ -9,7 +9,6 @@
     "start": "serve public",
     "start2": "serve -p 8000 public"
   },
-  "license": "ISC",
   "private": true,
   "devDependencies": {
     "cypress": "9.7.0",

--- a/examples/v9/wait-on-vite/package-lock.json
+++ b/examples/v9/wait-on-vite/package-lock.json
@@ -7,7 +7,6 @@
     "": {
       "name": "example-wait-on-vite",
       "version": "2.0.0",
-      "license": "ISC",
       "devDependencies": {
         "cypress": "9.7.0",
         "vite": "^3.2.3"

--- a/examples/v9/wait-on-vite/package.json
+++ b/examples/v9/wait-on-vite/package.json
@@ -8,7 +8,6 @@
     "build": "vite build",
     "preview": "vite preview"
   },
-  "license": "ISC",
   "private": true,
   "devDependencies": {
     "cypress": "9.7.0",

--- a/examples/v9/wait-on/package-lock.json
+++ b/examples/v9/wait-on/package-lock.json
@@ -7,7 +7,6 @@
     "": {
       "name": "example-wait-on",
       "version": "1.0.0",
-      "license": "ISC",
       "dependencies": {
         "arg": "5.0.0",
         "debug": "4.2.0"

--- a/examples/v9/wait-on/package.json
+++ b/examples/v9/wait-on/package.json
@@ -14,7 +14,6 @@
     "start3-after-200-seconds": "node ./index3 --delay 200",
     "start4": "node ./index4"
   },
-  "license": "ISC",
   "private": true,
   "devDependencies": {
     "cypress": "9.7.0"

--- a/examples/v9/webpack/package-lock.json
+++ b/examples/v9/webpack/package-lock.json
@@ -7,7 +7,6 @@
     "": {
       "name": "example-webpack",
       "version": "1.0.0",
-      "license": "ISC",
       "devDependencies": {
         "cypress": "9.7.0",
         "webpack": "^5.76.1",

--- a/examples/v9/webpack/package.json
+++ b/examples/v9/webpack/package.json
@@ -6,7 +6,6 @@
     "test": "cypress run",
     "start": "webpack-dev-server"
   },
-  "license": "ISC",
   "private": true,
   "devDependencies": {
     "cypress": "9.7.0",

--- a/examples/v9/yarn-classic/package.json
+++ b/examples/v9/yarn-classic/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "test": "cypress run"
   },
-  "license": "MIT",
   "private": true,
   "devDependencies": {
     "cypress": "9.7.0"

--- a/examples/v9/yarn-modern/package.json
+++ b/examples/v9/yarn-modern/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "test": "cypress run"
   },
-  "license": "MIT",
   "private": true,
   "devDependencies": {
     "cypress": "9.7.0"

--- a/examples/wait-on-vite/package-lock.json
+++ b/examples/wait-on-vite/package-lock.json
@@ -7,7 +7,6 @@
     "": {
       "name": "example-wait-on-vite",
       "version": "2.0.0",
-      "license": "ISC",
       "devDependencies": {
         "cypress": "12.11.0",
         "vite": "^4.0.0"

--- a/examples/wait-on-vite/package.json
+++ b/examples/wait-on-vite/package.json
@@ -8,7 +8,6 @@
     "build": "vite build",
     "preview": "vite preview"
   },
-  "license": "ISC",
   "private": true,
   "devDependencies": {
     "cypress": "12.11.0",

--- a/examples/wait-on/package-lock.json
+++ b/examples/wait-on/package-lock.json
@@ -7,7 +7,6 @@
     "": {
       "name": "example-wait-on",
       "version": "1.0.0",
-      "license": "ISC",
       "dependencies": {
         "arg": "5.0.0",
         "debug": "4.2.0"

--- a/examples/wait-on/package.json
+++ b/examples/wait-on/package.json
@@ -14,7 +14,6 @@
     "start3-after-200-seconds": "node ./index3 --delay 200",
     "start4": "node ./index4"
   },
-  "license": "ISC",
   "private": true,
   "dependencies": {
     "arg": "5.0.0",

--- a/examples/webpack/package-lock.json
+++ b/examples/webpack/package-lock.json
@@ -7,7 +7,6 @@
     "": {
       "name": "example-webpack",
       "version": "1.0.0",
-      "license": "ISC",
       "devDependencies": {
         "cypress": "12.11.0",
         "webpack": "^5.76.1",

--- a/examples/webpack/package.json
+++ b/examples/webpack/package.json
@@ -6,7 +6,6 @@
     "test": "cypress run",
     "start": "webpack-dev-server"
   },
-  "license": "ISC",
   "private": true,
   "devDependencies": {
     "cypress": "12.11.0",

--- a/examples/yarn-classic/package.json
+++ b/examples/yarn-classic/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "test": "cypress run"
   },
-  "license": "MIT",
   "private": true,
   "devDependencies": {
     "cypress": "12.11.0"

--- a/examples/yarn-modern/package.json
+++ b/examples/yarn-modern/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "test": "cypress run"
   },
-  "license": "MIT",
   "private": true,
   "devDependencies": {
     "cypress": "12.11.0"


### PR DESCRIPTION
**NOTE: The license information at the top-level of the repository is unaffected and remains in place.**

This PR removes any

- [license field](https://docs.npmjs.com/cli/v9/configuring-npm/package-json#license)

from `package.json` files in the [examples](https://github.com/cypress-io/github-action/tree/master/examples) sub-directories. These contained a mixture of `MIT` and `ISC` definitions.

The `license` field is defined at the top-level and applies to the whole repository, including the [examples](https://github.com/cypress-io/github-action/tree/master/examples) sub-directories. The [README: License](https://github.com/cypress-io/github-action/blob/master/README.md#license) section also shows the following, making additional definitions in sub-directories unnecessary:

---

[![license][license-badge]][license-file]

This project is licensed under the terms of the [MIT license][license-file].

[license-badge]:    https://img.shields.io/badge/license-MIT-green.svg
[license-file]:     https://github.com/cypress-io/github-action/blob/master/LICENSE.md

---

The `package.json` files for each of the examples, for instance, [examples/basic/package.json](https://github.com/cypress-io/github-action/blob/master/examples/basic/package.json) are set with `"private": true` indicating that they are not intended for individual publication.

In some cases the `license` field in the [examples](https://github.com/cypress-io/github-action/tree/master/examples) sub-directories contained conflicting information compared to the top-level `license` field. This PR removes these inconsistencies.
