### PR TITLE
docs: remove setup-node from auto cancel example

### DIFF
--- a/README.md
+++ b/README.md
@@ -452,8 +452,6 @@ jobs:
     runs-on: ubuntu-22.04
     name: E2E
     steps:
-      - name: Setup Node
-        uses: actions/setup-node@v3
 
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
## Change

In the example in the [README > Specify auto cancel after failures](https://github.com/cypress-io/github-action/blob/master/README.md#specify-auto-cancel-after-failures) section, the following lines are removed:

```yml
      - name: Setup Node
        uses: actions/setup-node@v3
```

## Reasons

- The example does not need any specific version of Node.js in order to be used and to be understandable
- [GitHub Actions Runner Images](https://github.com/actions/runner-images) already include Node.js LTS (currently Node.js `18.17.1`) installed by default
- `actions/setup-node@v3` is called without specifying any version of Node.js. [actions/setup-node](https://github.com/actions/setup-node) advises against this:

  > The node-version input is optional. If not supplied, the node version from PATH will be used. However, it is recommended to always specify Node.js version and don't rely on the system one.
