### PR TITLE
chore(deps): update cypress to 12.15.0

### DIFF
--- a/.github/workflows/example-install-only.yml
+++ b/.github/workflows/example-install-only.yml
@@ -63,7 +63,7 @@ jobs:
           key: my-cache-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
 
       - name: Install Cypress 📥
-        run: npm i cypress@12.14.0
+        run: npm i cypress@12.15.0
 
       - name: Cypress tests 🧪
         uses: ./

--- a/examples/basic-pnpm/package.json
+++ b/examples/basic-pnpm/package.json
@@ -8,6 +8,6 @@
   },
   "private": true,
   "devDependencies": {
-    "cypress": "12.14.0"
+    "cypress": "12.15.0"
   }
 }

--- a/examples/basic-pnpm/pnpm-lock.yaml
+++ b/examples/basic-pnpm/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.1'
+lockfileVersion: '6.0'
 
 settings:
   autoInstallPeers: true
@@ -6,8 +6,8 @@ settings:
 
 devDependencies:
   cypress:
-    specifier: 12.14.0
-    version: 12.14.0
+    specifier: 12.15.0
+    version: 12.15.0
 
 packages:
 
@@ -296,8 +296,8 @@ packages:
       which: 2.0.2
     dev: true
 
-  /cypress@12.14.0:
-    resolution: {integrity: sha512-HiLIXKXZaIT1RT7sw1sVPt+qKtis3uYNm6KwC4qoYjabwLKaqZlyS/P+uVvvlBNcHIwL/BC6nQZajpbUd7hOgQ==}
+  /cypress@12.15.0:
+    resolution: {integrity: sha512-FqGbxsH+QgjStuTO9onXMIeF44eOrgVwPvlcvuzLIaePQMkl72YgBvpuHlBGRcrw3Q4SvqKfajN8iV5XWShAiQ==}
     engines: {node: ^14.0.0 || ^16.0.0 || >=18.0.0}
     hasBin: true
     requiresBuild: true

--- a/examples/basic/package-lock.json
+++ b/examples/basic/package-lock.json
@@ -8,7 +8,7 @@
       "name": "example-basic",
       "version": "1.0.0",
       "devDependencies": {
-        "cypress": "12.14.0"
+        "cypress": "12.15.0"
       }
     },
     "node_modules/@colors/colors": {
@@ -544,9 +544,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "12.14.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.14.0.tgz",
-      "integrity": "sha512-HiLIXKXZaIT1RT7sw1sVPt+qKtis3uYNm6KwC4qoYjabwLKaqZlyS/P+uVvvlBNcHIwL/BC6nQZajpbUd7hOgQ==",
+      "version": "12.15.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.15.0.tgz",
+      "integrity": "sha512-FqGbxsH+QgjStuTO9onXMIeF44eOrgVwPvlcvuzLIaePQMkl72YgBvpuHlBGRcrw3Q4SvqKfajN8iV5XWShAiQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -2309,9 +2309,9 @@
       }
     },
     "cypress": {
-      "version": "12.14.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.14.0.tgz",
-      "integrity": "sha512-HiLIXKXZaIT1RT7sw1sVPt+qKtis3uYNm6KwC4qoYjabwLKaqZlyS/P+uVvvlBNcHIwL/BC6nQZajpbUd7hOgQ==",
+      "version": "12.15.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.15.0.tgz",
+      "integrity": "sha512-FqGbxsH+QgjStuTO9onXMIeF44eOrgVwPvlcvuzLIaePQMkl72YgBvpuHlBGRcrw3Q4SvqKfajN8iV5XWShAiQ==",
       "dev": true,
       "requires": {
         "@cypress/request": "^2.88.10",

--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -8,6 +8,6 @@
   },
   "private": true,
   "devDependencies": {
-    "cypress": "12.14.0"
+    "cypress": "12.15.0"
   }
 }

--- a/examples/browser/package-lock.json
+++ b/examples/browser/package-lock.json
@@ -8,7 +8,7 @@
       "name": "example-browser",
       "version": "1.1.0",
       "devDependencies": {
-        "cypress": "12.14.0",
+        "cypress": "12.15.0",
         "image-size": "^1.0.2"
       }
     },
@@ -545,9 +545,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "12.14.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.14.0.tgz",
-      "integrity": "sha512-HiLIXKXZaIT1RT7sw1sVPt+qKtis3uYNm6KwC4qoYjabwLKaqZlyS/P+uVvvlBNcHIwL/BC6nQZajpbUd7hOgQ==",
+      "version": "12.15.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.15.0.tgz",
+      "integrity": "sha512-FqGbxsH+QgjStuTO9onXMIeF44eOrgVwPvlcvuzLIaePQMkl72YgBvpuHlBGRcrw3Q4SvqKfajN8iV5XWShAiQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -2334,9 +2334,9 @@
       }
     },
     "cypress": {
-      "version": "12.14.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.14.0.tgz",
-      "integrity": "sha512-HiLIXKXZaIT1RT7sw1sVPt+qKtis3uYNm6KwC4qoYjabwLKaqZlyS/P+uVvvlBNcHIwL/BC6nQZajpbUd7hOgQ==",
+      "version": "12.15.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.15.0.tgz",
+      "integrity": "sha512-FqGbxsH+QgjStuTO9onXMIeF44eOrgVwPvlcvuzLIaePQMkl72YgBvpuHlBGRcrw3Q4SvqKfajN8iV5XWShAiQ==",
       "dev": true,
       "requires": {
         "@cypress/request": "^2.88.10",

--- a/examples/browser/package.json
+++ b/examples/browser/package.json
@@ -13,7 +13,7 @@
   },
   "private": true,
   "devDependencies": {
-    "cypress": "12.14.0",
+    "cypress": "12.15.0",
     "image-size": "^1.0.2"
   }
 }

--- a/examples/component-tests/package-lock.json
+++ b/examples/component-tests/package-lock.json
@@ -15,7 +15,7 @@
         "@types/react": "^18.0.26",
         "@types/react-dom": "^18.0.9",
         "@vitejs/plugin-react": "^3.0.0",
-        "cypress": "12.14.0",
+        "cypress": "12.15.0",
         "vite": "^4.3.9"
       }
     },
@@ -1393,9 +1393,9 @@
       "dev": true
     },
     "node_modules/cypress": {
-      "version": "12.14.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.14.0.tgz",
-      "integrity": "sha512-HiLIXKXZaIT1RT7sw1sVPt+qKtis3uYNm6KwC4qoYjabwLKaqZlyS/P+uVvvlBNcHIwL/BC6nQZajpbUd7hOgQ==",
+      "version": "12.15.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.15.0.tgz",
+      "integrity": "sha512-FqGbxsH+QgjStuTO9onXMIeF44eOrgVwPvlcvuzLIaePQMkl72YgBvpuHlBGRcrw3Q4SvqKfajN8iV5XWShAiQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -4295,9 +4295,9 @@
       "dev": true
     },
     "cypress": {
-      "version": "12.14.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.14.0.tgz",
-      "integrity": "sha512-HiLIXKXZaIT1RT7sw1sVPt+qKtis3uYNm6KwC4qoYjabwLKaqZlyS/P+uVvvlBNcHIwL/BC6nQZajpbUd7hOgQ==",
+      "version": "12.15.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.15.0.tgz",
+      "integrity": "sha512-FqGbxsH+QgjStuTO9onXMIeF44eOrgVwPvlcvuzLIaePQMkl72YgBvpuHlBGRcrw3Q4SvqKfajN8iV5XWShAiQ==",
       "dev": true,
       "requires": {
         "@cypress/request": "^2.88.10",

--- a/examples/component-tests/package.json
+++ b/examples/component-tests/package.json
@@ -17,7 +17,7 @@
     "@types/react": "^18.0.26",
     "@types/react-dom": "^18.0.9",
     "@vitejs/plugin-react": "^3.0.0",
-    "cypress": "12.14.0",
+    "cypress": "12.15.0",
     "vite": "^4.3.9"
   }
 }

--- a/examples/config/package-lock.json
+++ b/examples/config/package-lock.json
@@ -8,7 +8,7 @@
       "name": "example-config",
       "version": "1.0.0",
       "devDependencies": {
-        "cypress": "12.14.0",
+        "cypress": "12.15.0",
         "serve": "^14.2.0",
         "start-server-and-test": "2.0.0"
       }
@@ -932,9 +932,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "12.14.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.14.0.tgz",
-      "integrity": "sha512-HiLIXKXZaIT1RT7sw1sVPt+qKtis3uYNm6KwC4qoYjabwLKaqZlyS/P+uVvvlBNcHIwL/BC6nQZajpbUd7hOgQ==",
+      "version": "12.15.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.15.0.tgz",
+      "integrity": "sha512-FqGbxsH+QgjStuTO9onXMIeF44eOrgVwPvlcvuzLIaePQMkl72YgBvpuHlBGRcrw3Q4SvqKfajN8iV5XWShAiQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -3524,9 +3524,9 @@
       }
     },
     "cypress": {
-      "version": "12.14.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.14.0.tgz",
-      "integrity": "sha512-HiLIXKXZaIT1RT7sw1sVPt+qKtis3uYNm6KwC4qoYjabwLKaqZlyS/P+uVvvlBNcHIwL/BC6nQZajpbUd7hOgQ==",
+      "version": "12.15.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.15.0.tgz",
+      "integrity": "sha512-FqGbxsH+QgjStuTO9onXMIeF44eOrgVwPvlcvuzLIaePQMkl72YgBvpuHlBGRcrw3Q4SvqKfajN8iV5XWShAiQ==",
       "dev": true,
       "requires": {
         "@cypress/request": "^2.88.10",

--- a/examples/config/package.json
+++ b/examples/config/package.json
@@ -12,7 +12,7 @@
   },
   "private": true,
   "devDependencies": {
-    "cypress": "12.14.0",
+    "cypress": "12.15.0",
     "serve": "^14.2.0",
     "start-server-and-test": "2.0.0"
   }

--- a/examples/custom-command/package-lock.json
+++ b/examples/custom-command/package-lock.json
@@ -8,7 +8,7 @@
       "name": "example-custom-command",
       "version": "1.0.0",
       "devDependencies": {
-        "cypress": "12.14.0",
+        "cypress": "12.15.0",
         "lodash": "4.17.21"
       }
     },
@@ -545,9 +545,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "12.14.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.14.0.tgz",
-      "integrity": "sha512-HiLIXKXZaIT1RT7sw1sVPt+qKtis3uYNm6KwC4qoYjabwLKaqZlyS/P+uVvvlBNcHIwL/BC6nQZajpbUd7hOgQ==",
+      "version": "12.15.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.15.0.tgz",
+      "integrity": "sha512-FqGbxsH+QgjStuTO9onXMIeF44eOrgVwPvlcvuzLIaePQMkl72YgBvpuHlBGRcrw3Q4SvqKfajN8iV5XWShAiQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -2310,9 +2310,9 @@
       }
     },
     "cypress": {
-      "version": "12.14.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.14.0.tgz",
-      "integrity": "sha512-HiLIXKXZaIT1RT7sw1sVPt+qKtis3uYNm6KwC4qoYjabwLKaqZlyS/P+uVvvlBNcHIwL/BC6nQZajpbUd7hOgQ==",
+      "version": "12.15.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.15.0.tgz",
+      "integrity": "sha512-FqGbxsH+QgjStuTO9onXMIeF44eOrgVwPvlcvuzLIaePQMkl72YgBvpuHlBGRcrw3Q4SvqKfajN8iV5XWShAiQ==",
       "dev": true,
       "requires": {
         "@cypress/request": "^2.88.10",

--- a/examples/custom-command/package.json
+++ b/examples/custom-command/package.json
@@ -9,7 +9,7 @@
   },
   "private": true,
   "devDependencies": {
-    "cypress": "12.14.0",
+    "cypress": "12.15.0",
     "lodash": "4.17.21"
   }
 }

--- a/examples/env/package-lock.json
+++ b/examples/env/package-lock.json
@@ -8,7 +8,7 @@
       "name": "example-env",
       "version": "1.0.0",
       "devDependencies": {
-        "cypress": "12.14.0"
+        "cypress": "12.15.0"
       }
     },
     "node_modules/@colors/colors": {
@@ -544,9 +544,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "12.14.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.14.0.tgz",
-      "integrity": "sha512-HiLIXKXZaIT1RT7sw1sVPt+qKtis3uYNm6KwC4qoYjabwLKaqZlyS/P+uVvvlBNcHIwL/BC6nQZajpbUd7hOgQ==",
+      "version": "12.15.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.15.0.tgz",
+      "integrity": "sha512-FqGbxsH+QgjStuTO9onXMIeF44eOrgVwPvlcvuzLIaePQMkl72YgBvpuHlBGRcrw3Q4SvqKfajN8iV5XWShAiQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -2309,9 +2309,9 @@
       }
     },
     "cypress": {
-      "version": "12.14.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.14.0.tgz",
-      "integrity": "sha512-HiLIXKXZaIT1RT7sw1sVPt+qKtis3uYNm6KwC4qoYjabwLKaqZlyS/P+uVvvlBNcHIwL/BC6nQZajpbUd7hOgQ==",
+      "version": "12.15.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.15.0.tgz",
+      "integrity": "sha512-FqGbxsH+QgjStuTO9onXMIeF44eOrgVwPvlcvuzLIaePQMkl72YgBvpuHlBGRcrw3Q4SvqKfajN8iV5XWShAiQ==",
       "dev": true,
       "requires": {
         "@cypress/request": "^2.88.10",

--- a/examples/env/package.json
+++ b/examples/env/package.json
@@ -8,6 +8,6 @@
   },
   "private": true,
   "devDependencies": {
-    "cypress": "12.14.0"
+    "cypress": "12.15.0"
   }
 }

--- a/examples/install-command/package.json
+++ b/examples/install-command/package.json
@@ -7,7 +7,7 @@
   },
   "private": true,
   "devDependencies": {
-    "cypress": "12.14.0"
+    "cypress": "12.15.0"
   },
   "dependencies": {
     "arg": "5.0.0",

--- a/examples/install-command/yarn.lock
+++ b/examples/install-command/yarn.lock
@@ -308,10 +308,10 @@ cross-spawn@^7.0.0:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
-cypress@12.14.0:
-  version "12.14.0"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-12.14.0.tgz#37a19b85f5e9d881995e9fee1ddf41b3d3a623dd"
-  integrity sha512-HiLIXKXZaIT1RT7sw1sVPt+qKtis3uYNm6KwC4qoYjabwLKaqZlyS/P+uVvvlBNcHIwL/BC6nQZajpbUd7hOgQ==
+cypress@12.15.0:
+  version "12.15.0"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-12.15.0.tgz#06103529583c41f39712c6cfa6d9d09a01731760"
+  integrity sha512-FqGbxsH+QgjStuTO9onXMIeF44eOrgVwPvlcvuzLIaePQMkl72YgBvpuHlBGRcrw3Q4SvqKfajN8iV5XWShAiQ==
   dependencies:
     "@cypress/request" "^2.88.10"
     "@cypress/xvfb" "^1.2.4"

--- a/examples/install-only/package-lock.json
+++ b/examples/install-only/package-lock.json
@@ -12,7 +12,7 @@
         "debug": "4.2.0"
       },
       "devDependencies": {
-        "cypress": "12.14.0"
+        "cypress": "12.15.0"
       }
     },
     "node_modules/@colors/colors": {
@@ -553,9 +553,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "12.14.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.14.0.tgz",
-      "integrity": "sha512-HiLIXKXZaIT1RT7sw1sVPt+qKtis3uYNm6KwC4qoYjabwLKaqZlyS/P+uVvvlBNcHIwL/BC6nQZajpbUd7hOgQ==",
+      "version": "12.15.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.15.0.tgz",
+      "integrity": "sha512-FqGbxsH+QgjStuTO9onXMIeF44eOrgVwPvlcvuzLIaePQMkl72YgBvpuHlBGRcrw3Q4SvqKfajN8iV5XWShAiQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -2339,9 +2339,9 @@
       }
     },
     "cypress": {
-      "version": "12.14.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.14.0.tgz",
-      "integrity": "sha512-HiLIXKXZaIT1RT7sw1sVPt+qKtis3uYNm6KwC4qoYjabwLKaqZlyS/P+uVvvlBNcHIwL/BC6nQZajpbUd7hOgQ==",
+      "version": "12.15.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.15.0.tgz",
+      "integrity": "sha512-FqGbxsH+QgjStuTO9onXMIeF44eOrgVwPvlcvuzLIaePQMkl72YgBvpuHlBGRcrw3Q4SvqKfajN8iV5XWShAiQ==",
       "dev": true,
       "requires": {
         "@cypress/request": "^2.88.10",

--- a/examples/install-only/package.json
+++ b/examples/install-only/package.json
@@ -11,6 +11,6 @@
     "debug": "4.2.0"
   },
   "devDependencies": {
-    "cypress": "12.14.0"
+    "cypress": "12.15.0"
   }
 }

--- a/examples/nextjs/package-lock.json
+++ b/examples/nextjs/package-lock.json
@@ -13,7 +13,7 @@
         "react-dom": "18.2.0"
       },
       "devDependencies": {
-        "cypress": "12.14.0"
+        "cypress": "12.15.0"
       }
     },
     "node_modules/@colors/colors": {
@@ -732,9 +732,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "12.14.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.14.0.tgz",
-      "integrity": "sha512-HiLIXKXZaIT1RT7sw1sVPt+qKtis3uYNm6KwC4qoYjabwLKaqZlyS/P+uVvvlBNcHIwL/BC6nQZajpbUd7hOgQ==",
+      "version": "12.15.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.15.0.tgz",
+      "integrity": "sha512-FqGbxsH+QgjStuTO9onXMIeF44eOrgVwPvlcvuzLIaePQMkl72YgBvpuHlBGRcrw3Q4SvqKfajN8iV5XWShAiQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {

--- a/examples/nextjs/package.json
+++ b/examples/nextjs/package.json
@@ -15,6 +15,6 @@
     "react-dom": "18.2.0"
   },
   "devDependencies": {
-    "cypress": "12.14.0"
+    "cypress": "12.15.0"
   }
 }

--- a/examples/node-versions/package-lock.json
+++ b/examples/node-versions/package-lock.json
@@ -8,7 +8,7 @@
       "name": "example-node-versions",
       "version": "1.0.0",
       "devDependencies": {
-        "cypress": "12.14.0"
+        "cypress": "12.15.0"
       }
     },
     "node_modules/@colors/colors": {
@@ -544,9 +544,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "12.14.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.14.0.tgz",
-      "integrity": "sha512-HiLIXKXZaIT1RT7sw1sVPt+qKtis3uYNm6KwC4qoYjabwLKaqZlyS/P+uVvvlBNcHIwL/BC6nQZajpbUd7hOgQ==",
+      "version": "12.15.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.15.0.tgz",
+      "integrity": "sha512-FqGbxsH+QgjStuTO9onXMIeF44eOrgVwPvlcvuzLIaePQMkl72YgBvpuHlBGRcrw3Q4SvqKfajN8iV5XWShAiQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -2309,9 +2309,9 @@
       }
     },
     "cypress": {
-      "version": "12.14.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.14.0.tgz",
-      "integrity": "sha512-HiLIXKXZaIT1RT7sw1sVPt+qKtis3uYNm6KwC4qoYjabwLKaqZlyS/P+uVvvlBNcHIwL/BC6nQZajpbUd7hOgQ==",
+      "version": "12.15.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.15.0.tgz",
+      "integrity": "sha512-FqGbxsH+QgjStuTO9onXMIeF44eOrgVwPvlcvuzLIaePQMkl72YgBvpuHlBGRcrw3Q4SvqKfajN8iV5XWShAiQ==",
       "dev": true,
       "requires": {
         "@cypress/request": "^2.88.10",

--- a/examples/node-versions/package.json
+++ b/examples/node-versions/package.json
@@ -8,6 +8,6 @@
   },
   "private": true,
   "devDependencies": {
-    "cypress": "12.14.0"
+    "cypress": "12.15.0"
   }
 }

--- a/examples/quiet/package-lock.json
+++ b/examples/quiet/package-lock.json
@@ -8,7 +8,7 @@
       "name": "example-quiet",
       "version": "1.0.0",
       "devDependencies": {
-        "cypress": "12.14.0",
+        "cypress": "12.15.0",
         "image-size": "0.8.3"
       }
     },
@@ -545,9 +545,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "12.14.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.14.0.tgz",
-      "integrity": "sha512-HiLIXKXZaIT1RT7sw1sVPt+qKtis3uYNm6KwC4qoYjabwLKaqZlyS/P+uVvvlBNcHIwL/BC6nQZajpbUd7hOgQ==",
+      "version": "12.15.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.15.0.tgz",
+      "integrity": "sha512-FqGbxsH+QgjStuTO9onXMIeF44eOrgVwPvlcvuzLIaePQMkl72YgBvpuHlBGRcrw3Q4SvqKfajN8iV5XWShAiQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -2334,9 +2334,9 @@
       }
     },
     "cypress": {
-      "version": "12.14.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.14.0.tgz",
-      "integrity": "sha512-HiLIXKXZaIT1RT7sw1sVPt+qKtis3uYNm6KwC4qoYjabwLKaqZlyS/P+uVvvlBNcHIwL/BC6nQZajpbUd7hOgQ==",
+      "version": "12.15.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.15.0.tgz",
+      "integrity": "sha512-FqGbxsH+QgjStuTO9onXMIeF44eOrgVwPvlcvuzLIaePQMkl72YgBvpuHlBGRcrw3Q4SvqKfajN8iV5XWShAiQ==",
       "dev": true,
       "requires": {
         "@cypress/request": "^2.88.10",

--- a/examples/quiet/package.json
+++ b/examples/quiet/package.json
@@ -9,7 +9,7 @@
   },
   "private": true,
   "devDependencies": {
-    "cypress": "12.14.0",
+    "cypress": "12.15.0",
     "image-size": "0.8.3"
   }
 }

--- a/examples/recording/package-lock.json
+++ b/examples/recording/package-lock.json
@@ -8,7 +8,7 @@
       "name": "example-recording",
       "version": "1.0.0",
       "devDependencies": {
-        "cypress": "12.14.0"
+        "cypress": "12.15.0"
       }
     },
     "node_modules/@colors/colors": {
@@ -544,9 +544,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "12.14.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.14.0.tgz",
-      "integrity": "sha512-HiLIXKXZaIT1RT7sw1sVPt+qKtis3uYNm6KwC4qoYjabwLKaqZlyS/P+uVvvlBNcHIwL/BC6nQZajpbUd7hOgQ==",
+      "version": "12.15.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.15.0.tgz",
+      "integrity": "sha512-FqGbxsH+QgjStuTO9onXMIeF44eOrgVwPvlcvuzLIaePQMkl72YgBvpuHlBGRcrw3Q4SvqKfajN8iV5XWShAiQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -2309,9 +2309,9 @@
       }
     },
     "cypress": {
-      "version": "12.14.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.14.0.tgz",
-      "integrity": "sha512-HiLIXKXZaIT1RT7sw1sVPt+qKtis3uYNm6KwC4qoYjabwLKaqZlyS/P+uVvvlBNcHIwL/BC6nQZajpbUd7hOgQ==",
+      "version": "12.15.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.15.0.tgz",
+      "integrity": "sha512-FqGbxsH+QgjStuTO9onXMIeF44eOrgVwPvlcvuzLIaePQMkl72YgBvpuHlBGRcrw3Q4SvqKfajN8iV5XWShAiQ==",
       "dev": true,
       "requires": {
         "@cypress/request": "^2.88.10",

--- a/examples/recording/package.json
+++ b/examples/recording/package.json
@@ -9,6 +9,6 @@
   },
   "private": true,
   "devDependencies": {
-    "cypress": "12.14.0"
+    "cypress": "12.15.0"
   }
 }

--- a/examples/start-and-yarn-workspaces/workspace-1/package.json
+++ b/examples/start-and-yarn-workspaces/workspace-1/package.json
@@ -10,7 +10,7 @@
   },
   "private": true,
   "devDependencies": {
-    "cypress": "12.14.0",
+    "cypress": "12.15.0",
     "serve": "^14.2.0"
   }
 }

--- a/examples/start-and-yarn-workspaces/workspace-2/package.json
+++ b/examples/start-and-yarn-workspaces/workspace-2/package.json
@@ -10,7 +10,7 @@
   },
   "private": true,
   "devDependencies": {
-    "cypress": "12.14.0",
+    "cypress": "12.15.0",
     "serve": "^14.2.0"
   }
 }

--- a/examples/start-and-yarn-workspaces/yarn.lock
+++ b/examples/start-and-yarn-workspaces/yarn.lock
@@ -436,10 +436,10 @@ cross-spawn@^7.0.0, cross-spawn@^7.0.3:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
-cypress@12.14.0:
-  version "12.14.0"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-12.14.0.tgz#37a19b85f5e9d881995e9fee1ddf41b3d3a623dd"
-  integrity sha512-HiLIXKXZaIT1RT7sw1sVPt+qKtis3uYNm6KwC4qoYjabwLKaqZlyS/P+uVvvlBNcHIwL/BC6nQZajpbUd7hOgQ==
+cypress@12.15.0:
+  version "12.15.0"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-12.15.0.tgz#06103529583c41f39712c6cfa6d9d09a01731760"
+  integrity sha512-FqGbxsH+QgjStuTO9onXMIeF44eOrgVwPvlcvuzLIaePQMkl72YgBvpuHlBGRcrw3Q4SvqKfajN8iV5XWShAiQ==
   dependencies:
     "@cypress/request" "^2.88.10"
     "@cypress/xvfb" "^1.2.4"

--- a/examples/start/package-lock.json
+++ b/examples/start/package-lock.json
@@ -8,7 +8,7 @@
       "name": "example-start",
       "version": "1.0.0",
       "devDependencies": {
-        "cypress": "12.14.0",
+        "cypress": "12.15.0",
         "serve": "^14.2.0"
       }
     },
@@ -871,9 +871,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "12.14.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.14.0.tgz",
-      "integrity": "sha512-HiLIXKXZaIT1RT7sw1sVPt+qKtis3uYNm6KwC4qoYjabwLKaqZlyS/P+uVvvlBNcHIwL/BC6nQZajpbUd7hOgQ==",
+      "version": "12.15.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.15.0.tgz",
+      "integrity": "sha512-FqGbxsH+QgjStuTO9onXMIeF44eOrgVwPvlcvuzLIaePQMkl72YgBvpuHlBGRcrw3Q4SvqKfajN8iV5XWShAiQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -3208,9 +3208,9 @@
       }
     },
     "cypress": {
-      "version": "12.14.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.14.0.tgz",
-      "integrity": "sha512-HiLIXKXZaIT1RT7sw1sVPt+qKtis3uYNm6KwC4qoYjabwLKaqZlyS/P+uVvvlBNcHIwL/BC6nQZajpbUd7hOgQ==",
+      "version": "12.15.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.15.0.tgz",
+      "integrity": "sha512-FqGbxsH+QgjStuTO9onXMIeF44eOrgVwPvlcvuzLIaePQMkl72YgBvpuHlBGRcrw3Q4SvqKfajN8iV5XWShAiQ==",
       "dev": true,
       "requires": {
         "@cypress/request": "^2.88.10",

--- a/examples/start/package.json
+++ b/examples/start/package.json
@@ -11,7 +11,7 @@
   },
   "private": true,
   "devDependencies": {
-    "cypress": "12.14.0",
+    "cypress": "12.15.0",
     "serve": "^14.2.0"
   }
 }

--- a/examples/wait-on-vite/package-lock.json
+++ b/examples/wait-on-vite/package-lock.json
@@ -8,7 +8,7 @@
       "name": "example-wait-on-vite",
       "version": "2.0.0",
       "devDependencies": {
-        "cypress": "12.14.0",
+        "cypress": "12.15.0",
         "vite": "^4.3.9"
       }
     },
@@ -897,9 +897,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "12.14.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.14.0.tgz",
-      "integrity": "sha512-HiLIXKXZaIT1RT7sw1sVPt+qKtis3uYNm6KwC4qoYjabwLKaqZlyS/P+uVvvlBNcHIwL/BC6nQZajpbUd7hOgQ==",
+      "version": "12.15.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.15.0.tgz",
+      "integrity": "sha512-FqGbxsH+QgjStuTO9onXMIeF44eOrgVwPvlcvuzLIaePQMkl72YgBvpuHlBGRcrw3Q4SvqKfajN8iV5XWShAiQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -2992,9 +2992,9 @@
       }
     },
     "cypress": {
-      "version": "12.14.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.14.0.tgz",
-      "integrity": "sha512-HiLIXKXZaIT1RT7sw1sVPt+qKtis3uYNm6KwC4qoYjabwLKaqZlyS/P+uVvvlBNcHIwL/BC6nQZajpbUd7hOgQ==",
+      "version": "12.15.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.15.0.tgz",
+      "integrity": "sha512-FqGbxsH+QgjStuTO9onXMIeF44eOrgVwPvlcvuzLIaePQMkl72YgBvpuHlBGRcrw3Q4SvqKfajN8iV5XWShAiQ==",
       "dev": true,
       "requires": {
         "@cypress/request": "^2.88.10",

--- a/examples/wait-on-vite/package.json
+++ b/examples/wait-on-vite/package.json
@@ -10,7 +10,7 @@
   },
   "private": true,
   "devDependencies": {
-    "cypress": "12.14.0",
+    "cypress": "12.15.0",
     "vite": "^4.3.9"
   }
 }

--- a/examples/wait-on/package-lock.json
+++ b/examples/wait-on/package-lock.json
@@ -12,7 +12,7 @@
         "debug": "4.3.4"
       },
       "devDependencies": {
-        "cypress": "12.14.0"
+        "cypress": "12.15.0"
       }
     },
     "node_modules/@colors/colors": {
@@ -553,9 +553,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "12.14.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.14.0.tgz",
-      "integrity": "sha512-HiLIXKXZaIT1RT7sw1sVPt+qKtis3uYNm6KwC4qoYjabwLKaqZlyS/P+uVvvlBNcHIwL/BC6nQZajpbUd7hOgQ==",
+      "version": "12.15.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.15.0.tgz",
+      "integrity": "sha512-FqGbxsH+QgjStuTO9onXMIeF44eOrgVwPvlcvuzLIaePQMkl72YgBvpuHlBGRcrw3Q4SvqKfajN8iV5XWShAiQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -2321,9 +2321,9 @@
       }
     },
     "cypress": {
-      "version": "12.14.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.14.0.tgz",
-      "integrity": "sha512-HiLIXKXZaIT1RT7sw1sVPt+qKtis3uYNm6KwC4qoYjabwLKaqZlyS/P+uVvvlBNcHIwL/BC6nQZajpbUd7hOgQ==",
+      "version": "12.15.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.15.0.tgz",
+      "integrity": "sha512-FqGbxsH+QgjStuTO9onXMIeF44eOrgVwPvlcvuzLIaePQMkl72YgBvpuHlBGRcrw3Q4SvqKfajN8iV5XWShAiQ==",
       "dev": true,
       "requires": {
         "@cypress/request": "^2.88.10",

--- a/examples/wait-on/package.json
+++ b/examples/wait-on/package.json
@@ -20,6 +20,6 @@
     "debug": "4.3.4"
   },
   "devDependencies": {
-    "cypress": "12.14.0"
+    "cypress": "12.15.0"
   }
 }

--- a/examples/webpack/package-lock.json
+++ b/examples/webpack/package-lock.json
@@ -8,7 +8,7 @@
       "name": "example-webpack",
       "version": "1.0.0",
       "devDependencies": {
-        "cypress": "12.14.0",
+        "cypress": "12.15.0",
         "webpack": "5.81.0",
         "webpack-cli": "5.0.2",
         "webpack-dev-server": "4.13.3"
@@ -1436,9 +1436,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "12.14.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.14.0.tgz",
-      "integrity": "sha512-HiLIXKXZaIT1RT7sw1sVPt+qKtis3uYNm6KwC4qoYjabwLKaqZlyS/P+uVvvlBNcHIwL/BC6nQZajpbUd7hOgQ==",
+      "version": "12.15.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.15.0.tgz",
+      "integrity": "sha512-FqGbxsH+QgjStuTO9onXMIeF44eOrgVwPvlcvuzLIaePQMkl72YgBvpuHlBGRcrw3Q4SvqKfajN8iV5XWShAiQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {

--- a/examples/webpack/package.json
+++ b/examples/webpack/package.json
@@ -8,7 +8,7 @@
   },
   "private": true,
   "devDependencies": {
-    "cypress": "12.14.0",
+    "cypress": "12.15.0",
     "webpack": "5.81.0",
     "webpack-cli": "5.0.2",
     "webpack-dev-server": "4.13.3"

--- a/examples/yarn-classic/package.json
+++ b/examples/yarn-classic/package.json
@@ -7,6 +7,6 @@
   },
   "private": true,
   "devDependencies": {
-    "cypress": "12.14.0"
+    "cypress": "12.15.0"
   }
 }

--- a/examples/yarn-classic/yarn.lock
+++ b/examples/yarn-classic/yarn.lock
@@ -303,10 +303,10 @@ cross-spawn@^7.0.0:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
-cypress@12.14.0:
-  version "12.14.0"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-12.14.0.tgz#37a19b85f5e9d881995e9fee1ddf41b3d3a623dd"
-  integrity sha512-HiLIXKXZaIT1RT7sw1sVPt+qKtis3uYNm6KwC4qoYjabwLKaqZlyS/P+uVvvlBNcHIwL/BC6nQZajpbUd7hOgQ==
+cypress@12.15.0:
+  version "12.15.0"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-12.15.0.tgz#06103529583c41f39712c6cfa6d9d09a01731760"
+  integrity sha512-FqGbxsH+QgjStuTO9onXMIeF44eOrgVwPvlcvuzLIaePQMkl72YgBvpuHlBGRcrw3Q4SvqKfajN8iV5XWShAiQ==
   dependencies:
     "@cypress/request" "^2.88.10"
     "@cypress/xvfb" "^1.2.4"

--- a/examples/yarn-modern-pnp/package.json
+++ b/examples/yarn-modern-pnp/package.json
@@ -7,7 +7,7 @@
   },
   "private": true,
   "devDependencies": {
-    "cypress": "12.14.0"
+    "cypress": "12.15.0"
   },
   "packageManager": "yarn@3.6.0"
 }

--- a/examples/yarn-modern-pnp/yarn.lock
+++ b/examples/yarn-modern-pnp/yarn.lock
@@ -414,9 +414,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cypress@npm:12.14.0":
-  version: 12.14.0
-  resolution: "cypress@npm:12.14.0"
+"cypress@npm:12.15.0":
+  version: 12.15.0
+  resolution: "cypress@npm:12.15.0"
   dependencies:
     "@cypress/request": ^2.88.10
     "@cypress/xvfb": ^1.2.4
@@ -462,7 +462,7 @@ __metadata:
     yauzl: ^2.10.0
   bin:
     cypress: bin/cypress
-  checksum: c98d33dc50f5e48a215f41e3a5139514816d2320e433d143a352a460f74941d3106a1f7485f61172f544cf125176c1225ac8edec31645d5a89cd394f72f93588
+  checksum: a1989386bc0843377526c71d60a7c2d64593fbf3209cd5986cb684653d1092007add9d83910906b85e1801637206dd5fa5ce9627c6ada3a20a3a82ec5c2f4d7a
   languageName: node
   linkType: hard
 
@@ -563,7 +563,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "example-yarn-modern@workspace:."
   dependencies:
-    cypress: 12.14.0
+    cypress: 12.15.0
   languageName: unknown
   linkType: soft
 

--- a/examples/yarn-modern/package.json
+++ b/examples/yarn-modern/package.json
@@ -7,7 +7,7 @@
   },
   "private": true,
   "devDependencies": {
-    "cypress": "12.14.0"
+    "cypress": "12.15.0"
   },
   "packageManager": "yarn@3.6.0"
 }

--- a/examples/yarn-modern/yarn.lock
+++ b/examples/yarn-modern/yarn.lock
@@ -414,9 +414,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cypress@npm:12.14.0":
-  version: 12.14.0
-  resolution: "cypress@npm:12.14.0"
+"cypress@npm:12.15.0":
+  version: 12.15.0
+  resolution: "cypress@npm:12.15.0"
   dependencies:
     "@cypress/request": ^2.88.10
     "@cypress/xvfb": ^1.2.4
@@ -462,7 +462,7 @@ __metadata:
     yauzl: ^2.10.0
   bin:
     cypress: bin/cypress
-  checksum: c98d33dc50f5e48a215f41e3a5139514816d2320e433d143a352a460f74941d3106a1f7485f61172f544cf125176c1225ac8edec31645d5a89cd394f72f93588
+  checksum: a1989386bc0843377526c71d60a7c2d64593fbf3209cd5986cb684653d1092007add9d83910906b85e1801637206dd5fa5ce9627c6ada3a20a3a82ec5c2f4d7a
   languageName: node
   linkType: hard
 
@@ -563,7 +563,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "example-yarn-modern@workspace:."
   dependencies:
-    cypress: 12.14.0
+    cypress: 12.15.0
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
1. This PR updates the Cypress 12.x [examples](https://github.com/cypress-io/github-action/tree/master/examples) to [Cypress 12.15.0](https://docs.cypress.io/guides/references/changelog#12-14-0) released June 20, 2023.

2. Due to a fix in [pnpm@8.6.2](https://github.com/pnpm/pnpm/releases/tag/v8.6.2), the `lockfileVersion` in [examples/basic-pnpm/pnpm-lock.yaml](https://github.com/cypress-io/github-action/blob/master/examples/basic-pnpm/pnpm-lock.yaml) is reverted from `6.1` to `6.0`.