### PR TITLE
chore(deps): update cypress to 13.1.0

### DIFF
--- a/.github/workflows/example-install-only.yml
+++ b/.github/workflows/example-install-only.yml
@@ -30,7 +30,7 @@ jobs:
           key: my-cache-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
 
       - name: Install Cypress 📥
-        run: npm i cypress@13.0.0
+        run: npm i cypress@13.1.0
 
       - name: Cypress tests 🧪
         uses: ./

--- a/examples/basic-pnpm/package.json
+++ b/examples/basic-pnpm/package.json
@@ -8,6 +8,6 @@
   },
   "private": true,
   "devDependencies": {
-    "cypress": "13.0.0"
+    "cypress": "13.1.0"
   }
 }

--- a/examples/basic-pnpm/pnpm-lock.yaml
+++ b/examples/basic-pnpm/pnpm-lock.yaml
@@ -6,8 +6,8 @@ settings:
 
 devDependencies:
   cypress:
-    specifier: 13.0.0
-    version: 13.0.0
+    specifier: 13.1.0
+    version: 13.1.0
 
 packages:
 
@@ -296,8 +296,8 @@ packages:
       which: 2.0.2
     dev: true
 
-  /cypress@13.0.0:
-    resolution: {integrity: sha512-nWHU5dUxP2Wm/zrMd8SWTTl706aJex/l+H4vi/tbu2SWUr17BUcd/sIYeqyxeoSPW1JFV2pT1pf4JEImH/POMg==}
+  /cypress@13.1.0:
+    resolution: {integrity: sha512-LUKxCYlB973QBFls1Up4FAE9QIYobT+2I8NvvAwMfQS2YwsWbr6yx7y9hmsk97iqbHkKwZW3MRjoK1RToBFVdQ==}
     engines: {node: ^16.0.0 || ^18.0.0 || >=20.0.0}
     hasBin: true
     requiresBuild: true

--- a/examples/basic/package-lock.json
+++ b/examples/basic/package-lock.json
@@ -8,7 +8,7 @@
       "name": "example-basic",
       "version": "1.0.0",
       "devDependencies": {
-        "cypress": "13.0.0"
+        "cypress": "13.1.0"
       }
     },
     "node_modules/@colors/colors": {
@@ -544,9 +544,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.0.0.tgz",
-      "integrity": "sha512-nWHU5dUxP2Wm/zrMd8SWTTl706aJex/l+H4vi/tbu2SWUr17BUcd/sIYeqyxeoSPW1JFV2pT1pf4JEImH/POMg==",
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.1.0.tgz",
+      "integrity": "sha512-LUKxCYlB973QBFls1Up4FAE9QIYobT+2I8NvvAwMfQS2YwsWbr6yx7y9hmsk97iqbHkKwZW3MRjoK1RToBFVdQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -2366,9 +2366,9 @@
       }
     },
     "cypress": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.0.0.tgz",
-      "integrity": "sha512-nWHU5dUxP2Wm/zrMd8SWTTl706aJex/l+H4vi/tbu2SWUr17BUcd/sIYeqyxeoSPW1JFV2pT1pf4JEImH/POMg==",
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.1.0.tgz",
+      "integrity": "sha512-LUKxCYlB973QBFls1Up4FAE9QIYobT+2I8NvvAwMfQS2YwsWbr6yx7y9hmsk97iqbHkKwZW3MRjoK1RToBFVdQ==",
       "dev": true,
       "requires": {
         "@cypress/request": "^3.0.0",

--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -8,6 +8,6 @@
   },
   "private": true,
   "devDependencies": {
-    "cypress": "13.0.0"
+    "cypress": "13.1.0"
   }
 }

--- a/examples/browser/package-lock.json
+++ b/examples/browser/package-lock.json
@@ -8,7 +8,7 @@
       "name": "example-browser",
       "version": "1.1.0",
       "devDependencies": {
-        "cypress": "13.0.0",
+        "cypress": "13.1.0",
         "image-size": "^1.0.2"
       }
     },
@@ -545,9 +545,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.0.0.tgz",
-      "integrity": "sha512-nWHU5dUxP2Wm/zrMd8SWTTl706aJex/l+H4vi/tbu2SWUr17BUcd/sIYeqyxeoSPW1JFV2pT1pf4JEImH/POMg==",
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.1.0.tgz",
+      "integrity": "sha512-LUKxCYlB973QBFls1Up4FAE9QIYobT+2I8NvvAwMfQS2YwsWbr6yx7y9hmsk97iqbHkKwZW3MRjoK1RToBFVdQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -2391,9 +2391,9 @@
       }
     },
     "cypress": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.0.0.tgz",
-      "integrity": "sha512-nWHU5dUxP2Wm/zrMd8SWTTl706aJex/l+H4vi/tbu2SWUr17BUcd/sIYeqyxeoSPW1JFV2pT1pf4JEImH/POMg==",
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.1.0.tgz",
+      "integrity": "sha512-LUKxCYlB973QBFls1Up4FAE9QIYobT+2I8NvvAwMfQS2YwsWbr6yx7y9hmsk97iqbHkKwZW3MRjoK1RToBFVdQ==",
       "dev": true,
       "requires": {
         "@cypress/request": "^3.0.0",

--- a/examples/browser/package.json
+++ b/examples/browser/package.json
@@ -13,7 +13,7 @@
   },
   "private": true,
   "devDependencies": {
-    "cypress": "13.0.0",
+    "cypress": "13.1.0",
     "image-size": "^1.0.2"
   }
 }

--- a/examples/component-tests/package-lock.json
+++ b/examples/component-tests/package-lock.json
@@ -15,7 +15,7 @@
         "@types/react": "^18.2.15",
         "@types/react-dom": "^18.2.7",
         "@vitejs/plugin-react": "^4.0.3",
-        "cypress": "13.0.0",
+        "cypress": "13.1.0",
         "vite": "^4.4.5"
       }
     },
@@ -1394,9 +1394,9 @@
       "dev": true
     },
     "node_modules/cypress": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.0.0.tgz",
-      "integrity": "sha512-nWHU5dUxP2Wm/zrMd8SWTTl706aJex/l+H4vi/tbu2SWUr17BUcd/sIYeqyxeoSPW1JFV2pT1pf4JEImH/POMg==",
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.1.0.tgz",
+      "integrity": "sha512-LUKxCYlB973QBFls1Up4FAE9QIYobT+2I8NvvAwMfQS2YwsWbr6yx7y9hmsk97iqbHkKwZW3MRjoK1RToBFVdQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {

--- a/examples/component-tests/package.json
+++ b/examples/component-tests/package.json
@@ -17,7 +17,7 @@
     "@types/react": "^18.2.15",
     "@types/react-dom": "^18.2.7",
     "@vitejs/plugin-react": "^4.0.3",
-    "cypress": "13.0.0",
+    "cypress": "13.1.0",
     "vite": "^4.4.5"
   }
 }

--- a/examples/config/package-lock.json
+++ b/examples/config/package-lock.json
@@ -8,7 +8,7 @@
       "name": "example-config",
       "version": "1.0.0",
       "devDependencies": {
-        "cypress": "13.0.0",
+        "cypress": "13.1.0",
         "serve": "14.2.1",
         "start-server-and-test": "2.0.0"
       }
@@ -932,9 +932,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.0.0.tgz",
-      "integrity": "sha512-nWHU5dUxP2Wm/zrMd8SWTTl706aJex/l+H4vi/tbu2SWUr17BUcd/sIYeqyxeoSPW1JFV2pT1pf4JEImH/POMg==",
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.1.0.tgz",
+      "integrity": "sha512-LUKxCYlB973QBFls1Up4FAE9QIYobT+2I8NvvAwMfQS2YwsWbr6yx7y9hmsk97iqbHkKwZW3MRjoK1RToBFVdQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -3581,9 +3581,9 @@
       }
     },
     "cypress": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.0.0.tgz",
-      "integrity": "sha512-nWHU5dUxP2Wm/zrMd8SWTTl706aJex/l+H4vi/tbu2SWUr17BUcd/sIYeqyxeoSPW1JFV2pT1pf4JEImH/POMg==",
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.1.0.tgz",
+      "integrity": "sha512-LUKxCYlB973QBFls1Up4FAE9QIYobT+2I8NvvAwMfQS2YwsWbr6yx7y9hmsk97iqbHkKwZW3MRjoK1RToBFVdQ==",
       "dev": true,
       "requires": {
         "@cypress/request": "^3.0.0",

--- a/examples/config/package.json
+++ b/examples/config/package.json
@@ -12,7 +12,7 @@
   },
   "private": true,
   "devDependencies": {
-    "cypress": "13.0.0",
+    "cypress": "13.1.0",
     "serve": "14.2.1",
     "start-server-and-test": "2.0.0"
   }

--- a/examples/custom-command/package-lock.json
+++ b/examples/custom-command/package-lock.json
@@ -8,7 +8,7 @@
       "name": "example-custom-command",
       "version": "1.0.0",
       "devDependencies": {
-        "cypress": "13.0.0",
+        "cypress": "13.1.0",
         "lodash": "4.17.21"
       }
     },
@@ -545,9 +545,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.0.0.tgz",
-      "integrity": "sha512-nWHU5dUxP2Wm/zrMd8SWTTl706aJex/l+H4vi/tbu2SWUr17BUcd/sIYeqyxeoSPW1JFV2pT1pf4JEImH/POMg==",
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.1.0.tgz",
+      "integrity": "sha512-LUKxCYlB973QBFls1Up4FAE9QIYobT+2I8NvvAwMfQS2YwsWbr6yx7y9hmsk97iqbHkKwZW3MRjoK1RToBFVdQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -2367,9 +2367,9 @@
       }
     },
     "cypress": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.0.0.tgz",
-      "integrity": "sha512-nWHU5dUxP2Wm/zrMd8SWTTl706aJex/l+H4vi/tbu2SWUr17BUcd/sIYeqyxeoSPW1JFV2pT1pf4JEImH/POMg==",
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.1.0.tgz",
+      "integrity": "sha512-LUKxCYlB973QBFls1Up4FAE9QIYobT+2I8NvvAwMfQS2YwsWbr6yx7y9hmsk97iqbHkKwZW3MRjoK1RToBFVdQ==",
       "dev": true,
       "requires": {
         "@cypress/request": "^3.0.0",

--- a/examples/custom-command/package.json
+++ b/examples/custom-command/package.json
@@ -9,7 +9,7 @@
   },
   "private": true,
   "devDependencies": {
-    "cypress": "13.0.0",
+    "cypress": "13.1.0",
     "lodash": "4.17.21"
   }
 }

--- a/examples/env/package-lock.json
+++ b/examples/env/package-lock.json
@@ -8,7 +8,7 @@
       "name": "example-env",
       "version": "1.0.0",
       "devDependencies": {
-        "cypress": "13.0.0"
+        "cypress": "13.1.0"
       }
     },
     "node_modules/@colors/colors": {
@@ -544,9 +544,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.0.0.tgz",
-      "integrity": "sha512-nWHU5dUxP2Wm/zrMd8SWTTl706aJex/l+H4vi/tbu2SWUr17BUcd/sIYeqyxeoSPW1JFV2pT1pf4JEImH/POMg==",
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.1.0.tgz",
+      "integrity": "sha512-LUKxCYlB973QBFls1Up4FAE9QIYobT+2I8NvvAwMfQS2YwsWbr6yx7y9hmsk97iqbHkKwZW3MRjoK1RToBFVdQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -2366,9 +2366,9 @@
       }
     },
     "cypress": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.0.0.tgz",
-      "integrity": "sha512-nWHU5dUxP2Wm/zrMd8SWTTl706aJex/l+H4vi/tbu2SWUr17BUcd/sIYeqyxeoSPW1JFV2pT1pf4JEImH/POMg==",
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.1.0.tgz",
+      "integrity": "sha512-LUKxCYlB973QBFls1Up4FAE9QIYobT+2I8NvvAwMfQS2YwsWbr6yx7y9hmsk97iqbHkKwZW3MRjoK1RToBFVdQ==",
       "dev": true,
       "requires": {
         "@cypress/request": "^3.0.0",

--- a/examples/env/package.json
+++ b/examples/env/package.json
@@ -8,6 +8,6 @@
   },
   "private": true,
   "devDependencies": {
-    "cypress": "13.0.0"
+    "cypress": "13.1.0"
   }
 }

--- a/examples/install-command/package.json
+++ b/examples/install-command/package.json
@@ -7,7 +7,7 @@
   },
   "private": true,
   "devDependencies": {
-    "cypress": "13.0.0"
+    "cypress": "13.1.0"
   },
   "dependencies": {
     "arg": "5.0.0",

--- a/examples/install-command/yarn.lock
+++ b/examples/install-command/yarn.lock
@@ -316,10 +316,10 @@ cross-spawn@^7.0.0:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
-cypress@13.0.0:
-  version "13.0.0"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-13.0.0.tgz#8fe8f13dbb46f76ad30fa2d47be1c3489de625d2"
-  integrity sha512-nWHU5dUxP2Wm/zrMd8SWTTl706aJex/l+H4vi/tbu2SWUr17BUcd/sIYeqyxeoSPW1JFV2pT1pf4JEImH/POMg==
+cypress@13.1.0:
+  version "13.1.0"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-13.1.0.tgz#18f268e66662cd91b1766db18bd1f63a66592205"
+  integrity sha512-LUKxCYlB973QBFls1Up4FAE9QIYobT+2I8NvvAwMfQS2YwsWbr6yx7y9hmsk97iqbHkKwZW3MRjoK1RToBFVdQ==
   dependencies:
     "@cypress/request" "^3.0.0"
     "@cypress/xvfb" "^1.2.4"

--- a/examples/install-only/package-lock.json
+++ b/examples/install-only/package-lock.json
@@ -12,7 +12,7 @@
         "debug": "4.3.4"
       },
       "devDependencies": {
-        "cypress": "13.0.0"
+        "cypress": "13.1.0"
       }
     },
     "node_modules/@colors/colors": {
@@ -553,9 +553,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.0.0.tgz",
-      "integrity": "sha512-nWHU5dUxP2Wm/zrMd8SWTTl706aJex/l+H4vi/tbu2SWUr17BUcd/sIYeqyxeoSPW1JFV2pT1pf4JEImH/POMg==",
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.1.0.tgz",
+      "integrity": "sha512-LUKxCYlB973QBFls1Up4FAE9QIYobT+2I8NvvAwMfQS2YwsWbr6yx7y9hmsk97iqbHkKwZW3MRjoK1RToBFVdQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -2378,9 +2378,9 @@
       }
     },
     "cypress": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.0.0.tgz",
-      "integrity": "sha512-nWHU5dUxP2Wm/zrMd8SWTTl706aJex/l+H4vi/tbu2SWUr17BUcd/sIYeqyxeoSPW1JFV2pT1pf4JEImH/POMg==",
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.1.0.tgz",
+      "integrity": "sha512-LUKxCYlB973QBFls1Up4FAE9QIYobT+2I8NvvAwMfQS2YwsWbr6yx7y9hmsk97iqbHkKwZW3MRjoK1RToBFVdQ==",
       "dev": true,
       "requires": {
         "@cypress/request": "^3.0.0",

--- a/examples/install-only/package.json
+++ b/examples/install-only/package.json
@@ -11,6 +11,6 @@
     "debug": "4.3.4"
   },
   "devDependencies": {
-    "cypress": "13.0.0"
+    "cypress": "13.1.0"
   }
 }

--- a/examples/nextjs/package-lock.json
+++ b/examples/nextjs/package-lock.json
@@ -13,7 +13,7 @@
         "react-dom": "18.2.0"
       },
       "devDependencies": {
-        "cypress": "13.0.0"
+        "cypress": "13.1.0"
       }
     },
     "node_modules/@colors/colors": {
@@ -732,9 +732,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.0.0.tgz",
-      "integrity": "sha512-nWHU5dUxP2Wm/zrMd8SWTTl706aJex/l+H4vi/tbu2SWUr17BUcd/sIYeqyxeoSPW1JFV2pT1pf4JEImH/POMg==",
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.1.0.tgz",
+      "integrity": "sha512-LUKxCYlB973QBFls1Up4FAE9QIYobT+2I8NvvAwMfQS2YwsWbr6yx7y9hmsk97iqbHkKwZW3MRjoK1RToBFVdQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {

--- a/examples/nextjs/package.json
+++ b/examples/nextjs/package.json
@@ -15,6 +15,6 @@
     "react-dom": "18.2.0"
   },
   "devDependencies": {
-    "cypress": "13.0.0"
+    "cypress": "13.1.0"
   }
 }

--- a/examples/node-versions/package-lock.json
+++ b/examples/node-versions/package-lock.json
@@ -8,7 +8,7 @@
       "name": "example-node-versions",
       "version": "1.0.0",
       "devDependencies": {
-        "cypress": "13.0.0"
+        "cypress": "13.1.0"
       }
     },
     "node_modules/@colors/colors": {
@@ -544,9 +544,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.0.0.tgz",
-      "integrity": "sha512-nWHU5dUxP2Wm/zrMd8SWTTl706aJex/l+H4vi/tbu2SWUr17BUcd/sIYeqyxeoSPW1JFV2pT1pf4JEImH/POMg==",
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.1.0.tgz",
+      "integrity": "sha512-LUKxCYlB973QBFls1Up4FAE9QIYobT+2I8NvvAwMfQS2YwsWbr6yx7y9hmsk97iqbHkKwZW3MRjoK1RToBFVdQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -2366,9 +2366,9 @@
       }
     },
     "cypress": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.0.0.tgz",
-      "integrity": "sha512-nWHU5dUxP2Wm/zrMd8SWTTl706aJex/l+H4vi/tbu2SWUr17BUcd/sIYeqyxeoSPW1JFV2pT1pf4JEImH/POMg==",
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.1.0.tgz",
+      "integrity": "sha512-LUKxCYlB973QBFls1Up4FAE9QIYobT+2I8NvvAwMfQS2YwsWbr6yx7y9hmsk97iqbHkKwZW3MRjoK1RToBFVdQ==",
       "dev": true,
       "requires": {
         "@cypress/request": "^3.0.0",

--- a/examples/node-versions/package.json
+++ b/examples/node-versions/package.json
@@ -8,6 +8,6 @@
   },
   "private": true,
   "devDependencies": {
-    "cypress": "13.0.0"
+    "cypress": "13.1.0"
   }
 }

--- a/examples/quiet/package-lock.json
+++ b/examples/quiet/package-lock.json
@@ -8,7 +8,7 @@
       "name": "example-quiet",
       "version": "1.0.0",
       "devDependencies": {
-        "cypress": "13.0.0",
+        "cypress": "13.1.0",
         "image-size": "0.8.3"
       }
     },
@@ -545,9 +545,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.0.0.tgz",
-      "integrity": "sha512-nWHU5dUxP2Wm/zrMd8SWTTl706aJex/l+H4vi/tbu2SWUr17BUcd/sIYeqyxeoSPW1JFV2pT1pf4JEImH/POMg==",
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.1.0.tgz",
+      "integrity": "sha512-LUKxCYlB973QBFls1Up4FAE9QIYobT+2I8NvvAwMfQS2YwsWbr6yx7y9hmsk97iqbHkKwZW3MRjoK1RToBFVdQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -2391,9 +2391,9 @@
       }
     },
     "cypress": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.0.0.tgz",
-      "integrity": "sha512-nWHU5dUxP2Wm/zrMd8SWTTl706aJex/l+H4vi/tbu2SWUr17BUcd/sIYeqyxeoSPW1JFV2pT1pf4JEImH/POMg==",
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.1.0.tgz",
+      "integrity": "sha512-LUKxCYlB973QBFls1Up4FAE9QIYobT+2I8NvvAwMfQS2YwsWbr6yx7y9hmsk97iqbHkKwZW3MRjoK1RToBFVdQ==",
       "dev": true,
       "requires": {
         "@cypress/request": "^3.0.0",

--- a/examples/quiet/package.json
+++ b/examples/quiet/package.json
@@ -9,7 +9,7 @@
   },
   "private": true,
   "devDependencies": {
-    "cypress": "13.0.0",
+    "cypress": "13.1.0",
     "image-size": "0.8.3"
   }
 }

--- a/examples/recording/package-lock.json
+++ b/examples/recording/package-lock.json
@@ -8,7 +8,7 @@
       "name": "example-recording",
       "version": "1.0.0",
       "devDependencies": {
-        "cypress": "13.0.0"
+        "cypress": "13.1.0"
       }
     },
     "node_modules/@colors/colors": {
@@ -544,9 +544,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.0.0.tgz",
-      "integrity": "sha512-nWHU5dUxP2Wm/zrMd8SWTTl706aJex/l+H4vi/tbu2SWUr17BUcd/sIYeqyxeoSPW1JFV2pT1pf4JEImH/POMg==",
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.1.0.tgz",
+      "integrity": "sha512-LUKxCYlB973QBFls1Up4FAE9QIYobT+2I8NvvAwMfQS2YwsWbr6yx7y9hmsk97iqbHkKwZW3MRjoK1RToBFVdQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -2366,9 +2366,9 @@
       }
     },
     "cypress": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.0.0.tgz",
-      "integrity": "sha512-nWHU5dUxP2Wm/zrMd8SWTTl706aJex/l+H4vi/tbu2SWUr17BUcd/sIYeqyxeoSPW1JFV2pT1pf4JEImH/POMg==",
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.1.0.tgz",
+      "integrity": "sha512-LUKxCYlB973QBFls1Up4FAE9QIYobT+2I8NvvAwMfQS2YwsWbr6yx7y9hmsk97iqbHkKwZW3MRjoK1RToBFVdQ==",
       "dev": true,
       "requires": {
         "@cypress/request": "^3.0.0",

--- a/examples/recording/package.json
+++ b/examples/recording/package.json
@@ -9,6 +9,6 @@
   },
   "private": true,
   "devDependencies": {
-    "cypress": "13.0.0"
+    "cypress": "13.1.0"
   }
 }

--- a/examples/start-and-yarn-workspaces/workspace-1/package.json
+++ b/examples/start-and-yarn-workspaces/workspace-1/package.json
@@ -10,7 +10,7 @@
   },
   "private": true,
   "devDependencies": {
-    "cypress": "13.0.0",
+    "cypress": "13.1.0",
     "serve": "14.2.1"
   }
 }

--- a/examples/start-and-yarn-workspaces/workspace-2/package.json
+++ b/examples/start-and-yarn-workspaces/workspace-2/package.json
@@ -10,7 +10,7 @@
   },
   "private": true,
   "devDependencies": {
-    "cypress": "13.0.0",
+    "cypress": "13.1.0",
     "serve": "14.2.1"
   }
 }

--- a/examples/start-and-yarn-workspaces/yarn.lock
+++ b/examples/start-and-yarn-workspaces/yarn.lock
@@ -436,10 +436,10 @@ cross-spawn@^7.0.0, cross-spawn@^7.0.3:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
-cypress@13.0.0:
-  version "13.0.0"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-13.0.0.tgz#8fe8f13dbb46f76ad30fa2d47be1c3489de625d2"
-  integrity sha512-nWHU5dUxP2Wm/zrMd8SWTTl706aJex/l+H4vi/tbu2SWUr17BUcd/sIYeqyxeoSPW1JFV2pT1pf4JEImH/POMg==
+cypress@13.1.0:
+  version "13.1.0"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-13.1.0.tgz#18f268e66662cd91b1766db18bd1f63a66592205"
+  integrity sha512-LUKxCYlB973QBFls1Up4FAE9QIYobT+2I8NvvAwMfQS2YwsWbr6yx7y9hmsk97iqbHkKwZW3MRjoK1RToBFVdQ==
   dependencies:
     "@cypress/request" "^3.0.0"
     "@cypress/xvfb" "^1.2.4"

--- a/examples/start/package-lock.json
+++ b/examples/start/package-lock.json
@@ -8,7 +8,7 @@
       "name": "example-start",
       "version": "1.0.0",
       "devDependencies": {
-        "cypress": "13.0.0",
+        "cypress": "13.1.0",
         "serve": "14.2.1"
       }
     },
@@ -871,9 +871,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.0.0.tgz",
-      "integrity": "sha512-nWHU5dUxP2Wm/zrMd8SWTTl706aJex/l+H4vi/tbu2SWUr17BUcd/sIYeqyxeoSPW1JFV2pT1pf4JEImH/POMg==",
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.1.0.tgz",
+      "integrity": "sha512-LUKxCYlB973QBFls1Up4FAE9QIYobT+2I8NvvAwMfQS2YwsWbr6yx7y9hmsk97iqbHkKwZW3MRjoK1RToBFVdQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -3265,9 +3265,9 @@
       }
     },
     "cypress": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.0.0.tgz",
-      "integrity": "sha512-nWHU5dUxP2Wm/zrMd8SWTTl706aJex/l+H4vi/tbu2SWUr17BUcd/sIYeqyxeoSPW1JFV2pT1pf4JEImH/POMg==",
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.1.0.tgz",
+      "integrity": "sha512-LUKxCYlB973QBFls1Up4FAE9QIYobT+2I8NvvAwMfQS2YwsWbr6yx7y9hmsk97iqbHkKwZW3MRjoK1RToBFVdQ==",
       "dev": true,
       "requires": {
         "@cypress/request": "^3.0.0",

--- a/examples/start/package.json
+++ b/examples/start/package.json
@@ -11,7 +11,7 @@
   },
   "private": true,
   "devDependencies": {
-    "cypress": "13.0.0",
+    "cypress": "13.1.0",
     "serve": "14.2.1"
   }
 }

--- a/examples/wait-on-vite/package-lock.json
+++ b/examples/wait-on-vite/package-lock.json
@@ -8,7 +8,7 @@
       "name": "example-wait-on-vite",
       "version": "2.0.0",
       "devDependencies": {
-        "cypress": "13.0.0",
+        "cypress": "13.1.0",
         "vite": "^4.3.9"
       }
     },
@@ -897,9 +897,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.0.0.tgz",
-      "integrity": "sha512-nWHU5dUxP2Wm/zrMd8SWTTl706aJex/l+H4vi/tbu2SWUr17BUcd/sIYeqyxeoSPW1JFV2pT1pf4JEImH/POMg==",
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.1.0.tgz",
+      "integrity": "sha512-LUKxCYlB973QBFls1Up4FAE9QIYobT+2I8NvvAwMfQS2YwsWbr6yx7y9hmsk97iqbHkKwZW3MRjoK1RToBFVdQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -3049,9 +3049,9 @@
       }
     },
     "cypress": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.0.0.tgz",
-      "integrity": "sha512-nWHU5dUxP2Wm/zrMd8SWTTl706aJex/l+H4vi/tbu2SWUr17BUcd/sIYeqyxeoSPW1JFV2pT1pf4JEImH/POMg==",
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.1.0.tgz",
+      "integrity": "sha512-LUKxCYlB973QBFls1Up4FAE9QIYobT+2I8NvvAwMfQS2YwsWbr6yx7y9hmsk97iqbHkKwZW3MRjoK1RToBFVdQ==",
       "dev": true,
       "requires": {
         "@cypress/request": "^3.0.0",

--- a/examples/wait-on-vite/package.json
+++ b/examples/wait-on-vite/package.json
@@ -10,7 +10,7 @@
   },
   "private": true,
   "devDependencies": {
-    "cypress": "13.0.0",
+    "cypress": "13.1.0",
     "vite": "^4.3.9"
   }
 }

--- a/examples/wait-on/package-lock.json
+++ b/examples/wait-on/package-lock.json
@@ -12,7 +12,7 @@
         "debug": "4.3.4"
       },
       "devDependencies": {
-        "cypress": "13.0.0"
+        "cypress": "13.1.0"
       }
     },
     "node_modules/@colors/colors": {
@@ -553,9 +553,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.0.0.tgz",
-      "integrity": "sha512-nWHU5dUxP2Wm/zrMd8SWTTl706aJex/l+H4vi/tbu2SWUr17BUcd/sIYeqyxeoSPW1JFV2pT1pf4JEImH/POMg==",
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.1.0.tgz",
+      "integrity": "sha512-LUKxCYlB973QBFls1Up4FAE9QIYobT+2I8NvvAwMfQS2YwsWbr6yx7y9hmsk97iqbHkKwZW3MRjoK1RToBFVdQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -2378,9 +2378,9 @@
       }
     },
     "cypress": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.0.0.tgz",
-      "integrity": "sha512-nWHU5dUxP2Wm/zrMd8SWTTl706aJex/l+H4vi/tbu2SWUr17BUcd/sIYeqyxeoSPW1JFV2pT1pf4JEImH/POMg==",
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.1.0.tgz",
+      "integrity": "sha512-LUKxCYlB973QBFls1Up4FAE9QIYobT+2I8NvvAwMfQS2YwsWbr6yx7y9hmsk97iqbHkKwZW3MRjoK1RToBFVdQ==",
       "dev": true,
       "requires": {
         "@cypress/request": "^3.0.0",

--- a/examples/wait-on/package.json
+++ b/examples/wait-on/package.json
@@ -20,6 +20,6 @@
     "debug": "4.3.4"
   },
   "devDependencies": {
-    "cypress": "13.0.0"
+    "cypress": "13.1.0"
   }
 }

--- a/examples/webpack/package-lock.json
+++ b/examples/webpack/package-lock.json
@@ -8,7 +8,7 @@
       "name": "example-webpack",
       "version": "1.0.0",
       "devDependencies": {
-        "cypress": "13.0.0",
+        "cypress": "13.1.0",
         "webpack": "5.81.0",
         "webpack-cli": "5.0.2",
         "webpack-dev-server": "4.13.3"
@@ -1436,9 +1436,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.0.0.tgz",
-      "integrity": "sha512-nWHU5dUxP2Wm/zrMd8SWTTl706aJex/l+H4vi/tbu2SWUr17BUcd/sIYeqyxeoSPW1JFV2pT1pf4JEImH/POMg==",
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.1.0.tgz",
+      "integrity": "sha512-LUKxCYlB973QBFls1Up4FAE9QIYobT+2I8NvvAwMfQS2YwsWbr6yx7y9hmsk97iqbHkKwZW3MRjoK1RToBFVdQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {

--- a/examples/webpack/package.json
+++ b/examples/webpack/package.json
@@ -8,7 +8,7 @@
   },
   "private": true,
   "devDependencies": {
-    "cypress": "13.0.0",
+    "cypress": "13.1.0",
     "webpack": "5.81.0",
     "webpack-cli": "5.0.2",
     "webpack-dev-server": "4.13.3"

--- a/examples/yarn-classic/package.json
+++ b/examples/yarn-classic/package.json
@@ -7,6 +7,6 @@
   },
   "private": true,
   "devDependencies": {
-    "cypress": "13.0.0"
+    "cypress": "13.1.0"
   }
 }

--- a/examples/yarn-classic/yarn.lock
+++ b/examples/yarn-classic/yarn.lock
@@ -311,10 +311,10 @@ cross-spawn@^7.0.0:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
-cypress@13.0.0:
-  version "13.0.0"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-13.0.0.tgz#8fe8f13dbb46f76ad30fa2d47be1c3489de625d2"
-  integrity sha512-nWHU5dUxP2Wm/zrMd8SWTTl706aJex/l+H4vi/tbu2SWUr17BUcd/sIYeqyxeoSPW1JFV2pT1pf4JEImH/POMg==
+cypress@13.1.0:
+  version "13.1.0"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-13.1.0.tgz#18f268e66662cd91b1766db18bd1f63a66592205"
+  integrity sha512-LUKxCYlB973QBFls1Up4FAE9QIYobT+2I8NvvAwMfQS2YwsWbr6yx7y9hmsk97iqbHkKwZW3MRjoK1RToBFVdQ==
   dependencies:
     "@cypress/request" "^3.0.0"
     "@cypress/xvfb" "^1.2.4"

--- a/examples/yarn-modern-pnp/package.json
+++ b/examples/yarn-modern-pnp/package.json
@@ -8,6 +8,6 @@
   "private": true,
   "packageManager": "yarn@3.6.3",
   "devDependencies": {
-    "cypress": "13.0.0"
+    "cypress": "13.1.0"
   }
 }

--- a/examples/yarn-modern-pnp/yarn.lock
+++ b/examples/yarn-modern-pnp/yarn.lock
@@ -414,9 +414,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cypress@npm:13.0.0":
-  version: 13.0.0
-  resolution: "cypress@npm:13.0.0"
+"cypress@npm:13.1.0":
+  version: 13.1.0
+  resolution: "cypress@npm:13.1.0"
   dependencies:
     "@cypress/request": ^3.0.0
     "@cypress/xvfb": ^1.2.4
@@ -463,7 +463,7 @@ __metadata:
     yauzl: ^2.10.0
   bin:
     cypress: bin/cypress
-  checksum: 223dddfd85dbde5e3a915e87b6cb176b99a9e5bcc24baa40cd5b9ca4a93315a95cf53c5c6ac3a6984f59be55ffc8b58b93a713c0ddcb63a5f4996229cce70329
+  checksum: 238057b288f54401ad3fa8693c31ec08eef2d98a7fc93ce7f60bc009fcae18539e84be4c1cd41526816603f642f63444a7adce9d914b1338a53c0bf756bdb762
   languageName: node
   linkType: hard
 
@@ -565,7 +565,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "example-yarn-modern-pnp@workspace:."
   dependencies:
-    cypress: 13.0.0
+    cypress: 13.1.0
   languageName: unknown
   linkType: soft
 

--- a/examples/yarn-modern/package.json
+++ b/examples/yarn-modern/package.json
@@ -8,6 +8,6 @@
   "private": true,
   "packageManager": "yarn@3.6.3",
   "devDependencies": {
-    "cypress": "13.0.0"
+    "cypress": "13.1.0"
   }
 }

--- a/examples/yarn-modern/yarn.lock
+++ b/examples/yarn-modern/yarn.lock
@@ -414,9 +414,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cypress@npm:13.0.0":
-  version: 13.0.0
-  resolution: "cypress@npm:13.0.0"
+"cypress@npm:13.1.0":
+  version: 13.1.0
+  resolution: "cypress@npm:13.1.0"
   dependencies:
     "@cypress/request": ^3.0.0
     "@cypress/xvfb": ^1.2.4
@@ -463,7 +463,7 @@ __metadata:
     yauzl: ^2.10.0
   bin:
     cypress: bin/cypress
-  checksum: 223dddfd85dbde5e3a915e87b6cb176b99a9e5bcc24baa40cd5b9ca4a93315a95cf53c5c6ac3a6984f59be55ffc8b58b93a713c0ddcb63a5f4996229cce70329
+  checksum: 238057b288f54401ad3fa8693c31ec08eef2d98a7fc93ce7f60bc009fcae18539e84be4c1cd41526816603f642f63444a7adce9d914b1338a53c0bf756bdb762
   languageName: node
   linkType: hard
 
@@ -565,7 +565,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "example-yarn-modern@workspace:."
   dependencies:
-    cypress: 13.0.0
+    cypress: 13.1.0
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
This PR updates the [examples](https://github.com/cypress-io/github-action/tree/master/examples) to [Cypress 13.1.0](https://docs.cypress.io/guides/references/changelog#13-1-0) released August 31, 2023.