### PR TITLE
docs: link recording example to cypress cloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,6 +325,8 @@ For more information, visit [the Cypress command-line docs](https://on.cypress.i
 
 ### Record test results on Cypress Cloud
 
+By setting the parameter `record` to `true`, you can record your test results into the [Cypress Cloud](https://on.cypress.io/cloud). Read the [Cypress Cloud documentation](https://on.cypress.io/guides/cloud/introduction) to learn how to sign up and create a Cypress Cloud project.
+
 ```yml
 name: Cypress tests
 on: push


### PR DESCRIPTION
This PR links the README section

[Record test results on Cypress Cloud](https://github.com/cypress-io/github-action/blob/master/README.md#record-test-results-on-cypress-cloud)

to the [Cypress Cloud documentation](https://on.cypress.io/guides/cloud)

https://on.cypress.io/guides/cloud/introduction

and to the [Cypress Cloud](https://on.cypress.io/cloud)

https://on.cypress.io/cloud