### PR TITLE
test: add npm caching to pnpm examples

### DIFF
--- a/.github/workflows/example-basic-pnpm.yml
+++ b/.github/workflows/example-basic-pnpm.yml
@@ -19,6 +19,19 @@ jobs:
         with:
           version: 8
 
+      - name: Get pnpm store directory
+        shell: bash
+        run: |
+          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+
+      - name: Setup pnpm cache
+        uses: actions/cache@v3
+        with:
+          path: ${{ env.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('examples/basic-pnpm/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
       - name: Cypress tests
         # normally you would write
         # uses: cypress-io/github-action@v6
@@ -43,6 +56,19 @@ jobs:
         with:
           version: 8
 
+      - name: Get pnpm store directory
+        shell: bash
+        run: |
+          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+
+      - name: Setup pnpm cache
+        uses: actions/cache@v3
+        with:
+          path: ${{ env.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('examples/basic-pnpm/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
       - name: Cypress tests
         uses: ./
         with:
@@ -60,6 +86,19 @@ jobs:
         with:
           version: 8
 
+      - name: Get pnpm store directory
+        shell: bash
+        run: |
+          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+
+      - name: Setup pnpm cache
+        uses: actions/cache@v3
+        with:
+          path: ${{ env.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('examples/basic-pnpm/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
       - name: Cypress tests
         uses: ./
         with:
@@ -76,6 +115,19 @@ jobs:
         uses: pnpm/action-setup@v2
         with:
           version: 8
+
+      - name: Get pnpm store directory
+        shell: bash
+        run: |
+          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+
+      - name: Setup pnpm cache
+        uses: actions/cache@v3
+        with:
+          path: ${{ env.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('examples/basic-pnpm/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
 
       - name: Cypress tests
         uses: ./
@@ -96,6 +148,19 @@ jobs:
         uses: pnpm/action-setup@v2
         with:
           version: 8
+
+      - name: Get pnpm store directory
+        shell: bash
+        run: |
+          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+
+      - name: Setup pnpm cache
+        uses: actions/cache@v3
+        with:
+          path: ${{ env.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('examples/basic-pnpm/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
 
       - name: Cypress tests
         uses: ./

--- a/README.md
+++ b/README.md
@@ -1002,6 +1002,7 @@ jobs:
 ### pnpm
 
 The package manager `pnpm` is not pre-installed in [GitHub Actions runner images](https://github.com/actions/runner-images) (unlike `npm` and `yarn`): to install `pnpm` include [pnpm/action-setup](https://github.com/pnpm/action-setup) in your workflow. If the action finds a `pnpm-lock.yaml` file, it uses the [pnpm](https://pnpm.io/cli/install) command `pnpm install --frozen-lockfile` by default to install dependencies.
+At this time the action does not automatically cache dependencies installed by pnpm. The example below includes steps to locate the pnpm store directory and to cache its contents for later use.
 
 ```yaml
 name: example-basic-pnpm
@@ -1016,6 +1017,17 @@ jobs:
         uses: pnpm/action-setup@v2
         with:
           version: 8
+      - name: Get pnpm store directory
+        shell: bash
+        run: |
+          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+      - name: Setup pnpm cache
+        uses: actions/cache@v3
+        with:
+          path: ${{ env.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('examples/basic-pnpm/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
       - name: Cypress run
         uses: cypress-io/github-action@v6
         with:


### PR DESCRIPTION
If `cypress-io/github-action` finds a `pnpm-lock.yaml` file, it uses the pnpm command `pnpm install --frozen-lockfile` by default to install dependencies. It does not however cache these dependencies for a future run of the same workflow.

This PR is a workaround to the pnpm example to make up for this missing functionality.

It adds dependency caching of the [pnpm store](https://pnpm.io/cli/store) contents using the command `pnpm store path` to find the location of the store and [actions/cache](https://github.com/actions/cache) to cache the store contents. This is applied to

- the workflow [example-basic-pnpm.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-basic-pnpm.yml) and to
- the [README > pnpm](https://github.com/cypress-io/github-action/blob/master/README.md#pnpm) section.

There is no change to the action itself.

- A separate enhancement request is logged under https://github.com/cypress-io/github-action/issues/1044.

## Verification

Run the workflow [example-basic-pnpm.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-basic-pnpm.yml).

Check that each of the caches under `github-action/actions/caches`

- `macOS-pnpm-store-*`
- `Linux-pnpm-store-*`
- `Windows-pnpm-store-*`

is approximately 6MB large.

Run the workflow [example-basic-pnpm.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-basic-pnpm.yml) again.

Check the logs files and examine each job.

- `basic-pnpm-ubuntu-20`
- `basic-pnpm-ubuntu-22`
- `basic-pnpm-on-windows`
- `basic-pnpm-on-mac`
- `basic-pnpm-binary`

Under the step "Cypress tests" look for the line
> Progress: resolved 179, reused 179, downloaded 0, added 179, done

The number next to `downloaded` must be `0`.