### PR TITLE
feat(deps): remove node.js 16

### DIFF
--- a/.github/workflows/example-node-versions.yml
+++ b/.github/workflows/example-node-versions.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [16, 18, 20]
+        node: [18, 20]
     name: Cypress E2E on Node v${{ matrix.node }}
     steps:
       - name: Setup Node

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ See [Releases](https://github.com/cypress-io/github-action/releases) for full de
 
 | Version | Changes                                                                                                                              |
 | ------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| v6.5.0  | Examples remove Node.js 16. End of support for Node.js 16.                                                                           |
 | v6.4.0  | Action adds PR number and URL if available when recording                                                                            |
 | v6.3.0  | v6 is recommended action version                                                                                                     |
 | v6.2.0  | Examples updated to Cypress 13                                                                                                       |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,7 +107,7 @@ This information is for Cypress.io Members or Collaborators who merge pull reque
     ```text
     fix: upgrade dependency X
 
-    BREAKING CHANGE: requires minimum Node.js 16 to run
+    BREAKING CHANGE: requires minimum Node.js 18 to run
     ```
 
 1. New versions of this action will be released automatically by the CI when merged to the `master` branch, see [.github/workflows/main.yml](.github/workflows/main.yml). This will create a new [GitHub release](https://github.com/cypress-io/github-action/releases) and will update the current highest branch from the series `v5`, `v6`, ... etc. Thus specifying `uses: cypress-io/github-action@v6` (or higher version if available) selects the new version automatically. This **will not** push the latest release to GitHub Marketplace.

--- a/README.md
+++ b/README.md
@@ -410,7 +410,7 @@ jobs:
     # let's make sure our "app" works on several versions of Node
     strategy:
       matrix:
-        node: [16, 18, 20]
+        node: [18, 20]
     name: E2E on Node v${{ matrix.node }}
     steps:
       - name: Setup Node
@@ -1133,7 +1133,7 @@ jobs:
     # let's make sure our "app" works on several versions of Node
     strategy:
       matrix:
-        node: [16, 18, 20]
+        node: [18, 20]
     name: E2E on Node v${{ matrix.node }}
     steps:
       - name: Setup Node
@@ -1167,7 +1167,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        node: [16, 18, 20]
+        node: [18, 20]
     name: E2E on Node v${{ matrix.node }}
     steps:
       - uses: actions/setup-node@v3
@@ -1509,7 +1509,6 @@ If no related PR is detected, `CYPRESS_PULL_REQUEST_ID` and `CYPRESS_PULL_REQUES
 
 Node.js is required to run this action. The recommended version `v6` supports:
 
-- **Node.js** 16.x
 - **Node.js** 18.x
 - **Node.js** 20.x and above
 
@@ -1521,7 +1520,7 @@ and is generally aligned with [Node.js's release schedule](https://github.com/no
 
 [![Node versions example](https://github.com/cypress-io/github-action/workflows/example-node-versions/badge.svg?branch=master)](.github/workflows/example-node-versions.yml)
 
-Cypress itself runs with a fixed Node.js version specified by the [runs.using](https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#runs-for-javascript-actions) parameter of [action.yml](action.yml). `github-action@v5` uses `node16` and `github-action@v6` uses `node20`.
+Cypress itself runs with a fixed Node.js version specified by the [runs.using](https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#runs-for-javascript-actions) parameter of [action.yml](action.yml). `github-action@v6` uses `node20`.
 
 ## Changelog
 


### PR DESCRIPTION
This PR aligns the Cypress JavaScript GitHub Action documentation and examples in this repo with the Cypress documentation [Getting Started > System requirements > Node.js](https://docs.cypress.io/guides/getting-started/installing-cypress#Nodejs) which specifies

- Node.js 18.x
- Node.js 20.x and above

as being supported. Node.js `16` is no longer listed.

There is **no** change to the action itself, which can continue to be used with Node.js `16` although it will be classed as unsupported.

In any case Node.js `16` moves into a general end-of-life status on Sep 11, 2023 - see [Node.js 16 EOL announcement](https://nodejs.org/en/blog/announcements/nodejs16-eol).

This PR removes Node.js `16` ...

- from the list of versions which [.github/workflows/example-node-versions.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-node-versions.yml) tests

- from the examples in the [README](https://github.com/cypress-io/github-action/blob/master/README.md) file

## Version usage

- `cypress-io/github-action@v5` continues to use `node16` as its running environment as long as GitHub permits this usage
- `cypress-io/github-action@v6`, which has been available since Aug 24, 2023, uses `node20`

See [README > Usage](https://github.com/cypress-io/github-action#usage) for a more detailed explanation.

## References

- Node.js [Release schedule](https://github.com/nodejs/release#release-schedule)
- GitHub [runs.using for JavaScript actions](https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#runsusing-for-javascript-actions)
