### PR TITLE
test: demonstrate config-file parameter

### DIFF
--- a/.github/workflows/example-config.yml
+++ b/.github/workflows/example-config.yml
@@ -24,6 +24,22 @@ jobs:
           wait-on: 'http://localhost:3333'
           config: baseUrl=http://localhost:3333
 
+  config-file:
+    # example where we use a custom config-file
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Cypress tests
+        uses: ./
+        with:
+          working-directory: examples/config
+          build: npm run build
+          start: npm start
+          wait-on: 'http://localhost:3333'
+          config-file: cypress.config-alternate.js
+
   separate-specs:
     # example where we pass specs to run via multiple lines
     runs-on: ubuntu-22.04

--- a/README.md
+++ b/README.md
@@ -547,7 +547,7 @@ jobs:
 
 ### Config File
 
-Specify the path to your config file with `config-file` parameter
+Specify the path to your [Configuration File](https://on.cypress.io/guides/references/configuration#Configuration-File) with `config-file` parameter
 
 ```yml
 name: Cypress tests
@@ -563,8 +563,10 @@ jobs:
       - name: Cypress run
         uses: cypress-io/github-action@v6
         with:
-          config-file: tests/cypress-config.json
+          config-file: cypress.config-alternate.js
 ```
+
+[![example-config](https://github.com/cypress-io/github-action/workflows/example-config/badge.svg?branch=master)](.github/workflows/example-config.yml)
 
 ### Parallel
 

--- a/examples/config/cypress.config-alternate.js
+++ b/examples/config/cypress.config-alternate.js
@@ -1,0 +1,12 @@
+const { defineConfig } = require('cypress')
+
+module.exports = defineConfig({
+  fixturesFolder: false,
+  e2e: {
+    baseUrl: 'http://localhost:3333',
+    setupNodeEvents(on, config) {
+      console.log('\nUsing cypress.config-alternate.js config-file')
+    },
+    supportFile: false
+  },
+})


### PR DESCRIPTION
- This PR follows on from issue https://github.com/cypress-io/github-action/issues/1046.

The PR provides two improvements:

1. The [README > Config file](https://github.com/cypress-io/github-action#config-file) section is updated to use an example config filename from current Cypress configurations (Cypress `10.x` and later) where the filename by default is either `cypress.config.js` for JavaScript apps or `cypress.config.ts` for TypeScript apps, instead of `cypress.json` for legacy configurations (Cypress `9.x` and earlier).

2. A job is added to the [example-config.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-config.yml) workflow which demonstrates the use of the `config-file` parameter. This parameter was not previously being tested.

## Verification

Run the [example-config.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-config.yml) and examine the new job `config-file` for successful execution and console output which says:

> Using cypress.config-alternate.js config-file

## References

- [References > Configuration > Configuration File](https://docs.cypress.io/guides/references/configuration#Configuration-File)
