### PR TITLE
test: add live docker example

### DIFF
--- a/.github/workflows/example-docker.yml
+++ b/.github/workflows/example-docker.yml
@@ -1,0 +1,25 @@
+name: example-docker
+on:
+  push:
+    branches:
+      - 'master'
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  docker-browsers:
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        browser: [chrome, edge, electron, firefox]
+    # from https://hub.docker.com/r/cypress/browsers/tags
+    container:
+      image: cypress/browsers:node-20.5.0-chrome-114.0.5735.133-1-ff-114.0.2-edge-114.0.1823.51-1
+      options: --user 1001
+    steps:
+      - uses: actions/checkout@v3
+      - uses: cypress-io/github-action@v6
+        with:
+          working-directory: examples/basic
+          browser: ${{ matrix.browser }}

--- a/README.md
+++ b/README.md
@@ -239,6 +239,8 @@ Include `options: --user 1001` to avoid permissions issues.
 
 Refer to [cypress-io/cypress-docker-images](https://github.com/cypress-io/cypress-docker-images) for further information about using Cypress Docker images. Cypress offers the [Cypress Docker Factory](https://github.com/cypress-io/cypress-docker-images/tree/master/factory) to generate additional Docker images with selected components and versions.
 
+[![Docker example](https://github.com/cypress-io/github-action/workflows/example-docker/badge.svg?branch=master)](.github/workflows/example-docker.yml)
+
 ### Env
 
 Specify the env argument with `env` parameter


### PR DESCRIPTION
This PR adds a live workflow to demonstrate the use of `cypress/browsers` from [Cypress Docker images](https://github.com/cypress-io/cypress-docker-images) with the Cypress GitHub Action. This is already described in [README > Docker image](https://github.com/cypress-io/github-action#docker-image).
