### PR TITLE
chore(deps): update prettier to 3.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "@vercel/ncc": "0.36.1",
         "husky": "8.0.3",
         "markdown-link-check": "3.11.1",
-        "prettier": "2.8.4"
+        "prettier": "3.0.1"
       }
     },
     "node_modules/@actions/cache": {
@@ -1347,15 +1347,15 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.8.4",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.4.tgz",
-      "integrity": "sha512-vIS4Rlc2FNh0BySk3Wkd6xmwxB0FpOndW5fisM5H8hsZSxU2VWVB5CWIkIjWvrHjIhxk2g3bfMKM87zNTrZddw==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.1.tgz",
+      "integrity": "sha512-fcOWSnnpCrovBsmFZIGIy9UqK2FaI7Hqax+DIO0A9UxeVoY4iweyaFjS5TavZN97Hfehph0nhsZnjlVKzEQSrQ==",
       "dev": true,
       "bin": {
-        "prettier": "bin-prettier.js"
+        "prettier": "bin/prettier.cjs"
       },
       "engines": {
-        "node": ">=10.13.0"
+        "node": ">=14"
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
@@ -2586,9 +2586,9 @@
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="
     },
     "prettier": {
-      "version": "2.8.4",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.4.tgz",
-      "integrity": "sha512-vIS4Rlc2FNh0BySk3Wkd6xmwxB0FpOndW5fisM5H8hsZSxU2VWVB5CWIkIjWvrHjIhxk2g3bfMKM87zNTrZddw==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.1.tgz",
+      "integrity": "sha512-fcOWSnnpCrovBsmFZIGIy9UqK2FaI7Hqax+DIO0A9UxeVoY4iweyaFjS5TavZN97Hfehph0nhsZnjlVKzEQSrQ==",
       "dev": true
     },
     "process": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@vercel/ncc": "0.36.1",
     "husky": "8.0.3",
     "markdown-link-check": "3.11.1",
-    "prettier": "2.8.4"
+    "prettier": "3.0.1"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
This PR updates [prettier](https://www.npmjs.com/package/prettier) from `2.8.4` to [prettier@3.0.1](https://github.com/prettier/prettier/releases/tag/3.0.1).

This is in preparation for the expected support of Node.js `20` for JavaScript actions. Making updates separate as far as possible reduces the risk of causing unexpected breaking changes.

## Verification

Execute

```bash
npm ci
npm run format
npm run build
```

and check there are no `git` changes to be committed.