### PR TITLE
ci: remove unused release plugins

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,10 +41,7 @@ jobs:
         uses: cycjimmy/semantic-release-action@v3
         id: semantic
         with:
-          branch: master
-          extra_plugins: |
-            @semantic-release/git
-            @semantic-release/changelog
+          branches: master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
This PR follows on from https://github.com/cypress-io/github-action/issues/722#issuecomment-1533640162 which proposes to remove `extra_plugins` from the workflow. These plugins were inactive since the configuration was incomplete.

## Changes

The following changes are made to [.github/workflows/main.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/main.yml) using the GitHub JavaScript [action-for-semantic-release](https://github.com/marketplace/actions/action-for-semantic-release) called by `cycjimmy/semantic-release-action@v3`:

1. Remove the `extra_plugins:` parameter containing

  ```yaml
            extra_plugins: |
              @semantic-release/git
              @semantic-release/changelog
  ```

2. Change the `branch` parameter to `branches`. The `branch` parameter is only officially supported for [semantic-release](https://www.npmjs.com/package/semantic-release) `v16` and earlier. The workflow currently already uses [v19.0.5](https://github.com/semantic-release/semantic-release/releases/tag/v19.0.5) and there is no guarantee that future versions of the action will continue to provide an undocumented conversion of the old parameter name to the new parameter name.

## Impact

The change should have no impact on the way that the `release` job of [.github/workflows/main.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/main.yml) carries out its work. This is simply a clean-up.

## References

- [cycjimmy/semantic-release-action: branches](https://github.com/cycjimmy/semantic-release-action#branches)

- [cycjimmy/semantic-release-action: extra_plugins](https://github.com/cycjimmy/semantic-release-action#extra_plugins)
