### PR TITLE
test(deps): update pnpm to 8

### DIFF
--- a/.github/workflows/example-basic-pnpm.yml
+++ b/.github/workflows/example-basic-pnpm.yml
@@ -120,7 +120,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v2
         with:
-          version: 7
+          version: 8
 
       - name: Cypress tests
         # normally you would write
@@ -144,7 +144,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v2
         with:
-          version: 7
+          version: 8
 
       - name: Cypress tests
         uses: ./
@@ -161,7 +161,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v2
         with:
-          version: 7
+          version: 8
 
       - name: Cypress tests
         uses: ./
@@ -178,7 +178,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v2
         with:
-          version: 7
+          version: 8
 
       - name: Cypress tests
         uses: ./
@@ -198,7 +198,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v2
         with:
-          version: 7
+          version: 8
 
       - name: Cypress tests
         uses: ./


### PR DESCRIPTION
This PR updates the version of pnpm used in [.github/workflows/example-basic-pnpm.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-basic-pnpm.yml) from `7` to `8` (latest version) for the Cypress v10 and higher jobs only. Legacy Cypress v9 jobs remain using the older pnpm `7`.

[pnpm 8.0.0](https://github.com/pnpm/pnpm/releases/tag/v8.0.0) removed support for Node.js `14` and adopted [Lockfile v6](https://github.com/pnpm/pnpm/pull/5810).

The prerequisites for using [pnpm 8.0.0](https://github.com/pnpm/pnpm/releases/tag/v8.0.0) are already fulfilled:

- Node.js `14.x` itself moved to [End-of-Life](https://github.com/nodejs/release#release-schedule) on April 30, 2023
- The [examples/basic-pnpm/pnpm-lock.yaml](https://github.com/cypress-io/github-action/blob/master/examples/basic-pnpm/pnpm-lock.yaml) was already migrated to [Lockfile v6](https://github.com/pnpm/pnpm/pull/5810) (introduced through PR https://github.com/cypress-io/github-action/pull/856), which is compatible also with pnpm `7` (see [pnpm 8.0.0](https://github.com/pnpm/pnpm/releases/tag/v8.0.0) release notes)
