### PR TITLE
ci: remove microsoft windows from markdown-link-check

### DIFF
--- a/docs/MAINTENANCE.md
+++ b/docs/MAINTENANCE.md
@@ -12,7 +12,7 @@ The examples make use of [npm](https://www.npmjs.com/), [pnpm](https://pnpm.io/)
 
 ## Requirements
 
-- A local system running [Ubuntu](https://ubuntu.com/), [Microsoft Windows](https://www.microsoft.com/windows/) or [Apple macOS](https://www.apple.com/macos/).
+- A local system running [Ubuntu](https://ubuntu.com/), <!-- markdown-link-check-disable -->[Microsoft Windows](https://www.microsoft.com/windows/)<!-- markdown-link-check-enable --> or [Apple macOS](https://www.apple.com/macos/).
 
 - [Node.js](https://nodejs.org/en/) as described in the [CONTRIBUTING](../CONTRIBUTING.md#requirements) document.
 


### PR DESCRIPTION
## Issue

Since last week `npm run check:markdown` has been sporadically failing when checking the link

`[Microsoft Windows](https://www.microsoft.com/windows/)` to https://www.microsoft.com/windows/ in the document

[docs/MAINTENANCE.md](https://github.com/cypress-io/github-action/blob/master/docs/MAINTENANCE.md).

This is the portion of the check log showing the failure:

```text
FILE: docs/MAINTENANCE.md
  [✓] ../examples
  [✓] https://docs.cypress.io/guides/references/configuration
  [✓] https://github.com/cypress-io/github-action
  [✓] https://www.npmjs.com/
  [✓] https://pnpm.io/
  [✓] https://classic.yarnpkg.com/
  [✓] https://yarnpkg.com/
  [✓] https://github.com/cypress-io/github-action/tree/v5/examples/v9
  [✓] https://github.com/cypress-io/github-action/tree/v5/
  [✓] https://docs.cypress.io/guides/references/legacy-configuration
  [✓] https://ubuntu.com/
  [✖] https://www.microsoft.com/windows/
  [✓] https://www.apple.com/macos/
  [✓] https://nodejs.org/en/
  [✓] ../CONTRIBUTING.md#requirements
  [✓] https://git-scm.com/
  [✓] https://nodejs.org/
  [✓] https://code.visualstudio.com/
  [✓] https://docs.cypress.io/guides/references/changelog
  [✓] ../.github/workflows/example-install-only.yml

  20 links checked.

  ERROR: 1 dead links found!
  [✖] https://www.microsoft.com/windows/ → Status: 0
```

When accessed manually in a browser (instead of automatically through the npm module [markdown-link-check](https://www.npmjs.com/package/markdown-link-check)) the browser correctly displays a localized version of the page.

If the link is checked by Cypress with a cy.visit(`https://www.microsoft.com/windows/`) the page is displayed, however there is a marked delay of several seconds.

In similar situations where the issue has been sporadic and the failing only occurs when checking the link with `markdown-link-check`, the reason behind the failure has been increased network security, for instance as protection against Denial of Service attacks.

## Change

Using [Disable comments](https://github.com/tcort/markdown-link-check/blob/master/README.md#disable-comments)
`<!-- markdown-link-check-disable -->` and
`<!-- markdown-link-check-enable -->`
the link https://www.microsoft.com/windows/ in [docs/MAINTENANCE.md](https://github.com/cypress-io/github-action/blob/master/docs/MAINTENANCE.md) is disabled from `markdown-link-check`-ing.

## Verification

Execute the following locally

```shell
npx markdown-link-check -c md-linkcheck.json docs/MAINTENANCE.md
```

and confirm `19 links checked.` successfully.

Execute

```shell
npm run check:markdown
```

and confirm that all links in all checked files are successfully checked.
