### PR TITLE
docs: readme update pnpm to version 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -1041,7 +1041,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v2
         with:
-          version: 7
+          version: 8
       - name: Cypress run
         uses: cypress-io/github-action@v5
         with:


### PR DESCRIPTION
This PR updates the documentation example

- [README > pnpm](https://github.com/cypress-io/github-action/blob/master/README.md#pnpm)

to use pnpm version `8` corresponding to the latest major version [pnpm release](https://github.com/pnpm/pnpm/releases).

- PR https://github.com/cypress-io/github-action/pull/899 already updated [.github/workflows/example-basic-pnpm.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-basic-pnpm.yml) to use pnpm `8`.