### PR TITLE
fix: use yarn instead of npx with yarn.lock

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -74457,6 +74457,11 @@ const useYarn = () => fs.existsSync(yarnFilename)
 const usePnpm = () => fs.existsSync(pnpmLockFilename)
 const useNpm = () => fs.existsSync(packageLockFilename)
 
+let runPrefix = 'npx'
+if (useYarn()) {
+  runPrefix = 'yarn'
+}
+
 const lockHash = () => {
   const lockFilename = useYarn()
     ? yarnFilename
@@ -74635,9 +74640,9 @@ const listCypressBinaries = () => {
   }
 
   core.exportVariable('CYPRESS_CACHE_FOLDER', CYPRESS_CACHE_FOLDER)
-  return io.which('npx', true).then((npxPath) => {
+  return io.which(runPrefix, true).then((runPath) => {
     return exec.exec(
-      quote(npxPath),
+      quote(runPath),
       ['cypress', 'cache', 'list'],
       cypressCommandOptions
     )
@@ -74654,9 +74659,9 @@ const verifyCypressBinary = () => {
   }
 
   core.exportVariable('CYPRESS_CACHE_FOLDER', CYPRESS_CACHE_FOLDER)
-  return io.which('npx', true).then((npxPath) => {
+  return io.which(runPrefix, true).then((runPath) => {
     return exec.exec(
-      quote(npxPath),
+      quote(runPath),
       ['cypress', 'verify'],
       cypressCommandOptions
     )

--- a/dist/index.js
+++ b/dist/index.js
@@ -74457,10 +74457,7 @@ const useYarn = () => fs.existsSync(yarnFilename)
 const usePnpm = () => fs.existsSync(pnpmLockFilename)
 const useNpm = () => fs.existsSync(packageLockFilename)
 
-let runPrefix = 'npx'
-if (useYarn()) {
-  runPrefix = 'yarn'
-}
+const runPrefix = useYarn() ? 'yarn' : 'npx'
 
 const lockHash = () => {
   const lockFilename = useYarn()

--- a/index.js
+++ b/index.js
@@ -106,10 +106,7 @@ const useYarn = () => fs.existsSync(yarnFilename)
 const usePnpm = () => fs.existsSync(pnpmLockFilename)
 const useNpm = () => fs.existsSync(packageLockFilename)
 
-let runPrefix = 'npx'
-if (useYarn()) {
-  runPrefix = 'yarn'
-}
+const runPrefix = useYarn() ? 'yarn' : 'npx'
 
 const lockHash = () => {
   const lockFilename = useYarn()

--- a/index.js
+++ b/index.js
@@ -106,6 +106,11 @@ const useYarn = () => fs.existsSync(yarnFilename)
 const usePnpm = () => fs.existsSync(pnpmLockFilename)
 const useNpm = () => fs.existsSync(packageLockFilename)
 
+let runPrefix = 'npx'
+if (useYarn()) {
+  runPrefix = 'yarn'
+}
+
 const lockHash = () => {
   const lockFilename = useYarn()
     ? yarnFilename
@@ -284,9 +289,9 @@ const listCypressBinaries = () => {
   }
 
   core.exportVariable('CYPRESS_CACHE_FOLDER', CYPRESS_CACHE_FOLDER)
-  return io.which('npx', true).then((npxPath) => {
+  return io.which(runPrefix, true).then((runPath) => {
     return exec.exec(
-      quote(npxPath),
+      quote(runPath),
       ['cypress', 'cache', 'list'],
       cypressCommandOptions
     )
@@ -303,9 +308,9 @@ const verifyCypressBinary = () => {
   }
 
   core.exportVariable('CYPRESS_CACHE_FOLDER', CYPRESS_CACHE_FOLDER)
-  return io.which('npx', true).then((npxPath) => {
+  return io.which(runPrefix, true).then((runPath) => {
     return exec.exec(
-      quote(npxPath),
+      quote(runPath),
       ['cypress', 'verify'],
       cypressCommandOptions
     )


### PR DESCRIPTION
This PR resolves an issue calling commands `cypress cache list` and `cypress cache verify` if the project is using [Yarn Plug'n'Play](https://yarnpkg.com/features/pnp) (introduced through PR https://github.com/cypress-io/github-action/pull/599 from @PilotConway). In this case the commands were not finding the installed version of Cypress.

## Changes

The following commands, which are called internally by the action, are replaced if the action is working from a `yarn.lock` file. This is the case for [Yarn Classic](https://classic.yarnpkg.com/) and [Yarn Modern](https://yarnpkg.com/) projects. Although the issue only affects [Yarn Modern](https://yarnpkg.com/) using [Yarn Plug'n'Play](https://yarnpkg.com/features/pnp) configuration, the change is activated for **all** types of Yarn projects.

The following commands are retained for `npm` and `pnpm` projects:

```bash
npx cypress cache list
npx cypress verify
```

For Yarn projects they are changed to use instead:

```bash
yarn cypress cache list
yarn cypress verify
```

## Issue

When [.github/workflows/example-yarn-modern-pnp.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-yarn-modern-pnp.yml) is run, it shows `npx` being called and not finding the installed version of cypress.

For example job [4959218510](https://github.com/cypress-io/github-action/actions/runs/4959218510) shows:

```text
/usr/local/bin/npx cypress cache list
npm WARN exec The following package was not found and will be installed: cypress@12.12.0
┌─────────┬───────────────────┐
│ version │ last used         │
├─────────┼───────────────────┤
│ 12.11.0 │ a few seconds ago │
├─────────┼───────────────────┤
│ 12.12.0 │ 3 days ago        │
└─────────┴───────────────────┘
/usr/local/bin/npx cypress verify
```

With [Yarn Plug'n'Play](https://yarnpkg.com/features/pnp) there is no directory `node_modules` set up and therefore [npx](https://docs.npmjs.com/cli/v9/commands/npx) cannot find `cypress` and it installs instead the latest version, which may or may not correspond to the version specified in `yarn.lock`.

## Verification

Check the workflow results:

- [example-basic.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-basic.yml)
- [example-basic-pnpm.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-basic-pnpm.yml)
- [example-yarn-classic.yml](https://github.com/cypress-io/github-action/actions/workflows/example-yarn-classic.yml)
- [example-yarn-modern.yml](https://github.com/cypress-io/github-action/actions/workflows/example-yarn-modern.yml)
- [example-yarn-modern-pnp.yml](https://github.com/cypress-io/github-action/actions/workflows/example-yarn-modern-pnp.yml)

1. All workflows should be successful.
2. [example-basic.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-basic.yml) and [example-basic-pnpm.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-basic-pnpm.yml) should use `npx` when calling  `cypress cache list` or `cypress verify`.
3. Each of the Yarn workflows should use `yarn` when calling  `cypress cache list` and `cypress verify`. Only one version of Cypress should be shown by `cypress cache list`.
