### PR TITLE
docs: add nodelinker information to yarn modern readme section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1102,7 +1102,7 @@ jobs:
           command: yarn cypress run
 ```
 
-This description covers the [`.yarnrc.yml`](https://yarnpkg.com/configuration/yarnrc#nodeLinker) configuration when `nodeLinker` is undefined or set to `nodeLinker: pnp` corresponding to Yarn Plug'n'Play. Yarn uses this by default for projects newly created with Yarn Modern.
+This example covers the [`.yarnrc.yml`](https://yarnpkg.com/configuration/yarnrc#nodeLinker) configuration when `nodeLinker` is undefined or set to `nodeLinker: pnp` corresponding to Yarn Plug'n'Play. Yarn uses this by default for projects newly created with Yarn Modern.
 
 [![Yarn Plug'n'Play example](https://github.com/cypress-io/github-action/actions/workflows/example-yarn-modern-pnp.yml/badge.svg?branch=master)](https://github.com/cypress-io/github-action/actions/workflows/example-yarn-modern-pnp.yml)
 

--- a/README.md
+++ b/README.md
@@ -1076,7 +1076,7 @@ jobs:
           install-command: yarn install
 ```
 
-This description covers the [`.yarnrc.yml`](https://yarnpkg.com/configuration/yarnrc#nodeLinker) configuration `nodeLinker: node-modules` which Yarn uses by default for projects updated from Yarn Classic. For `nodeLinker: pnp` see [Yarn Plug'n'Play](#yarn-plugnplay) below.
+This example covers the [`.yarnrc.yml`](https://yarnpkg.com/configuration/yarnrc#nodeLinker) configuration `nodeLinker: node-modules` which Yarn uses by default for projects updated from Yarn Classic. For `nodeLinker: pnp` see [Yarn Plug'n'Play](#yarn-plugnplay) below.
 (Note that `github-action` is not compatible with the `nodeLinker: pnpm` setting.)
 
 [![Yarn Modern example](https://github.com/cypress-io/github-action/workflows/example-yarn-modern/badge.svg?branch=master)](.github/workflows/example-yarn-modern.yml)

--- a/README.md
+++ b/README.md
@@ -1076,11 +1076,14 @@ jobs:
           install-command: yarn install
 ```
 
+This description covers the [`.yarnrc.yml`](https://yarnpkg.com/configuration/yarnrc#nodeLinker) configuration `nodeLinker: node-modules` which Yarn uses by default for projects updated from Yarn Classic. For `nodeLinker: pnp` see [Yarn Plug'n'Play](#yarn-plugnplay) below.
+(Note that `github-action` is not compatible with the `nodeLinker: pnpm` setting.)
+
 [![Yarn Modern example](https://github.com/cypress-io/github-action/workflows/example-yarn-modern/badge.svg?branch=master)](.github/workflows/example-yarn-modern.yml)
 
 ### Yarn Plug'n'Play
 
-When using [Yarn Modern](https://yarnpkg.com/) (Yarn 2 and later) with [Plug'n'Play](https://yarnpkg.com/features/pnp) enabled, you will need to use the `command` parameter to run `yarn` instead of [npx](https://docs.npmjs.com/cli/v9/commands/npx).
+When using [Yarn Modern](https://yarnpkg.com/) (Yarn 2 and later) with [Plug'n'Play](https://yarnpkg.com/features/pnp) enabled, you will need to use the `command` parameter to run [`yarn`](https://yarnpkg.com/cli/run) instead of [`npx`](https://docs.npmjs.com/cli/v9/commands/npx).
 
 ```yaml
 name: example-yarn-modern-pnp
@@ -1098,6 +1101,8 @@ jobs:
           install-command: yarn install
           command: yarn cypress run
 ```
+
+This description covers the [`.yarnrc.yml`](https://yarnpkg.com/configuration/yarnrc#nodeLinker) configuration when `nodeLinker` is undefined or set to `nodeLinker: pnp` corresponding to Yarn Plug'n'Play. Yarn uses this by default for projects newly created with Yarn Modern.
 
 [![Yarn Plug'n'Play example](https://github.com/cypress-io/github-action/actions/workflows/example-yarn-modern-pnp.yml/badge.svg?branch=master)](https://github.com/cypress-io/github-action/actions/workflows/example-yarn-modern-pnp.yml)
 


### PR DESCRIPTION
This PR provides clarification about the Yarn Modern `nodeLinker` configuration option of Yarn Modern through [`.yarnrc.yml`](https://yarnpkg.com/configuration/yarnrc#nodeLinker).

| `nodeLinker` value | Comments                                                                |
| ------------------ | ----------------------------------------------------------------------- |
| undefined          | defaults to `pnp`. Default for new Yarn Modern projects.                |
| `pnp`              | Yarn Modern Plug'n'Play                                                 |
| `node-modules`     | `npm` compatible mode. Projects upgraded from Yarn Classic use this.    |
| `pnpm`             | Cannot be used with `github-action`. Does not work with `npx` commands. |

