### PR TITLE
chore(deps): revert examples/yarn-modern-pnp to cypress 12.9.0

### DIFF
--- a/examples/yarn-modern-pnp/README.md
+++ b/examples/yarn-modern-pnp/README.md
@@ -1,3 +1,5 @@
 # example: yarn-modern-pnp
 
 This example demonstrates installing dependencies using [Yarn Modern (version 2 and later)](https://yarnpkg.com/) with [Plug'n'Play](https://yarnpkg.com/features/pnp) turned on.
+
+Cypress [12.9.0](https://docs.cypress.io/guides/references/changelog#12-9-0) is used, pending resolution of a compatibility issue between [Yarn Plug'n'Play](https://yarnpkg.com/features/pnp) and the [Cypress desktop app](https://on.cypress.io/guides/core-concepts/cypress-app) using later versions of Cypress. See issue https://github.com/cypress-io/cypress/issues/26567.

--- a/examples/yarn-modern-pnp/package.json
+++ b/examples/yarn-modern-pnp/package.json
@@ -7,7 +7,7 @@
   },
   "private": true,
   "devDependencies": {
-    "cypress": "12.11.0"
+    "cypress": "12.9.0"
   },
   "packageManager": "yarn@3.5.0"
 }

--- a/examples/yarn-modern-pnp/yarn.lock
+++ b/examples/yarn-modern-pnp/yarn.lock
@@ -375,10 +375,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"commander@npm:^6.2.1":
-  version: 6.2.1
-  resolution: "commander@npm:6.2.1"
-  checksum: d7090410c0de6bc5c67d3ca41c41760d6d268f3c799e530aafb73b7437d1826bbf0d2a3edac33f8b57cc9887b4a986dce307fa5557e109be40eadb7c43b21742
+"commander@npm:^5.1.0":
+  version: 5.1.0
+  resolution: "commander@npm:5.1.0"
+  checksum: 0b7fec1712fbcc6230fcb161d8d73b4730fa91a21dc089515489402ad78810547683f058e2a9835929c212fead1d6a6ade70db28bbb03edbc2829a9ab7d69447
   languageName: node
   linkType: hard
 
@@ -414,9 +414,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cypress@npm:12.11.0":
-  version: 12.11.0
-  resolution: "cypress@npm:12.11.0"
+"cypress@npm:12.9.0":
+  version: 12.9.0
+  resolution: "cypress@npm:12.9.0"
   dependencies:
     "@cypress/request": ^2.88.10
     "@cypress/xvfb": ^1.2.4
@@ -432,7 +432,7 @@ __metadata:
     check-more-types: ^2.24.0
     cli-cursor: ^3.1.0
     cli-table3: ~0.6.1
-    commander: ^6.2.1
+    commander: ^5.1.0
     common-tags: ^1.8.0
     dayjs: ^1.10.4
     debug: ^4.3.4
@@ -450,7 +450,7 @@ __metadata:
     listr2: ^3.8.3
     lodash: ^4.17.21
     log-symbols: ^4.0.0
-    minimist: ^1.2.8
+    minimist: ^1.2.6
     ospath: ^1.2.2
     pretty-bytes: ^5.6.0
     proxy-from-env: 1.0.0
@@ -462,7 +462,7 @@ __metadata:
     yauzl: ^2.10.0
   bin:
     cypress: bin/cypress
-  checksum: 56e5ebaec59dffca5d19704f2b2674cbb0002f20050c1d624217ede157c528757f58ad42f0899fc67c32c61d5461eef5e2a3a99a6a52b77b152362a025a22599
+  checksum: aad2278310fe4897b2c4e1f23e22f28992c83bcac945a6c350d077b1b2fb1805e44d5c58e19e2a9d63ca04aa3f9eabdd3c661cab0ce5dddd75c72702262ac89e
   languageName: node
   linkType: hard
 
@@ -563,7 +563,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "example-yarn-modern@workspace:."
   dependencies:
-    cypress: 12.11.0
+    cypress: 12.9.0
   languageName: unknown
   linkType: soft
 
@@ -1068,7 +1068,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimist@npm:^1.2.8":
+"minimist@npm:^1.2.6":
   version: 1.2.8
   resolution: "minimist@npm:1.2.8"
   checksum: 75a6d645fb122dad29c06a7597bddea977258957ed88d7a6df59b5cd3fe4a527e253e9bbf2e783e4b73657f9098b96a5fe96ab8a113655d4109108577ecf85b0


### PR DESCRIPTION
This PR reverts [examples/yarn-modern-pnp](https://github.com/cypress-io/github-action/tree/master/examples/yarn-modern-pnp) from Cypress [12.11.0](https://docs.cypress.io/guides/references/changelog#12-11-0) to Cypress [12.9.0](https://docs.cypress.io/guides/references/changelog#12-9-0).

## Issue

Changes introduced in Cypress [12.10.0](https://docs.cypress.io/guides/references/changelog#12-10-0) have caused the Cypress App to fail to work when invoked through `yarn cypress open` in a [Yarn Plug'n'Play](https://yarnpkg.com/features/pnp) environment using Cypress [12.10.0](https://docs.cypress.io/guides/references/changelog#12-10-0) or [12.11.0](https://docs.cypress.io/guides/references/changelog#12-11-0)

To reproduce, execute locally in `master` branch:

```bash
cd examples/yarn-modern-pnp
yarn
yarn cypress open
```

Click on "E2E Testing"
Note error message relating to "bluebird" (details differ according to operating system - see https://github.com/cypress-io/cypress/issues/26567#issuecomment-1536178066). For Ubuntu 22.04 the error looks like this:

![image](https://user-images.githubusercontent.com/66998419/236456083-f0c729b3-85d8-4848-819c-9bbf19157e47.png)

## Verification

After application of this PR, execute locally:

```bash
cd examples/yarn-modern-pnp
yarn
yarn cypress open
```

Click on "E2E Testing"
Select Electron
Select Start E2E Testing in Electron
Select `spec.cy.js`
Confirm successful execution of Cypress test

## Related issues

- https://github.com/cypress-io/cypress/issues/26567
- https://github.com/cypress-io/cypress/issues/26676
