### PR TITLE
docs: correct yarn-modern job name in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1064,7 +1064,7 @@ To install dependencies using a `yarn.lock` file from [Yarn Modern](https://yarn
 name: example-yarn-modern
 on: push
 jobs:
-  yarn-classic:
+  yarn-modern:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout


### PR DESCRIPTION
This PR corrects the name of the example `yarn-modern` job in the [README > Yarn Modern](https://github.com/cypress-io/github-action/blob/master/README.md#yarn-modern) section.

This README section displays an `example-yarn-modern` workflow with the confusingly misnamed job name `yarn-classic`.

The job name is changed to `yarn-modern` so that it aligns with the actual [example-yarn-modern.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-yarn-modern.yml) workflow example containing the two jobs:

- `yarn-modern-v9`
- `yarn-modern`