### PR TITLE
build: add missing yarn.lock for cypress update if necessary

### DIFF
--- a/scripts/update-cypress-latest-other.sh
+++ b/scripts/update-cypress-latest-other.sh
@@ -45,6 +45,7 @@ echo
 echo updating examples/yarn-modern to cypress@latest
 cd yarn-modern
 yarn set version latest
+touch yarn.lock # create if missing to avoid a Yarn error
 yarn add cypress --dev --exact
 cd ..
 
@@ -53,6 +54,7 @@ echo
 echo updating examples/yarn-modern-pnp to cypress@latest
 cd yarn-modern-pnp
 yarn set version latest
+touch yarn.lock # create if missing to avoid a Yarn error
 yarn add cypress --dev --exact
 cd ..
 


### PR DESCRIPTION
This PR increases the robustness of the update script

- [scripts/update-cypress-latest-other.sh](https://github.com/cypress-io/github-action/blob/master/scripts/update-cypress-latest-other.sh)

used by

```bash
npm run update:cypress
```

If the `yarn.lock` file is missing in the following Yarn Modern example directories, then Yarn will output an error message and not install:

- [examples/yarn-modern](https://github.com/cypress-io/github-action/tree/master/examples/yarn-modern)
- [examples/yarn-modern-pnp](https://github.com/cypress-io/github-action/tree/master/examples/yarn-modern-pnp)

This is due to the mixture of Yarn and npm in the same monorepo. To make the update script more robust, an empty `yarn.lock` is created in the above directories, if it is missing. Yarn will then populate the respective lockfile correctly and not look in higher level directories for a lockfile.

## Verification

Delete

- [examples/yarn-modern/yarn.lock](https://github.com/cypress-io/github-action/tree/master/examples/yarn-modern/yarn.lock)
- [examples/yarn-modern-pnp/yarn.lock](https://github.com/cypress-io/github-action/tree/master/examples/yarn-modern-pnp/yarn.lock)

then execute

```bash
npm run update:cypress
```

ensuring that there are no Yarn errors reported. Restore the original contents of the `yarn.lock` files after the test.
