### PR TITLE
docs: rework requirements for contributors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,12 @@ This document describes topics useful to contributors to this repository. The re
 
 You can read the GitHub document [Creating a JavaScript action](https://docs.github.com/en/actions/creating-actions/creating-a-javascript-action) for background information on how JavaScript actions for GitHub are created and how they work.
 
+### Requirements
+
+You must have the following installed on your system to contribute locally:
+
+- [`Node.js`](https://nodejs.org/en/) (See the [.node-version](.node-version) file for the required version. You can find a list of tools on [node-version-usage](https://github.com/shadowspawn/node-version-usage) to switch the version of [`Node.js`](https://nodejs.org/en/) based on [.node-version](.node-version).)
+
 ### Providing fixes or features
 
 If you are submitting a Pull Request (PR) to provide a fix or feature for the action, the following is relevant to you:
@@ -34,9 +40,9 @@ The action runs from the [dist](dist) directory, which requires a `build` step t
 To contribute changes, follow these instructions in the order given below:
 
 1. If you are a new external contributor, then first fork the repository (see GitHub documentation [About forks](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/about-forks)).
+1. Clone the repository
 1. Create a new branch with a meaningful name e.g. `fix/my-bug` based on the current `master` branch.
 1. Make the necessary source code changes, including additions or changes to the [README.md](./README.md) documentation if parameters are added or affected.
-1. Ensure you have [`Node.js`](https://nodejs.org/en/) installed. (See the root [.node-version](.node-version) file for the required version. You can find a list of tools on [node-version-usage](https://github.com/shadowspawn/node-version-usage) to switch the version of [`Node.js`](https://nodejs.org/en/) based on [.node-version](.node-version)).
 1. Execute the following in the root directory of the cloned repository
 
     ```bash

--- a/docs/MAINTENANCE.md
+++ b/docs/MAINTENANCE.md
@@ -10,11 +10,11 @@ The examples make use of [npm](https://www.npmjs.com/), [pnpm](https://pnpm.io/)
 
 *The previous [examples/v9](https://github.com/cypress-io/github-action/tree/v5/examples/v9) are archived in the [v5](https://github.com/cypress-io/github-action/tree/v5/) branch. This directory contains examples which were set up to use Cypress `9.7.0`, the last version using [Legacy Configuration](https://docs.cypress.io/guides/references/legacy-configuration), covering Cypress 9 and below. These `v9` examples are no longer maintained.
 
-## Prerequisites
+## Requirements
 
 - A local system running [Ubuntu](https://ubuntu.com/), [Microsoft Windows](https://www.microsoft.com/windows/) or [Apple macOS](https://www.apple.com/macos/).
 
-- The LTS version of [Node.js](https://nodejs.org/). For convenience of switching to other versions of Node.js, [nvm](https://github.com/nvm-sh/nvm) for unix, macOS and windows WSL. For Windows [nvm-windows](https://github.com/coreybutler/nvm-windows).
+- [Node.js](https://nodejs.org/en/) as described in the [CONTRIBUTING](../CONTRIBUTING.md#requirements) document.
 
 - [git](https://git-scm.com/) distributed version control system.
 
@@ -26,15 +26,11 @@ The examples make use of [npm](https://www.npmjs.com/), [pnpm](https://pnpm.io/)
 npm install pnpm@latest -g
 ```
 
-This needs to be repeated if you change the base node version using nvm.
-
 - [Yarn 1 (Classic)](https://classic.yarnpkg.com/) installed through:
 
 ```bash
 npm install yarn@latest -g
 ```
-
-Again, this needs to be repeated if you change the base node version using nvm.
 
 - [Visual Studio Code](https://code.visualstudio.com/) or other editor
 


### PR DESCRIPTION
This PR adds a Requirements section to [CONTRIBUTING.md](https://github.com/cypress-io/github-action/blob/master/CONTRIBUTING.md) and aligns with the wording used in [cypress-io/cypress > CONTRIBUTING.md > Requirements](https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#requirements).

The [MAINTENANCE](https://github.com/cypress-io/github-action/blob/master/docs/MAINTENANCE.md) document now refers to the list of tools on [node-version-usage](https://github.com/shadowspawn/node-version-usage) to switch the version of [`Node.js`](https://nodejs.org/en/) based on [.node-version](.node-version) instead of specifying the Node.js LTS version and suggesting the use of `nvm` and `nvm-windows` explicitly.