### PR TITLE
docs: github postpones set-output removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -1499,7 +1499,7 @@ See [Releases](https://github.com/cypress-io/github-action/releases) for full de
 | v2      | Cypress runs using the [Module API](https://docs.cypress.io/guides/guides/module-api) instead of being started via the command line. |
 | v1      | *This version is no longer runnable in GitHub due to security changes.*                                                              |
 
-*Note: [GitHub announced](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) their plan to disable `save-state` and `set-output` commands by May 31, 2023. This will prevent [cypress-io/github-action](https://github.com/cypress-io/github-action) version [v4.2.1](https://github.com/cypress-io/github-action/releases/tag/v4.2.1), and earlier, running after this date since they use `set-output`. Affected users should update to using `v5` of the [cypress-io/github-action](https://github.com/cypress-io/github-action) action before the deadline.*
+*Note: [GitHub announced](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) their plan to disable `save-state` and `set-output` commands. This will prevent [cypress-io/github-action](https://github.com/cypress-io/github-action) version [v4.2.1](https://github.com/cypress-io/github-action/releases/tag/v4.2.1) and earlier from running, since they use `set-output`. Affected users should update to using `v5` of the [cypress-io/github-action](https://github.com/cypress-io/github-action) action.*
 
 ## Contributing
 


### PR DESCRIPTION
This PR updates the [README > Changelog](https://github.com/cypress-io/github-action/blob/master/README.md#changelog) to reflect the updated text in [GitHub's blog](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/).

They originally planned to disable `save-state` and `set-output` commands by May 31, 2023.

Now they write:

> Our telemetry shows significant usage of these commands. Given the number of impacted customers we are postponing the removal.

with no new plan date published.