### PR TITLE
test: run component test example from current branch

### DIFF
--- a/.github/workflows/example-component-test.yml
+++ b/.github/workflows/example-component-test.yml
@@ -13,7 +13,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Cypress run
-        uses: cypress-io/github-action@v5
+        # normally you would write
+        # uses: cypress-io/github-action@v5
+        uses: ./
         with:
           working-directory: examples/component-tests
           component: true


### PR DESCRIPTION
This PR changes the workflow [.github/workflows/example-component-test.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-component-test.yml) to run the action from the `HEAD` of the branch it is started in instead of explicitly from the [v5](https://github.com/cypress-io/github-action/tree/v5) branch as is currently the case:

https://github.com/cypress-io/github-action/blob/d5d4c90348e3b92abdcbbad1a3659597b18945bb/.github/workflows/example-component-test.yml#L15-L16

This aligns the workflow with all the other example workflows in [.github/workflows](https://github.com/cypress-io/github-action/blob/master/.github/workflows/) which use the construct:

```yml
      - name: Cypress tests
        # normally you would write
        # uses: cypress-io/github-action@v5
        uses: ./
```
