### PR TITLE
test: rework example-chrome workflow

### DIFF
--- a/.github/workflows/example-chrome.yml
+++ b/.github/workflows/example-chrome.yml
@@ -21,7 +21,10 @@ jobs:
           # including detected browsers
           # which are pre-installed in GitHub-hosted runners
           # see https://on.cypress.io/command-line#cypress-info
-          # For convenience, (mis-)use build parameter to get cypress info
+          # We do not need the build parameter to build an app here
+          # because the remote https://example.cypress.io site
+          # is already built and running, and so for convenience
+          # we repurpose the build parameter to get cypress info instead.
           build: npx cypress info
           working-directory: examples/browser
           browser: chrome

--- a/.github/workflows/example-chrome.yml
+++ b/.github/workflows/example-chrome.yml
@@ -14,39 +14,40 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Cypress info
+      - name: Chrome headless
         uses: ./
         with:
-          # just for full picture after installing Cypress
-          # print information about detected browsers, etc
+          # Print information about the system and current environment
+          # including detected browsers
+          # which are pre-installed in GitHub-hosted runners
           # see https://on.cypress.io/command-line#cypress-info
+          # For convenience, (mis-)use build parameter to get cypress info
           build: npx cypress info
           working-directory: examples/browser
-
-      - name: Chrome
-        uses: ./
-        with:
-          working-directory: examples/browser
           browser: chrome
+          # As of Cypress v8.0 the `cypress run` command
+          # executes tests in `headless` mode by default
 
       - uses: actions/upload-artifact@v3
         with:
-          name: screenshots-in-chrome
+          name: screenshots-headless-chrome
           path: examples/browser/cypress/screenshots
 
       - run: npx image-size cypress/screenshots/**/*.png
         working-directory: examples/browser
 
-      - name: Chrome headless
+      - name: Chrome headed
         uses: ./
         with:
+          # Cypress and dependencies are already installed
+          install: false
           working-directory: examples/browser
           browser: chrome
-          headed: false
+          headed: true
 
       - uses: actions/upload-artifact@v3
         with:
-          name: screenshots-in-headless-chrome
+          name: screenshots-headed-chrome
           path: examples/browser/cypress/screenshots
 
       - run: npx image-size cypress/screenshots/**/*.png


### PR DESCRIPTION
This PR rationalizes the [example-chrome.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-chrome.yml) workflow.

- Electron tests run with `npx cypress info` are disabled. Testing against Electron does not belong in a Chrome workflow.
- Instead of running headless tests twice, now one headless and one headed test is run.