### PR TITLE
feat: replace dashboardUrl by resultsUrl

### DIFF
--- a/.github/workflows/example-recording.yml
+++ b/.github/workflows/example-recording.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Print Cypress Cloud URL
         run: |
           echo Cypress finished with: ${{ steps.cypress.outcome }}
-          echo See results at ${{ steps.cypress.outputs.dashboardUrl }}
+          echo See results at ${{ steps.cypress.outputs.dashboardUrl }} # note: dashboardUrl is now deprecated
 
   group-v9:
     runs-on: ubuntu-22.04
@@ -131,7 +131,7 @@ jobs:
       - name: Print Cypress Cloud URL
         run: |
           echo Cypress finished with: ${{ steps.cypress.outcome }}
-          echo See results at ${{ steps.cypress.outputs.dashboardUrl }}
+          echo See results at ${{ steps.cypress.outputs.resultsUrl }}
 
   group:
     runs-on: ubuntu-22.04

--- a/README.md
+++ b/README.md
@@ -1359,9 +1359,9 @@ If you add `workflow_dispatch` event to your workflow, you will be able to start
 
 ### Outputs
 
-This action sets a GitHub step output `dashboardUrl` if the run was recorded on [Cypress Cloud](https://on.cypress.io/cloud-introduction) using the action parameter setting `record: true` (see [Record test results on Cypress Cloud](#record-test-results-on-cypress-cloud)). Note that using a [Custom test command](#custom-test-command) with the `command` parameter overrides the `record` parameter and in this case no `dashboardUrl` step output is saved.
+This action sets a GitHub step output `resultsUrl` if the run was recorded on [Cypress Cloud](https://on.cypress.io/cloud-introduction) using the action parameter setting `record: true` (see [Record test results on Cypress Cloud](#record-test-results-on-cypress-cloud)). Note that using a [Custom test command](#custom-test-command) with the `command` parameter overrides the `record` parameter and in this case no `resultsUrl` step output is saved.
 
-This is an example of using the step output `dashboardUrl`:
+This is an example of using the step output `resultsUrl`:
 
 ```yml
 - name: Cypress tests
@@ -1379,8 +1379,10 @@ This is an example of using the step output `dashboardUrl`:
 - name: Print Cypress Cloud URL
   run: |
     echo Cypress finished with: ${{ steps.cypress.outcome }}
-    echo See results at ${{ steps.cypress.outputs.dashboardUrl }}
+    echo See results at ${{ steps.cypress.outputs.resultsUrl }}
 ```
+
+The GitHub step output `dashboardUrl` is deprecated. Cypress Dashboard is now [Cypress Cloud](https://on.cypress.io/cloud-introduction).
 
 [![recording example](https://github.com/cypress-io/github-action/workflows/example-recording/badge.svg?branch=master)](.github/workflows/example-recording.yml)
 

--- a/action.yml
+++ b/action.yml
@@ -93,7 +93,9 @@ inputs:
     default: false
 outputs:
   dashboardUrl:
-    description: 'Cypress Dashboard URL if the run was recorded'
+    description: 'Cypress Cloud URL if the run was recorded (deprecated)'
+  resultsUrl:
+    description: 'Cypress Cloud URL if the run was recorded'
 runs:
   using: 'node16'
   main: 'dist/index.js'

--- a/dist/index.js
+++ b/dist/index.js
@@ -75091,7 +75091,8 @@ const runTests = async () => {
   debug(`Cypress options ${JSON.stringify(cypressOptions)}`)
 
   const onTestsFinished = (testResults) => {
-    const dashboardUrl = testResults.runUrl
+    const dashboardUrl = testResults.runUrl // dashboardUrl is deprecated
+    const resultsUrl = testResults.runUrl // and replaced by resultsUrl
     process.chdir(startWorkingDirectory)
 
     if (testResults.failures) {
@@ -75112,14 +75113,15 @@ const runTests = async () => {
 
     debug(`Cypress tests: ${testResults.totalFailed} failed`)
 
-    if (dashboardUrl) {
-      debug(`Dashboard url ${dashboardUrl}`)
+    if (resultsUrl) {
+      debug(`resultsUrl ${resultsUrl}`)
     } else {
-      debug('There is no Dashboard url')
+      debug('There is no resultsUrl')
     }
 
     // we still set the output explicitly
-    core.setOutput('dashboardUrl', dashboardUrl)
+    core.setOutput('dashboardUrl', dashboardUrl) // deprecated and retained for backward compatibility
+    core.setOutput('resultsUrl', resultsUrl) // replacement for dashboardUrl
 
     if (testResults.totalFailed) {
       return Promise.reject(

--- a/dist/index.js
+++ b/dist/index.js
@@ -75091,8 +75091,7 @@ const runTests = async () => {
   debug(`Cypress options ${JSON.stringify(cypressOptions)}`)
 
   const onTestsFinished = (testResults) => {
-    const dashboardUrl = testResults.runUrl // dashboardUrl is deprecated
-    const resultsUrl = testResults.runUrl // and replaced by resultsUrl
+    const resultsUrl = testResults.runUrl
     process.chdir(startWorkingDirectory)
 
     if (testResults.failures) {
@@ -75120,7 +75119,7 @@ const runTests = async () => {
     }
 
     // we still set the output explicitly
-    core.setOutput('dashboardUrl', dashboardUrl) // deprecated and retained for backward compatibility
+    core.setOutput('dashboardUrl', resultsUrl) // deprecated and retained for backward compatibility
     core.setOutput('resultsUrl', resultsUrl) // replacement for dashboardUrl
 
     if (testResults.totalFailed) {

--- a/index.js
+++ b/index.js
@@ -740,7 +740,8 @@ const runTests = async () => {
   debug(`Cypress options ${JSON.stringify(cypressOptions)}`)
 
   const onTestsFinished = (testResults) => {
-    const dashboardUrl = testResults.runUrl
+    const dashboardUrl = testResults.runUrl // dashboardUrl is deprecated
+    const resultsUrl = testResults.runUrl // and replaced by resultsUrl
     process.chdir(startWorkingDirectory)
 
     if (testResults.failures) {
@@ -761,14 +762,15 @@ const runTests = async () => {
 
     debug(`Cypress tests: ${testResults.totalFailed} failed`)
 
-    if (dashboardUrl) {
-      debug(`Dashboard url ${dashboardUrl}`)
+    if (resultsUrl) {
+      debug(`resultsUrl ${resultsUrl}`)
     } else {
-      debug('There is no Dashboard url')
+      debug('There is no resultsUrl')
     }
 
     // we still set the output explicitly
-    core.setOutput('dashboardUrl', dashboardUrl)
+    core.setOutput('dashboardUrl', dashboardUrl) // deprecated and retained for backward compatibility
+    core.setOutput('resultsUrl', resultsUrl) // replacement for dashboardUrl
 
     if (testResults.totalFailed) {
       return Promise.reject(

--- a/index.js
+++ b/index.js
@@ -740,8 +740,7 @@ const runTests = async () => {
   debug(`Cypress options ${JSON.stringify(cypressOptions)}`)
 
   const onTestsFinished = (testResults) => {
-    const dashboardUrl = testResults.runUrl // dashboardUrl is deprecated
-    const resultsUrl = testResults.runUrl // and replaced by resultsUrl
+    const resultsUrl = testResults.runUrl
     process.chdir(startWorkingDirectory)
 
     if (testResults.failures) {
@@ -769,7 +768,7 @@ const runTests = async () => {
     }
 
     // we still set the output explicitly
-    core.setOutput('dashboardUrl', dashboardUrl) // deprecated and retained for backward compatibility
+    core.setOutput('dashboardUrl', resultsUrl) // deprecated and retained for backward compatibility
     core.setOutput('resultsUrl', resultsUrl) // replacement for dashboardUrl
 
     if (testResults.totalFailed) {


### PR DESCRIPTION
Closes #909.

This PR adds a GitHub step output ~~`cloudRunUrl`~~ `resultsUrl` for recording, providing a name which is not tied to the branding name of Cypress Dashboard or Cypress Cloud. This is a replacement for `dashboardUrl`.

The GitHub step output `dashboardUrl`, stemming from the previous Cypress Dashboard branding, continues to function and is documented as deprecated.

Documentation and examples are updated accordingly.

[examples/v9](https://github.com/cypress-io/github-action/tree/master/examples/v9) are left using `dashboardUrl`
