### PR TITLE
revert: "fix: use yarn instead of npx with yarn.lock (#914)"

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -74457,8 +74457,6 @@ const useYarn = () => fs.existsSync(yarnFilename)
 const usePnpm = () => fs.existsSync(pnpmLockFilename)
 const useNpm = () => fs.existsSync(packageLockFilename)
 
-const runPrefix = useYarn() ? 'yarn' : 'npx'
-
 const lockHash = () => {
   const lockFilename = useYarn()
     ? yarnFilename
@@ -74637,9 +74635,9 @@ const listCypressBinaries = () => {
   }
 
   core.exportVariable('CYPRESS_CACHE_FOLDER', CYPRESS_CACHE_FOLDER)
-  return io.which(runPrefix, true).then((runPath) => {
+  return io.which('npx', true).then((npxPath) => {
     return exec.exec(
-      quote(runPath),
+      quote(npxPath),
       ['cypress', 'cache', 'list'],
       cypressCommandOptions
     )
@@ -74656,9 +74654,9 @@ const verifyCypressBinary = () => {
   }
 
   core.exportVariable('CYPRESS_CACHE_FOLDER', CYPRESS_CACHE_FOLDER)
-  return io.which(runPrefix, true).then((runPath) => {
+  return io.which('npx', true).then((npxPath) => {
     return exec.exec(
-      quote(runPath),
+      quote(npxPath),
       ['cypress', 'verify'],
       cypressCommandOptions
     )

--- a/index.js
+++ b/index.js
@@ -106,8 +106,6 @@ const useYarn = () => fs.existsSync(yarnFilename)
 const usePnpm = () => fs.existsSync(pnpmLockFilename)
 const useNpm = () => fs.existsSync(packageLockFilename)
 
-const runPrefix = useYarn() ? 'yarn' : 'npx'
-
 const lockHash = () => {
   const lockFilename = useYarn()
     ? yarnFilename
@@ -286,9 +284,9 @@ const listCypressBinaries = () => {
   }
 
   core.exportVariable('CYPRESS_CACHE_FOLDER', CYPRESS_CACHE_FOLDER)
-  return io.which(runPrefix, true).then((runPath) => {
+  return io.which('npx', true).then((npxPath) => {
     return exec.exec(
-      quote(runPath),
+      quote(npxPath),
       ['cypress', 'cache', 'list'],
       cypressCommandOptions
     )
@@ -305,9 +303,9 @@ const verifyCypressBinary = () => {
   }
 
   core.exportVariable('CYPRESS_CACHE_FOLDER', CYPRESS_CACHE_FOLDER)
-  return io.which(runPrefix, true).then((runPath) => {
+  return io.which('npx', true).then((npxPath) => {
     return exec.exec(
-      quote(runPath),
+      quote(npxPath),
       ['cypress', 'verify'],
       cypressCommandOptions
     )


### PR DESCRIPTION
This PR reverts https://github.com/cypress-io/github-action/pull/914 which caused a breaking change due to replacing `npx cypress cache list` by `yarn cypress cache list` for Yarn projects.

If the working-directory contains a script definition with the name `cypress` then yarn uses this script definition instead of executing `cypress` from `node_modules`. In the case of issue https://github.com/cypress-io/github-action/issues/941 this caused the workflow to hang indefinitely.

PR https://github.com/cypress-io/github-action/pull/914 was intended to resolve an issue with Yarn Modern Plug'n'Play, however the PR is applied to all types of Yarn projects (Classic & Modern).

The changes defined in https://github.com/cypress-io/github-action/pull/914 should be rescheduled for a future date when other breaking changes are planned.

cc: @warrensplayer - Assignee of #914