### PR TITLE
chore(deps): use npm ci instead of npm-install

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 20.5.0
-      - uses: bahmutov/npm-install@v1
+      - run: npm ci
       - run: npm run format
       - run: npm run build
 

--- a/.github/workflows/check-markdown.yml
+++ b/.github/workflows/check-markdown.yml
@@ -13,5 +13,5 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - uses: bahmutov/npm-install@v1
+      - run: npm ci
       - run: npm run check:markdown

--- a/.github/workflows/example-wait-on.yml
+++ b/.github/workflows/example-wait-on.yml
@@ -163,7 +163,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Install dependencies
-        uses: bahmutov/npm-install@v1
+        run: npm ci
       - name: Run ping from CLI
         run: node src/ping-cli https://example.cypress.io
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
           # Node.js minor version is aligned to
           # https://github.com/actions/runner/blob/main/src/Misc/externals.sh
           node-version: 20.5.0
-      - uses: bahmutov/npm-install@v1
+      - run: npm ci
       - run: npm run format
       - run: npm run build
       - run: npm test
@@ -35,7 +35,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - uses: bahmutov/npm-install@v1
+      - run: npm ci
       # https://github.com/cycjimmy/semantic-release-action
       - name: Semantic Release
         uses: cycjimmy/semantic-release-action@v3


### PR DESCRIPTION
This PR replaces the use of the JavaScript action [bahmutov/npm-install](https://github.com/marketplace/actions/npm-or-yarn-install-with-caching) in several [.github/workflows](https://github.com/cypress-io/github-action/tree/master/.github/workflows) by a call to [npm-ci](https://docs.npmjs.com/cli/v10/commands/npm-ci).

## Reasons

The JavaScript action [bahmutov/npm-install](https://github.com/bahmutov/npm-install) relies on `node16`, which reached [end-of-life](https://nodejs.org/en/blog/announcements/nodejs16-eol) on Sep 11, 2023. It is uncertain if there will be a new release to support `node20` and it has been more than a year since any maintainer has responded to issues in this repo.

The alternative [npm-ci](https://docs.npmjs.com/cli/v10/commands/npm-ci) is available for all supported versions of Node.js as part of the  `npm` utility, which is included in all standard [GitHub runner images](https://github.com/actions/runner-images). This is equally fast or sometimes faster than using [bahmutov/npm-install](https://github.com/bahmutov/npm-install).

## Impact

- Removes reliance on end-of-life Node.js `16`

- Removes dependency on [bahmutov/npm-install](https://github.com/bahmutov/npm-install)

- Removes caching of npm modules. Counterintuitively, this does not lengthen the run time of any of the changed actions. In some cases (see below) dealing with cache mechanics using `npm-install` was taking longer than installing using `npm ci` without caching.

## Typical run times

The following table compares the run times of:

- `npm-install` (cache miss)
- `npm-install` (cache hit)
- `npm ci` (no cache usage)

| Workflow                                                                                                                           | npm-install<br>cache miss | npm-install<br>cache hit | npm ci<br>no cache |
| ---------------------------------------------------------------------------------------------------------------------------------- | ------------------------- | ------------------------ | ------------------ |
| [check-dist.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/check-dist.yml)                         | 4s                        | 5s                       | 2s                 |
| [check-markdown.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/check-markdown.yml)                 | 4s                        | 5s                       | 3s                 |
| [example-wait-on.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-wait-on.yml) in `ping-cli` | 12s                       | 3s                       | 3s                 |
| [main.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/main.yml)                                     | 12s                       | 3s                       | 3s                 |
