### PR TITLE
test: fix example-recording failure reporting status

### DIFF
--- a/.github/workflows/example-recording.yml
+++ b/.github/workflows/example-recording.yml
@@ -55,9 +55,6 @@ jobs:
         # let's give this action an ID so we can refer
         # to its output values later
         id: cypress
-        # Continue the build in case of an error, as we need to set the
-        # commit status in the next step, both in case of success and failure
-        continue-on-error: true
         with:
           working-directory: examples/recording
           record: true
@@ -69,6 +66,7 @@ jobs:
       # https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#steps-context
       # "output" can be success, failure, cancelled, or skipped
       - name: Print Cypress Cloud URL
+        if: always()
         run: |
           echo Cypress finished with: ${{ steps.cypress.outcome }}
           echo See results at ${{ steps.cypress.outputs.resultsUrl }}

--- a/README.md
+++ b/README.md
@@ -1370,14 +1370,12 @@ This is an example of using the step output `resultsUrl`:
   # let's give this action an ID so we can refer
   # to its output values later
   id: cypress
-  # Continue the build in case of an error, as we need to set the
-  # commit status in the next step, both in case of success or failure
-  continue-on-error: true
   with:
     record: true
   env:
     CYPRESS_RECORD_KEY: ${{ secrets.RECORDING_KEY }}
 - name: Print Cypress Cloud URL
+  if: always()
   run: |
     echo Cypress finished with: ${{ steps.cypress.outcome }}
     echo See results at ${{ steps.cypress.outputs.resultsUrl }}


### PR DESCRIPTION
- closes #1072

## Changes

This PR corrects an issue where the [example-recording.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-recording.yml) workflow passes back a success status to GitHub in the `parallel` job whether or not the Cypress tests from the project [examples/recording](https://github.com/cypress-io/github-action/tree/master/examples/recording) pass or fail.

The code example in [README > Outputs](https://github.com/cypress-io/github-action/blob/master/README.md#outputs) is also corrected.

## Verification

1. Modify [examples/recording/cypress/e2e/spec-a.cy.js](https://github.com/cypress-io/github-action/blob/master/examples/recording/cypress/e2e/spec-a.cy.js) to introduce a deliberate failure condition by adding the following to the test spec:

```js
assert.fail('This is a deliberate error')
```

2. Manually trigger a run of [workflows/example-recording.yml](https://github.com/cypress-io/github-action/actions/workflows/example-recording.yml) by clicking on "Run workflow".

3. After the workflow run has completed, examine the logs and confirm that one of the jobs `parallel (1)` or `parallel (2)` is marked with a red cross to indicate failure.

4. Confirm that the step "Print Cypress Cloud URL" was executed for both `parallel (1)` and `parallel (2)`, and that it reports the correct status of either "failure" or "success". One job should succeed, the other should fail.

5. Revert the deliberate error and push the correction as a new commit to the repo.

6. Run the workflow again via "Run workflow". (Don't use "Re-run jobs" as this will run against the original commit, not the corrected one.)

7. Confirm that all jobs pass, that the step "Print Cypress Cloud URL" was executed in the `parallel` jobs and that it reports "success".
