### PR TITLE
docs: add resultsurl to changelog

### DIFF
--- a/README.md
+++ b/README.md
@@ -1493,6 +1493,7 @@ See [Releases](https://github.com/cypress-io/github-action/releases) for full de
 | Version | Changes                                                                                                                              |
 | ------- | ------------------------------------------------------------------------------------------------------------------------------------ |
 | v5.8.1  | Examples remove Node.js 19. End of support for Node.js 19.                                                                           |
+| v5.8.0  | Add GitHub step output `resultsUrl`. Deprecate `dashboardUrl`.                                                                       |
 | v5.6.2  | Examples add Node.js 20. End of support and removal of Node.js 14 examples.                                                          |
 | v5.2.0  | Examples add Node.js 19.                                                                                                             |
 | v5.0.0  | Examples add Node.js 18 and remove Node.js 12.                                                                                       |


### PR DESCRIPTION
This PR documents the addition of `resultsUrl` and the deprecation of `dashboardUrl` from PR https://github.com/cypress-io/github-action/pull/916 in release [v5.8.0](https://github.com/cypress-io/github-action/releases/tag/v5.8.0) of the action into the [README > Changelog](https://github.com/cypress-io/github-action/blob/master/README.md#changelog) section.