### PR TITLE
test: disable video collection and artifact upload for v12 examples

### DIFF
--- a/.github/workflows/example-chrome.yml
+++ b/.github/workflows/example-chrome.yml
@@ -92,11 +92,6 @@ jobs:
           name: screenshots-in-chrome
           path: examples/browser/cypress/screenshots
 
-      - uses: actions/upload-artifact@v3
-        with:
-          name: video-in-chrome
-          path: examples/browser/cypress/videos
-
       - run: npx image-size cypress/screenshots/**/*.png
         working-directory: examples/browser
 
@@ -111,11 +106,6 @@ jobs:
         with:
           name: screenshots-in-headless-chrome
           path: examples/browser/cypress/screenshots
-
-      - uses: actions/upload-artifact@v3
-        with:
-          name: video-in-headless-chrome
-          path: examples/browser/cypress/videos
 
       - run: npx image-size cypress/screenshots/**/*.png
         working-directory: examples/browser

--- a/examples/browser/cypress.config.js
+++ b/examples/browser/cypress.config.js
@@ -27,5 +27,6 @@ module.exports = defineConfig({
       })
     },
     supportFile: false,
+    video: false
   },
 })


### PR DESCRIPTION
This PR makes changes affecting Chrome and Edge browser testing for Cypress 12.x based tests: It ...

- disables video generation in [examples/browser](https://github.com/cypress-io/github-action/tree/master/examples/browser)

- disables video artifact upload in [.github/workflows/example-chrome.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-chrome.yml) for v10+ examples.

*([examples/v9](https://github.com/cypress-io/github-action/tree/master/examples/v9) are not changed)*

## Reasons

Harmonization, simplification and preparation for future Cypress release:

1. Groundwork to be able to consolidate and harmonize browser testing:
    - Cypress cannot generate videos with Firefox (see open issue https://github.com/cypress-io/cypress/issues/18415). PR aligns with [examples/firefox](https://github.com/cypress-io/github-action/blob/master/examples/firefox), which does not generate videos.
    - PR aligns with the [.github/workflows/example-edge.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-edge.yml) example which does not upload videos
2. Uploading video artifacts in addition to screenshot artifacts is not necessary in order to demonstrate artifact upload. Screenshot upload is sufficient for that purpose.
3. Prepares examples for planned changes in Cypress `13` (see https://github.com/cypress-io/cypress/issues/26157). The `v10+` examples for Chrome, Edge and Firefox continue to be compatible with Cypress 10 - 12 and should also be compatible with Cypress `13` when it is released.

## Proposed follow-on steps

In a follow-on PR, additional changes could then be made:

1. Change [.github/workflows/example-firefox.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-firefox.yml) to use common [examples/browser](https://github.com/cypress-io/github-action/tree/master/examples/browser) working-directory
2. Remove [examples/firefox](https://github.com/cypress-io/github-action/tree/master/examples/firefox) redundant working-directory
