### PR TITLE
chore: correct package name for yarn-modern-pnp example

### DIFF
--- a/examples/yarn-modern-pnp/package.json
+++ b/examples/yarn-modern-pnp/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "example-yarn-modern",
-  "version": "1.0.0",
-  "description": "Use modern yarn with pnp",
+  "name": "example-yarn-modern-pnp",
+  "version": "2.0.0",
+  "description": "Use Yarn Modern with Plug'n'Play (pnp)",
   "scripts": {
     "test": "cypress run"
   },

--- a/examples/yarn-modern-pnp/yarn.lock
+++ b/examples/yarn-modern-pnp/yarn.lock
@@ -560,9 +560,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"example-yarn-modern@workspace:.":
+"example-yarn-modern-pnp@workspace:.":
   version: 0.0.0-use.local
-  resolution: "example-yarn-modern@workspace:."
+  resolution: "example-yarn-modern-pnp@workspace:."
   dependencies:
     cypress: 12.17.3
   languageName: unknown


### PR DESCRIPTION
This PR corrects the package name in [examples/yarn-modern-pnp/package.json](https://github.com/cypress-io/github-action/blob/master/examples/yarn-modern-pnp/package.json) which was a misleading duplicate of the package name also used in [examples/yarn-modern/package.json](https://github.com/cypress-io/github-action/blob/master/examples/yarn-modern/package.json).
