### PR TITLE
docs: deprecate versions v4 & v5 using node16

### DIFF
--- a/README.md
+++ b/README.md
@@ -1529,8 +1529,8 @@ View the [CHANGELOG](./CHANGELOG.md) document for an overview of version changes
 ## Compatibility
 
 - `v6` is the current recommended version and uses `node20`
-- `v5` uses `node16`
-- `v4` is the minimum version required for Cypress `10.x` and later - also uses `node16`
+- `v5` uses the deprecated version `node16`
+- `v4` is the minimum version required for Cypress `10.x` and later - also uses the deprecated version `node16`
 
 Pay attention to any GitHub Actions deprecation warnings shown in logs which may recommend updating.
 


### PR DESCRIPTION
This PR adds a note in [README > Compatibility](https://github.com/cypress-io/github-action/blob/master/README.md#compatibility) that `v4` and `v5` of the `cypress-io/github-action` which use `node16` are now deprecated.

## Background

1. Node.js 16 entered [end-of-life](https://nodejs.org/en/blog/announcements/nodejs16-eol) on Sep 11, 2023.
2. [GitHub Actions: Transitioning from Node 16 to Node 20](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/) announced on Sep 22, 2023 the beginning of the deprecation process for `node16` actions. (`node12` are already forced to run under `node16`. Early next year they will all be forced on to `node20`.)