### PR TITLE
fix(deps): update node.js versions in examples

### DIFF
--- a/.github/workflows/example-node-versions.yml
+++ b/.github/workflows/example-node-versions.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [14, 16, 18, 19, 20]
+        node: [16, 18, 19, 20]
     name: Cypress v9 E2E on Node v${{ matrix.node }}
     steps:
       - name: Setup Node
@@ -43,7 +43,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [14, 16, 18, 19, 20]
+        node: [16, 18, 19, 20]
     name: Cypress E2E on Node v${{ matrix.node }}
     steps:
       - name: Setup Node

--- a/README.md
+++ b/README.md
@@ -385,7 +385,7 @@ jobs:
     # let's make sure our "app" works on several versions of Node
     strategy:
       matrix:
-        node: [14, 16, 18, 19]
+        node: [16, 18, 19, 20]
     name: E2E on Node v${{ matrix.node }}
     steps:
       - name: Setup Node
@@ -1111,7 +1111,7 @@ jobs:
     # let's make sure our "app" works on several versions of Node
     strategy:
       matrix:
-        node: [14, 16, 18, 19]
+        node: [16, 18, 19, 20]
     name: E2E on Node v${{ matrix.node }}
     steps:
       - name: Setup Node
@@ -1145,7 +1145,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        node: [14, 16, 18, 19]
+        node: [16, 18, 19, 20]
     name: E2E on Node v${{ matrix.node }}
     steps:
       - uses: actions/setup-node@v3
@@ -1260,16 +1260,6 @@ This action installs local dependencies using lock files. Ensure that exactly on
  | `yarn.lock`         | [Yarn Classic](https://classic.yarnpkg.com/en/docs/cli/install#toc-yarn-install-frozen-lockfile) | `yarn --frozen-lockfile`         |
 
 See section [Yarn Modern](#yarn-modern) for information about using Yarn version 2 and later.
-
-#### Node.js Support
-
-Node.js is required to run this action. The current version `v5` supports:
-
-- **Node.js** 14.x
-- **Node.js** 16.x
-- **Node.js** 18.x and above
-
-and is generally aligned with [Node.js's release schedule](https://github.com/nodejs/Release).
 
 ## Debugging
 
@@ -1456,18 +1446,30 @@ jobs:
           publish-summary: false
 ```
 
+## Node.js Support
+
+Node.js is required to run this action. The current version `v5` supports:
+
+- **Node.js** 16.x
+- **Node.js** 18.x and above
+
+and is generally aligned with [Node.js's release schedule](https://github.com/nodejs/Release).
+
 ## Changelog
 
 See [Releases](https://github.com/cypress-io/github-action/releases) for full details of changes.
 
-| Version | Changes                                                                                                                                  |
-| ------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| v5      | Examples and workflows additionally use Node.js 18. Use of the end-of-life Node.js version 12 in examples and workflows is removed.      |
-| v4.2.0  | Support for pnpm added.                                                                                      |
-| v4      | Support for Cypress 10 and later versions is added.                                                                                      |
-| v3      | Action runs under Node.js 16 instead of Node.js 12.                                                                                      |
-| v2      | Cypress runs using the [Module API](https://docs.cypress.io/guides/guides/module-api) instead of being started via the command line.     |
-| v1      | *This version is no longer runnable in GitHub due to security changes.*                                                                  |
+| Version | Changes                                                                                                                              |
+| ------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| v5.6.2  | Examples add Node.js 20. End of support and removal of Node.js 14 examples.                                                          |
+| v5.2.0  | Examples add Node.js 19.                                                                                                             |
+| v5.0.0  | Examples add Node.js 18 and remove Node.js 12.                                                                                       |
+| v4.2.2  | Dependency on GitHub `set-output` workflow command removed.                                                                          |
+| v4.2.0  | Support for `pnpm` added.                                                                                                            |
+| v4.0.0  | Support for Cypress 10 and later versions added.                                                                                     |
+| v3      | Action runs under Node.js 16 instead of Node.js 12.                                                                                  |
+| v2      | Cypress runs using the [Module API](https://docs.cypress.io/guides/guides/module-api) instead of being started via the command line. |
+| v1      | *This version is no longer runnable in GitHub due to security changes.*                                                              |
 
 *Note: [GitHub announced](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) their plan to disable `save-state` and `set-output` commands by May 31, 2023. This will prevent [cypress-io/github-action](https://github.com/cypress-io/github-action) version [v4.2.1](https://github.com/cypress-io/github-action/releases/tag/v4.2.1), and earlier, running after this date since they use `set-output`. Affected users should update to using `v5` of the [cypress-io/github-action](https://github.com/cypress-io/github-action) action before the deadline.*
 


### PR DESCRIPTION
Node.js `14` moved into end-of-life status on April 30, 2023 and is therefore no longer officially supported. The versions which are currently supported by Node.js according to their [Release schedule](https://github.com/nodejs/release#release-schedule) are now `16`, `18`, `19` and  `20`.

This PR takes account of this Node.js status change and it removes Node.js `14` ...

- from the list of versions which [.github/workflows/example-node-versions.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-node-versions.yml) tests

- from the list [Node.js Support](https://github.com/cypress-io/github-action/blob/master/README.md#nodejs-support) of supported versions for the action

All examples in the [README](https://github.com/cypress-io/github-action/blob/master/README.md) file which use a matrix of Node.js versions are moved to the consistent set:

    ```yml
        strategy:
        matrix:
            node: [16, 18, 19, 20]
    ```

The [Node.js Support](https://github.com/cypress-io/github-action/blob/master/README.md#nodejs-support) section is moved to near the bottom of the [README](https://github.com/cypress-io/github-action/blob/master/README.md) file above the section [Changelog](https://github.com/cypress-io/github-action/blob/master/README.md#changelog) to which it relates. Some more detail is added to the table concerning when certain Node.js version additions and removals were made.

There is **no** change to the action itself which continues to use `node16` as its running environment, therefore these changes are **not** breaking changes. `node16` is the current latest available version for GitHub JavaScript actions.

(The next status change for Node.js is planned for June 1, 2023, when Node.js `19` enters end-of-life.)

## References

- Node.js [Release schedule](https://github.com/nodejs/release#release-schedule)
- GitHub [runs.using for JavaScript actions](https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#runsusing-for-javascript-actions)
