### PR TITLE
test: example-docker use action from branch

### DIFF
--- a/.github/workflows/example-docker.yml
+++ b/.github/workflows/example-docker.yml
@@ -19,7 +19,7 @@ jobs:
       options: --user 1001
     steps:
       - uses: actions/checkout@v4
-      # replace by the following for regular use:
+      # replace with the following for regular use:
       # uses: cypress-io/github-action@v6
       - uses: ./
         with:

--- a/.github/workflows/example-docker.yml
+++ b/.github/workflows/example-docker.yml
@@ -19,7 +19,9 @@ jobs:
       options: --user 1001
     steps:
       - uses: actions/checkout@v4
-      - uses: cypress-io/github-action@v6
+      # replace by the following for regular use:
+      # uses: cypress-io/github-action@v6
+      - uses: ./
         with:
           working-directory: examples/basic
           browser: ${{ matrix.browser }}


### PR DESCRIPTION
For consistency with other examples, the [example-docker.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-docker.yml) workflow is modified to use the action from its branch instead of from the published action. CI will then test after `push` or `pull_request` event triggers correctly using any modifications to the action.

```yaml
- uses: cypress-io/github-action@v6
```

is changed to

```yaml
- uses: ./
```
