### PR TITLE
docs: update changelog for release v6.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ See [Releases](https://github.com/cypress-io/github-action/releases) for full de
 
 | Version | Changes                                                                                                                              |
 | ------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| v6.6.0  | Add parameter `summary-title`                                                                                                        |
 | v6.5.0  | Examples remove Node.js 16. End of support for Node.js 16.                                                                           |
 | v6.4.0  | Action adds PR number and URL if available when recording                                                                            |
 | v6.3.0  | v6 is recommended action version                                                                                                     |

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Alternatively, to mitigate unforeseen breaks, bind to a specific [tag](https://g
   uses: cypress-io/github-action@v6.1.0
 ```
 
-The changes associated with each tag are shown under GitHub's [releases](https://github.com/cypress-io/github-action/releases) list. Refer also to the [Changelog](#changelog) for an overview of major changes.
+The changes associated with each tag are shown under GitHub's [releases](https://github.com/cypress-io/github-action/releases) list. Refer also to the [CHANGELOG](./CHANGELOG.md) for an overview of major changes.
 
 ### Browser
 


### PR DESCRIPTION
This PR adds release [v6.6.0](https://github.com/cypress-io/github-action/releases/tag/v6.6.0) to the [CHANGELOG.md](https://github.com/cypress-io/github-action/blob/master/CHANGELOG.md).

- [v6.6.0](https://github.com/cypress-io/github-action/releases/tag/v6.6.0) included PR https://github.com/cypress-io/github-action/pull/1056
