### PR TITLE
fix(deps): remove node.js 19

### DIFF
--- a/.github/workflows/example-node-versions.yml
+++ b/.github/workflows/example-node-versions.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [16, 18, 19, 20]
+        node: [16, 18, 20]
     name: Cypress v9 E2E on Node v${{ matrix.node }}
     steps:
       - name: Setup Node
@@ -43,7 +43,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [16, 18, 19, 20]
+        node: [16, 18, 20]
     name: Cypress E2E on Node v${{ matrix.node }}
     steps:
       - name: Setup Node

--- a/README.md
+++ b/README.md
@@ -394,7 +394,7 @@ jobs:
     # let's make sure our "app" works on several versions of Node
     strategy:
       matrix:
-        node: [16, 18, 19, 20]
+        node: [16, 18, 20]
     name: E2E on Node v${{ matrix.node }}
     steps:
       - name: Setup Node
@@ -1141,7 +1141,7 @@ jobs:
     # let's make sure our "app" works on several versions of Node
     strategy:
       matrix:
-        node: [16, 18, 19, 20]
+        node: [16, 18, 20]
     name: E2E on Node v${{ matrix.node }}
     steps:
       - name: Setup Node
@@ -1175,7 +1175,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        node: [16, 18, 19, 20]
+        node: [16, 18, 20]
     name: E2E on Node v${{ matrix.node }}
     steps:
       - uses: actions/setup-node@v3
@@ -1481,7 +1481,8 @@ jobs:
 Node.js is required to run this action. The current version `v5` supports:
 
 - **Node.js** 16.x
-- **Node.js** 18.x and above
+- **Node.js** 18.x
+- **Node.js** 20.x and above
 
 and is generally aligned with [Node.js's release schedule](https://github.com/nodejs/Release).
 
@@ -1491,6 +1492,7 @@ See [Releases](https://github.com/cypress-io/github-action/releases) for full de
 
 | Version | Changes                                                                                                                              |
 | ------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| v5.8.1  | Examples remove Node.js 19. End of support for Node.js 19.                                                                           |
 | v5.6.2  | Examples add Node.js 20. End of support and removal of Node.js 14 examples.                                                          |
 | v5.2.0  | Examples add Node.js 19.                                                                                                             |
 | v5.0.0  | Examples add Node.js 18 and remove Node.js 12.                                                                                       |


### PR DESCRIPTION
Node.js `19` moved into end-of-life status on June 1, 2023 and is therefore no longer officially supported. The versions which are currently supported by Node.js according to their [Release schedule](https://github.com/nodejs/release#release-schedule) are now `16`, `18`, and  `20`.

This PR takes account of this Node.js status change. It removes Node.js `19` ...

- from the list of versions which [.github/workflows/example-node-versions.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-node-versions.yml) tests

- from the examples in the [README](https://github.com/cypress-io/github-action/blob/master/README.md) file

The list [Node.js Support](https://github.com/cypress-io/github-action/blob/master/README.md#nodejs-support) of supported versions for the action is changed to show Node.js `16`, `18` and then Node.js `20` and later, thus excluding Node.js `19` from support.

There is **no** change to the action itself which continues to use `node16` as its running environment, therefore these changes are **not** breaking changes. `node16` is the current latest available version for GitHub JavaScript actions.

(The next status change for Node.js is planned for Sep 11, 2023, when Node.js `16` enters end-of-life.)

## References

- Node.js [Release schedule](https://github.com/nodejs/release#release-schedule)
- GitHub [runs.using for JavaScript actions](https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#runsusing-for-javascript-actions)
