### PR TITLE
build: fix version update for yarn workspace

### DIFF
--- a/scripts/update-cypress-latest-other.sh
+++ b/scripts/update-cypress-latest-other.sh
@@ -15,11 +15,8 @@ echo
 echo updating examples/start-and-yarn-workspaces to cypress@latest
 cd start-and-yarn-workspaces
 for i in 1 2; do
-cd workspace-${i}
 echo updating workspace-${i}
-npm install cypress@latest --save-dev --save-exact --package-lock=false
-npm ls cypress
-cd ..
+yarn workspace workspace-${i} add cypress --dev --exact
 done
 echo
 echo updating yarn lockfile for start-and-yarn-workspaces


### PR DESCRIPTION
## Issue

If [scripts/update-cypress-latest-other.sh](https://github.com/cypress-io/github-action/blob/master/scripts/update-cypress-latest-other.sh) is run on a cleanly cloned repository or on one where `git clean` has been run, then it fails to update Cypress in the Yarn `workspace-2` [examples/start-and-yarn-workspaces/workspace-2](https://github.com/cypress-io/github-action/tree/master/examples/start-and-yarn-workspaces/workspace-2). If it is run again, then the update works as expected.

## Change

Replace the use of `npm install` in [scripts/update-cypress-latest-other.sh](https://github.com/cypress-io/github-action/blob/master/scripts/update-cypress-latest-other.sh) operating on [examples/start-and-yarn-workspaces](https://github.com/cypress-io/github-action/tree/master/examples/start-and-yarn-workspaces) by `yarn workspace` commands to update Cypress to the latest version.

## Verification

In clone of https://github.com/cypress-io/github-action

```bash
git clean -x -f -d
npm ci
npm install yarn@latest -g
npm install pnpm@latest -g
./scripts/update-cypress-latest-other.sh
```

Ensure there are no errors reported.

Compare the version of Cypress installed in [examples/start-and-yarn-workspaces](https://github.com/cypress-io/github-action/tree/master/examples/start-and-yarn-workspaces)

```bash
cd examples/start-and-yarn-workspaces
yarn list --pattern cypress
```

with the latest version shown by

```bash
npm view cypress dist-tags
```
