### PR TITLE
docs: update actions/checkout to v4 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       # Install npm dependencies, cache them correctly
       # and run all Cypress tests
       - name: Cypress run
@@ -102,7 +102,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Cypress run
         uses: cypress-io/github-action@v6
         with:
@@ -149,7 +149,7 @@ jobs:
     runs-on: ubuntu-22.04
     name: E2E on Chrome
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: cypress-io/github-action@v6
         with:
           browser: chrome
@@ -167,7 +167,7 @@ jobs:
     runs-on: ubuntu-22.04
     name: E2E on Firefox
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: cypress-io/github-action@v6
         with:
           browser: firefox
@@ -185,7 +185,7 @@ jobs:
     runs-on: ubuntu-22.04
     name: E2E on Edge
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: cypress-io/github-action@v6
         with:
           browser: edge
@@ -204,7 +204,7 @@ jobs:
   cypress-run:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: cypress-io/github-action@v6
         with:
           browser: chrome
@@ -227,7 +227,7 @@ jobs:
       image: cypress/browsers:latest
       options: --user 1001
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: cypress-io/github-action@v6
         with:
           browser: chrome
@@ -253,7 +253,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Cypress run with env
         uses: cypress-io/github-action@v6
@@ -271,7 +271,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Cypress run with env
         uses: cypress-io/github-action@v6
@@ -297,7 +297,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Cypress run
         uses: cypress-io/github-action@v6
@@ -328,7 +328,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Cypress run
         uses: cypress-io/github-action@v6
         with:
@@ -350,7 +350,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Cypress run
         uses: cypress-io/github-action@v6
@@ -382,7 +382,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Cypress run
         uses: cypress-io/github-action@v6
@@ -420,7 +420,7 @@ jobs:
       - run: node -v
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Cypress run
         uses: cypress-io/github-action@v6
@@ -454,7 +454,7 @@ jobs:
     steps:
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Cypress run
         uses: cypress-io/github-action@v6
@@ -481,7 +481,7 @@ jobs:
     runs-on: ubuntu-22.04
     name: Artifacts
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: cypress-io/github-action@v6
       # after the test run completes store videos and any screenshots
       - uses: actions/upload-artifact@v3
@@ -510,7 +510,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       # Install npm dependencies, cache them correctly
       # and run all Cypress tests with `quiet` parameter
       - name: Cypress run
@@ -535,7 +535,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Cypress run
         uses: cypress-io/github-action@v6
@@ -558,7 +558,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Cypress run
         uses: cypress-io/github-action@v6
@@ -590,7 +590,7 @@ jobs:
         containers: [1, 2, 3]
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # because of "record" and "parallel" parameters
       # these containers will load balance all found tests among themselves
@@ -646,7 +646,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Cypress run
         uses: cypress-io/github-action@v6
         with:
@@ -665,7 +665,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Cypress run
         uses: cypress-io/github-action@v6
         with:
@@ -683,7 +683,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Cypress run
         uses: cypress-io/github-action@v6
         with:
@@ -709,7 +709,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Cypress run
         uses: cypress-io/github-action@v6
         with:
@@ -739,7 +739,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Cypress run
         uses: cypress-io/github-action@v6
         with:
@@ -824,7 +824,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Cypress run
         uses: cypress-io/github-action@v6
         with:
@@ -843,7 +843,7 @@ You can overwrite the Cypress run command with your own command.
 ```yml
 steps:
   - name: Checkout 🛎
-    uses: actions/checkout@v3
+    uses: actions/checkout@v4
 
   - name: Custom tests 🧪
     uses: cypress-io/github-action@v6
@@ -870,7 +870,7 @@ jobs:
         # run 3 copies of the current job in parallel
         containers: [1, 2, 3]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: cypress-io/github-action@v6
         with:
           record: true
@@ -905,7 +905,7 @@ jobs:
   smoke-tests:
     needs: ['prepare']
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: cypress-io/github-action@v6
         with:
           record: true
@@ -945,7 +945,7 @@ jobs:
   cypress-run:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: cypress-io/github-action@v6
         with:
           start: npm start
@@ -983,7 +983,7 @@ jobs:
   test:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Install root dependencies
         uses: bahmutov/npm-install@v1
 
@@ -1009,7 +1009,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install pnpm
         uses: pnpm/action-setup@v2
         with:
@@ -1034,7 +1034,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Cypress run
         uses: cypress-io/github-action@v6
         with:
@@ -1055,7 +1055,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Cypress run
         uses: cypress-io/github-action@v6
         with:
@@ -1080,7 +1080,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Cypress run
         uses: cypress-io/github-action@v6
         with:
@@ -1109,7 +1109,7 @@ jobs:
     # and tests in a subfolder like "workspace-1"
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: cypress-io/github-action@v6
         with:
           working-directory: examples/start-and-yarn-workspaces/workspace-1
@@ -1141,7 +1141,7 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       # run Cypress tests and record them under the same run
       # associated with commit SHA and just give a different group name
       - name: Cypress run
@@ -1173,7 +1173,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node }}
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: cypress-io/github-action@v6
 ```
 
@@ -1192,7 +1192,7 @@ jobs:
   test:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Install dependencies
         uses: cypress-io/github-action@v6
         with:
@@ -1219,7 +1219,7 @@ Finally, you might not need this GH Action at all. For example, if you want to s
 If the project has many dependencies, but you want to install just Cypress you can combine this action with `actions/cache` and `npm i cypress` commands yourself.
 
 ```yml
-- uses: actions/checkout@v3
+- uses: actions/checkout@v4
 - uses: actions/cache@v2
   with:
     path: |
@@ -1246,7 +1246,7 @@ jobs:
     # to prevent a hanging process from using all your CI minutes
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: cypress-io/github-action@v6
         # you can specify individual step timeout too
         timeout-minutes: 5
@@ -1386,7 +1386,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Cypress run
         uses: cypress-io/github-action@v6
         with:
@@ -1403,7 +1403,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Cypress install
         uses: cypress-io/github-action@v6
         with:
@@ -1434,7 +1434,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Cypress nightly tests 🌃
         uses: cypress-io/github-action@v6
 ```
@@ -1455,7 +1455,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Cypress run
         uses: cypress-io/github-action@v6
         with:
@@ -1478,7 +1478,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Cypress run
         uses: cypress-io/github-action@v6
         with:


### PR DESCRIPTION
Update all workflow examples in the [README](https://github.com/cypress-io/github-action/blob/master/README.md) documentation to use JavaScript action [actions/checkout](https://github.com/actions/checkout) `v4`.

- The previously used `v3` runs under `node16` with [end-of-life](https://nodejs.org/en/blog/announcements/nodejs16-eol) today, Sep 11, 2023
- `v4` is the latest version, which runs under `node20`, and this is under active support