### PR TITLE
chore(deps): update to actions/setup-node@v4

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -20,9 +20,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: 20.5.0
+          node-version: 20.8.1
       - run: npm ci
       - run: npm run format
       - run: npm run build

--- a/.github/workflows/example-node-versions.yml
+++ b/.github/workflows/example-node-versions.yml
@@ -18,7 +18,7 @@ jobs:
     name: Cypress E2E on Node v${{ matrix.node }}
     steps:
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
       - run: node -v

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,13 +12,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           # Action runs: using: node20 as defined in
           # https://github.com/cypress-io/github-action/blob/master/action.yml
           # Node.js minor version is aligned to
           # https://github.com/actions/runner/blob/main/src/Misc/externals.sh
-          node-version: 20.5.0
+          node-version: 20.8.1
       - run: npm ci
       - run: npm run format
       - run: npm run build

--- a/README.md
+++ b/README.md
@@ -414,7 +414,7 @@ jobs:
     name: E2E on Node v${{ matrix.node }}
     steps:
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
       - run: node -v
@@ -1151,7 +1151,7 @@ jobs:
     name: E2E on Node v${{ matrix.node }}
     steps:
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
       - name: Checkout
@@ -1184,7 +1184,7 @@ jobs:
         node: [18, 20, 21]
     name: E2E on Node v${{ matrix.node }}
     steps:
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
       - uses: actions/checkout@v4


### PR DESCRIPTION
This PR updates workflows and examples to use [actions/setup-node@v4](https://github.com/actions/setup-node/releases/tag/v4) that runs under `node20` (instead of [actions/setup-node@v3](https://github.com/actions/setup-node/releases/tag/v3) which runs under the deprecated `node16` version).

The specific version of Node.js used in workflows

- [.github/workflows/main.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/main.yml)
- [.github/workflows/check-dist.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/check-dist.yml)

is updated and aligned to `NODE20_VERSION="20.8.1"` in https://github.com/actions/runner/blob/main/src/Misc/externals.sh.
