### PR TITLE
chore(deps): update serve to 14.2.1

### DIFF
--- a/examples/config/package-lock.json
+++ b/examples/config/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "devDependencies": {
         "cypress": "12.17.4",
-        "serve": "^14.2.0",
+        "serve": "14.2.1",
         "start-server-and-test": "2.0.0"
       }
     },
@@ -2300,9 +2300,9 @@
       }
     },
     "node_modules/serve": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/serve/-/serve-14.2.0.tgz",
-      "integrity": "sha512-+HOw/XK1bW8tw5iBilBz/mJLWRzM8XM6MPxL4J/dKzdxq1vfdEWSwhaR7/yS8EJp5wzvP92p1qirysJvnEtjXg==",
+      "version": "14.2.1",
+      "resolved": "https://registry.npmjs.org/serve/-/serve-14.2.1.tgz",
+      "integrity": "sha512-48er5fzHh7GCShLnNyPBRPEjs2I6QBozeGr02gaacROiyS/8ARADlj595j39iZXAqBbJHH/ivJJyPRWY9sQWZA==",
       "dev": true,
       "dependencies": {
         "@zeit/schemas": "2.29.0",
@@ -4623,9 +4623,9 @@
       }
     },
     "serve": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/serve/-/serve-14.2.0.tgz",
-      "integrity": "sha512-+HOw/XK1bW8tw5iBilBz/mJLWRzM8XM6MPxL4J/dKzdxq1vfdEWSwhaR7/yS8EJp5wzvP92p1qirysJvnEtjXg==",
+      "version": "14.2.1",
+      "resolved": "https://registry.npmjs.org/serve/-/serve-14.2.1.tgz",
+      "integrity": "sha512-48er5fzHh7GCShLnNyPBRPEjs2I6QBozeGr02gaacROiyS/8ARADlj595j39iZXAqBbJHH/ivJJyPRWY9sQWZA==",
       "dev": true,
       "requires": {
         "@zeit/schemas": "2.29.0",

--- a/examples/config/package.json
+++ b/examples/config/package.json
@@ -13,7 +13,7 @@
   "private": true,
   "devDependencies": {
     "cypress": "12.17.4",
-    "serve": "^14.2.0",
+    "serve": "14.2.1",
     "start-server-and-test": "2.0.0"
   }
 }

--- a/examples/start-and-yarn-workspaces/workspace-1/package.json
+++ b/examples/start-and-yarn-workspaces/workspace-1/package.json
@@ -11,6 +11,6 @@
   "private": true,
   "devDependencies": {
     "cypress": "12.17.4",
-    "serve": "^14.2.0"
+    "serve": "14.2.1"
   }
 }

--- a/examples/start-and-yarn-workspaces/workspace-2/package.json
+++ b/examples/start-and-yarn-workspaces/workspace-2/package.json
@@ -11,6 +11,6 @@
   "private": true,
   "devDependencies": {
     "cypress": "12.17.4",
-    "serve": "^14.2.0"
+    "serve": "14.2.1"
   }
 }

--- a/examples/start-and-yarn-workspaces/yarn.lock
+++ b/examples/start-and-yarn-workspaces/yarn.lock
@@ -1297,10 +1297,10 @@ serve-handler@6.1.5:
     path-to-regexp "2.2.1"
     range-parser "1.2.0"
 
-serve@^14.2.0:
-  version "14.2.0"
-  resolved "https://registry.yarnpkg.com/serve/-/serve-14.2.0.tgz#3d768e88fa13ad8644f2393599189707176e66b8"
-  integrity sha512-+HOw/XK1bW8tw5iBilBz/mJLWRzM8XM6MPxL4J/dKzdxq1vfdEWSwhaR7/yS8EJp5wzvP92p1qirysJvnEtjXg==
+serve@14.2.1:
+  version "14.2.1"
+  resolved "https://registry.yarnpkg.com/serve/-/serve-14.2.1.tgz#3f078d292ed5e7b2c5a64f957af2765b0459798b"
+  integrity sha512-48er5fzHh7GCShLnNyPBRPEjs2I6QBozeGr02gaacROiyS/8ARADlj595j39iZXAqBbJHH/ivJJyPRWY9sQWZA==
   dependencies:
     "@zeit/schemas" "2.29.0"
     ajv "8.11.0"

--- a/examples/start/package-lock.json
+++ b/examples/start/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "devDependencies": {
         "cypress": "12.17.4",
-        "serve": "^14.2.0"
+        "serve": "14.2.1"
       }
     },
     "node_modules/@colors/colors": {
@@ -2149,9 +2149,9 @@
       }
     },
     "node_modules/serve": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/serve/-/serve-14.2.0.tgz",
-      "integrity": "sha512-+HOw/XK1bW8tw5iBilBz/mJLWRzM8XM6MPxL4J/dKzdxq1vfdEWSwhaR7/yS8EJp5wzvP92p1qirysJvnEtjXg==",
+      "version": "14.2.1",
+      "resolved": "https://registry.npmjs.org/serve/-/serve-14.2.1.tgz",
+      "integrity": "sha512-48er5fzHh7GCShLnNyPBRPEjs2I6QBozeGr02gaacROiyS/8ARADlj595j39iZXAqBbJHH/ivJJyPRWY9sQWZA==",
       "dev": true,
       "dependencies": {
         "@zeit/schemas": "2.29.0",
@@ -4237,9 +4237,9 @@
       }
     },
     "serve": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/serve/-/serve-14.2.0.tgz",
-      "integrity": "sha512-+HOw/XK1bW8tw5iBilBz/mJLWRzM8XM6MPxL4J/dKzdxq1vfdEWSwhaR7/yS8EJp5wzvP92p1qirysJvnEtjXg==",
+      "version": "14.2.1",
+      "resolved": "https://registry.npmjs.org/serve/-/serve-14.2.1.tgz",
+      "integrity": "sha512-48er5fzHh7GCShLnNyPBRPEjs2I6QBozeGr02gaacROiyS/8ARADlj595j39iZXAqBbJHH/ivJJyPRWY9sQWZA==",
       "dev": true,
       "requires": {
         "@zeit/schemas": "2.29.0",

--- a/examples/start/package.json
+++ b/examples/start/package.json
@@ -12,6 +12,6 @@
   "private": true,
   "devDependencies": {
     "cypress": "12.17.4",
-    "serve": "^14.2.0"
+    "serve": "14.2.1"
   }
 }


### PR DESCRIPTION
This PR updates the npm module [serve](https://www.npmjs.com/package/serve) to [serve@14.2.1](https://github.com/vercel/serve/releases/tag/14.2.1) which is the latest version.

[serve](https://www.npmjs.com/package/serve) is used in several examples as a webserver.

It reminds in logs if it is not the latest version, for example in job [16178553414](https://github.com/cypress-io/github-action/actions/runs/5964083289/job/16178553414):

>> example-config@1.0.0 start
>> serve public --listen 3333
>
> UPDATE  The latest version of `serve` is 14.2.1
> INFO  Accepting connections at http://localhost:3333
> HTTP  8/24/2023 1:04:00 PM ::1 GET /
> HTTP  8/24/2023 1:04:00 PM ::1 Returned 200 in 1027 ms
