### PR TITLE
docs: rework docker example

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,23 +213,31 @@ jobs:
 
 ### Docker image
 
-You can run tests in a GH Action in your Docker container.
+You can run the action in a Docker container.
 
 ```yml
-name: E2E in custom container
+name: Test in Docker
 on: push
 jobs:
   cypress-run:
     runs-on: ubuntu-22.04
-    # Cypress Docker image with Chrome v106
-    # and Firefox v106 pre-installed
-    container: cypress/browsers:node18.12.0-chrome106-ff106
+    # Cypress Docker image from https://hub.docker.com/r/cypress
+    # with browsers pre-installed
+    container:
+      image: cypress/browsers:latest
+      options: --user 1001
     steps:
       - uses: actions/checkout@v3
       - uses: cypress-io/github-action@v5
         with:
           browser: chrome
 ```
+
+Replace the `latest` tag with a specific version image tag from [`cypress/browsers` on Docker Hub](https://hub.docker.com/r/cypress/browsers/tags) to avoid breaking changes when new images are released (especially when they include new major versions of Node.js).
+
+Include `options: --user 1001` to avoid permissions issues.
+
+Refer to [cypress-io/cypress-docker-images](https://github.com/cypress-io/cypress-docker-images) for further information about using Cypress Docker images. Cypress offers the [Cypress Docker Factory](https://github.com/cypress-io/cypress-docker-images/tree/master/factory) to generate additional Docker images with selected components and versions.
 
 ### Env
 


### PR DESCRIPTION
This PR improves the [README > Docker image](https://github.com/cypress-io/github-action#docker-image) example:

1. It builds on the suggestions made in the open PRs #938 and #963 to add `options: --user 1001` to the Docker example. For GitHub-hosted runners `--user 1001` is mandatory when testing against Mozilla Firefox and optional for other browsers.

2. The container is changed to the generic `cypress/browsers:latest` image tag to provide a timeless and easily readable example. A link to the Docker Hub [cypress/browsers:latest](https://hub.docker.com/r/cypress/browsers/tags) is provided so that readers can search for specific versions such as [cypress/browsers:node-20.5.0-chrome-114.0.5735.133-1-ff-114.0.2-edge-114.0.1823.51-1](https://hub.docker.com/layers/cypress/browsers/node-20.5.0-chrome-114.0.5735.133-1-ff-114.0.2-edge-114.0.1823.51-1/images/sha256-8b899d0292e700c80629d13a98ae309295e719f5b4f9aa50a98c6cdd2b6c5215)

3. The example is linked to the [cypress-io/cypress-docker-images](https://github.com/cypress-io/cypress-docker-images) repo for further information. A pointer to [cypress-io/cypress-docker-images > factory](https://github.com/cypress-io/cypress-docker-images/tree/master/factory) is given for users who want to generate containers for specific versions.

## Verification

The [Workflow](https://github.com/MikeMcC399/github-action/actions/runs/5866097433/workflow) below demonstrates the example using the four supported browsers `chrome`, `edge`, `electron` & `firefox` on a GitHub-hosted runner, with successful results logged to [run 5866097433](https://github.com/MikeMcC399/github-action/actions/runs/5866097433).

```yml
name: example-docker

on: workflow_dispatch

jobs:
  docker-browsers:
    runs-on: ubuntu-22.04
    strategy:
      fail-fast: false
      matrix:
        browser: [chrome, edge, electron, firefox]
    # from https://hub.docker.com/r/cypress/browsers/tags
    container:
      image: cypress/browsers:latest
      options: --user 1001
    steps:
      - uses: actions/checkout@v3
      - uses: cypress-io/github-action@v5
        with:
          working-directory: examples/basic
          browser: ${{ matrix.browser }}
```
