### PR TITLE
docs: caution use of start to run tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -657,6 +657,7 @@ jobs:
         with:
           start: npm start
 ```
+**Caution:** use the `start` parameter only to start a server, not to run Cypress, otherwise tests may be run twice. The action runs Cypress tests by default, unless the parameter `runTests` is to `false`.
 
 **Note:** sometimes on Windows you need to run a different start command. You can use the `start-windows` parameter for this.
 


### PR DESCRIPTION
This PR cautions about the use of the `start` parameter to run tests. There have been several instances lately where users have made this mistake.
