### PR TITLE
docs: add cypress kitchensink and realworld-app to examples list

### DIFF
--- a/README.md
+++ b/README.md
@@ -1265,6 +1265,8 @@ See [cypress-gh-action-example](https://github.com/bahmutov/cypress-gh-action-ex
 <!-- prettier-ignore-start -->
 | Name                                                                                                    | Description                                                                               |
 | ------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| [cypress-io/cypress-example-kitchensink](https://github.com/cypress-io/cypress-example-kitchensink)     | Runs every API command in Cypress using various CI platforms including GitHub Actions     |
+| [cypress-io/cypress-realworld-app](https://github.com/cypress-io/cypress-realworld-app)                 | A real-world example payment application. Uses GitHub Actions and CircleCI.               |
 | [cypress-gh-action-small-example](https://github.com/bahmutov/cypress-gh-action-small-example) (legacy) | Runs tests and records them on Cypress Cloud                                              |
 | [cypress-gh-action-example](https://github.com/bahmutov/cypress-gh-action-example)  (legacy)            | Uses Yarn, and runs in parallel on several versions of Node, different browsers, and more |
 | [cypress-gh-action-monorepo](https://github.com/bahmutov/cypress-gh-action-monorepo)                    | Splits install and running tests commands, runs Cypress from sub-folder                   |


### PR DESCRIPTION
This PR adds

- [cypress-io/cypress-example-kitchensink](https://github.com/cypress-io/cypress-example-kitchensink)
- [cypress-io/cypress-realworld-app](https://github.com/cypress-io/cypress-realworld-app)

to the list of example repositories in [README > More examples](https://github.com/cypress-io/github-action/blob/master/README.md#more-examples) which demonstrate the use of the Cypress JavaScript GitHub action `cypress-io/github-action` from this repository.