### PR TITLE
docs: create separate changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+This document gives an overview of changes to the Cypress GitHub JavaScript Action [cypress-io/github-action](https://github.com/cypress-io/github-action).
+
+See [Releases](https://github.com/cypress-io/github-action/releases) for full details of changes.
+
+| Version | Changes                                                                                                                              |
+| ------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| v5.8.1  | Examples remove Node.js 19. End of support for Node.js 19.                                                                           |
+| v5.8.0  | Add GitHub step output `resultsUrl`. Deprecate `dashboardUrl`.                                                                       |
+| v5.6.2  | Examples add Node.js 20. End of support and removal of Node.js 14 examples.                                                          |
+| v5.2.0  | Examples add Node.js 19.                                                                                                             |
+| v5.0.0  | Examples add Node.js 18 and remove Node.js 12.                                                                                       |
+| v4.2.2  | Dependency on GitHub `set-output` workflow command removed.                                                                          |
+| v4.2.0  | Support for `pnpm` added.                                                                                                            |
+| v4.0.0  | Support for Cypress 10 and later versions added.                                                                                     |
+| v3      | Action runs under Node.js 16 instead of Node.js 12.                                                                                  |
+| v2      | Cypress runs using the [Module API](https://docs.cypress.io/guides/guides/module-api) instead of being started via the command line. |
+| v1      | *This version is no longer runnable in GitHub due to security changes.*                                                              |

--- a/README.md
+++ b/README.md
@@ -1511,23 +1511,12 @@ Cypress itself runs with a fixed Node.js version specified by the [runs.using](h
 
 ## Changelog
 
-See [Releases](https://github.com/cypress-io/github-action/releases) for full details of changes.
+View the [CHANGELOG](./CHANGELOG.md) document for an overview of version changes.
 
-| Version | Changes                                                                                                                              |
-| ------- | ------------------------------------------------------------------------------------------------------------------------------------ |
-| v5.8.1  | Examples remove Node.js 19. End of support for Node.js 19.                                                                           |
-| v5.8.0  | Add GitHub step output `resultsUrl`. Deprecate `dashboardUrl`.                                                                       |
-| v5.6.2  | Examples add Node.js 20. End of support and removal of Node.js 14 examples.                                                          |
-| v5.2.0  | Examples add Node.js 19.                                                                                                             |
-| v5.0.0  | Examples add Node.js 18 and remove Node.js 12.                                                                                       |
-| v4.2.2  | Dependency on GitHub `set-output` workflow command removed.                                                                          |
-| v4.2.0  | Support for `pnpm` added.                                                                                                            |
-| v4.0.0  | Support for Cypress 10 and later versions added.                                                                                     |
-| v3      | Action runs under Node.js 16 instead of Node.js 12.                                                                                  |
-| v2      | Cypress runs using the [Module API](https://docs.cypress.io/guides/guides/module-api) instead of being started via the command line. |
-| v1      | *This version is no longer runnable in GitHub due to security changes.*                                                              |
+## Compatibility
 
-*Note: [GitHub announced](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) their plan to disable `save-state` and `set-output` commands. This will prevent [cypress-io/github-action](https://github.com/cypress-io/github-action) version [v4.2.1](https://github.com/cypress-io/github-action/releases/tag/v4.2.1) and earlier from running, since they use `set-output`. Affected users should update to using `v5` of the [cypress-io/github-action](https://github.com/cypress-io/github-action) action.*
+[GitHub announced](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) their plan to disable `save-state` and `set-output` commands. This will prevent [cypress-io/github-action](https://github.com/cypress-io/github-action) version [v4.2.1](https://github.com/cypress-io/github-action/releases/tag/v4.2.1) and earlier from running, since they use `set-output`. Affected users should update to using `v5` of the [cypress-io/github-action](https://github.com/cypress-io/github-action) action.
+
 
 ## Contributing
 


### PR DESCRIPTION
This PR moves the [README > Changelog](https://github.com/cypress-io/github-action/blob/master/README.md#changelog) section contents to a separate new file `CHANGELOG.md` in the root of the repository.

This is in preparation to add more details to the Changelog, which would make it overly long to be displayed directly in the [README](https://github.com/cypress-io/github-action/blob/master/README.md) file itself. Once this PR is reviewed and merged, I will submit a follow-on PR to expand the details in the new `CHANGELOG.md`.

I also plan to submit a separate PR with new information about GitHub compatibility.