### PR TITLE
tests(deps): add node.js 21 (current) to tests

### DIFF
--- a/.github/workflows/example-node-versions.yml
+++ b/.github/workflows/example-node-versions.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [18, 20]
+        node: [18, 20, 21]
     name: Cypress E2E on Node v${{ matrix.node }}
     steps:
       - name: Setup Node

--- a/README.md
+++ b/README.md
@@ -410,7 +410,7 @@ jobs:
     # let's make sure our "app" works on several versions of Node
     strategy:
       matrix:
-        node: [18, 20]
+        node: [18, 20, 21]
     name: E2E on Node v${{ matrix.node }}
     steps:
       - name: Setup Node
@@ -1135,7 +1135,7 @@ jobs:
     # let's make sure our "app" works on several versions of Node
     strategy:
       matrix:
-        node: [18, 20]
+        node: [18, 20, 21]
     name: E2E on Node v${{ matrix.node }}
     steps:
       - name: Setup Node
@@ -1169,7 +1169,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        node: [18, 20]
+        node: [18, 20, 21]
     name: E2E on Node v${{ matrix.node }}
     steps:
       - uses: actions/setup-node@v3


### PR DESCRIPTION
[Node.js 21.0.0](https://nodejs.org/en/blog/release/v21.0.0) was released on Oct 17, 2023.

This PR adds Node.js `21` to the matrix of tested nodes under [.github/workflows/example-node-versions.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-node-versions.yml) and to the [README](https://github.com/cypress-io/github-action/blob/master/README.md).

 According to [Node.js release schedule](https://github.com/nodejs/release#release-schedule) plans, Node.js `20.x` changes from "Current" status to "LTS" status on Oct 24, 2023. This does not affect the tests as Node.js `20` is already included in the matrix of tested versions.