### PR TITLE
test: remove comment about rebuilding dist in node test

### DIFF
--- a/.github/workflows/example-node-versions.yml
+++ b/.github/workflows/example-node-versions.yml
@@ -29,8 +29,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      # Hmm, should we rebuild the "dist" before using the action?
-
       - uses: ./
         with:
           working-directory: examples/v9/node-versions
@@ -55,8 +53,6 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v3
-
-      # Hmm, should we rebuild the "dist" before using the action?
 
       - uses: ./
         with:


### PR DESCRIPTION
This PR removes the following comment from [.github/workflows/example-node-versions.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-node-versions.yml):

"# Hmm, should we rebuild the "dist" before using the action?"

It's unclear whether this was supposed to be an exercise for the reader or a to-do task for the author of the comment!

In fact it is not necessary to rebuild the [`dist/`](https://github.com/cypress-io/github-action/tree/master/dist) folder because:

1. the workflow [.github/workflows/check-dist.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/check-dist.yml) independently rebuilds and checks the consistency of the [`dist/`](https://github.com/cypress-io/github-action/tree/master/dist) folder
2. in practice the result of rebuilding the [`dist/`](https://github.com/cypress-io/github-action/tree/master/dist) folder under the currently supported Node.js 16, 18 and 20 versions is identical anyway, with:

    ```bash
    npm run format
    npm run build
    git status
    ```
