### PR TITLE
docs: update compatibility information

### DIFF
--- a/README.md
+++ b/README.md
@@ -1515,8 +1515,10 @@ View the [CHANGELOG](./CHANGELOG.md) document for an overview of version changes
 
 ## Compatibility
 
-[GitHub announced](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) their plan to disable `save-state` and `set-output` commands. This will prevent [cypress-io/github-action](https://github.com/cypress-io/github-action) version [v4.2.1](https://github.com/cypress-io/github-action/releases/tag/v4.2.1) and earlier from running, since they use `set-output`. Affected users should update to using `v5` of the [cypress-io/github-action](https://github.com/cypress-io/github-action) action.
+- `v5` is the recommended version of [cypress-io/github-action](https://github.com/cypress-io/github-action)
+- `v4` is the minimum version required for Cypress `10.x` and later
 
+Pay attention to any GitHub Actions deprecation warnings shown in logs which may recommend updating.
 
 ## Contributing
 


### PR DESCRIPTION
This PR updates the [README > Compatibility](https://github.com/cypress-io/github-action/blob/master/README.md#compatibility) section.

`v5` is the recommended version
`v4` is the minimum version required for Cypress `10.x` and later

[GitHub Changelog](https://github.blog/changelog/) notices have continually updated deprecation deadlines and decisions, so it does not make sense to try to keep the [README](https://github.com/cypress-io/github-action/blob/master/README.md) up-to-date in this respect. Instead add a generic comment:

Pay attention to any GitHub Actions log deprecation warnings which recommend updating.

## Background

| Version   | v9                 | v10                | Comment                                            |
| --------- | ------------------ | ------------------ | -------------------------------------------------- |
| `v5`      | :white_check_mark: | :white_check_mark: | current version                                    |
| `v4`      | :white_check_mark: | :white_check_mark: | no deprecations                                    |
| `v4.2.2`  | :white_check_mark: | :white_check_mark: | no deprecations                                    |
| `v4.2.1`  | :white_check_mark: | :white_check_mark: | `set-output` deprecated                            |
| `v3`      | :white_check_mark: | :x:                | `set-output` deprecated                            |
| `v2`      | :white_check_mark: | :x:                | `set-output` deprecated, forced to run on `node16` |
| `v1`      | :x:                | :x:                | `v1` branch no longer available                    |
| `v1.25.3` | :white_check_mark: | :x:                | See Note 1 below                                   |

Notes
1. `v1.25.3`
    - environment variable `ACTIONS_ALLOW_UNSECURE_COMMANDS` must be set to `true` to override GitHub security check
    - `save-state` deprecated
    - runs in Node.js version of workflow

Tested with above versions (see job [5681409124](https://github.com/MikeMcC399/github-action/actions/runs/5681409124)).
