### PR TITLE
docs: rework subfolders example

### DIFF
--- a/README.md
+++ b/README.md
@@ -958,7 +958,7 @@ Each of the examples in this monorepo is separated from other examples by using 
 
 ### Subfolders
 
-Sometimes Cypress and end-to-end tests have their own `package.json` file in a subfolder, like
+Sometimes the application under test and the Cypress end-to-end tests may have separately defined dependencies. In the example below, Cypress has its own `package.json` file in a subfolder:
 
 ```text
 root/
@@ -966,15 +966,15 @@ root/
     (code for installing and running Cypress tests)
     package.json
     package-lock.json
-    cypress.json
-    cypress
+    cypress.config.js
+    cypress/
 
   (code for running the "app" with "npm start")
   package.json
-  yarn.lock
+  package-lock.json
 ```
 
-In that case you can combine this action with [bahmutov/npm-install](https://github.com/bahmutov/npm-install) action to install dependencies separately.
+In this case you can first install the dependencies for the application (`npm ci`), then start the application server (`npm start`) before calling `cypress-io/github-action` to install the dependencies for Cypress and to run Cypress. You may also need to use the [wait-on](#wait-on) parameter to make sure that the app server is fully available.
 
 ```yml
 name: E2E
@@ -985,7 +985,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install root dependencies
-        uses: bahmutov/npm-install@v1
+        run: npm ci
 
       - name: Start server in the background
         run: npm start &


### PR DESCRIPTION
This PR updates the documentation-only example [README > Subfolders](https://github.com/cypress-io/github-action/blob/master/README.md#subfolders).

- Instead of having an unusual mixture of Yarn and npm package managers and their corresponding lock files, the example is changed to only using npm with `package-lock.json` files.

- The use of the JavaScript action [bahmutov/npm-install](https://github.com/marketplace/actions/npm-or-yarn-install-with-caching) is replaced by a call to [npm-ci](https://docs.npmjs.com/cli/v10/commands/npm-ci), since the JavaScript action runs only on the end-of-life Node.js `16` version.

- The [Cypress configuration file](https://docs.cypress.io/guides/references/configuration#Configuration-File) name is updated to the correct name `cypress.config.js` for current configurations of Cypress `10.x` and later.