### PR TITLE
chore(deps): update prettier to 3.1.1

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -74506,10 +74506,10 @@ const lockHash = () => {
   const lockFilename = useYarn()
     ? yarnFilename
     : usePnpm()
-    ? pnpmLockFilename
-    : useNpm()
-    ? packageLockFilename
-    : noLockFile()
+      ? pnpmLockFilename
+      : useNpm()
+        ? packageLockFilename
+        : noLockFile()
   const fileHash = hasha.fromFileSync(lockFilename)
   debug(`Hash from file ${lockFilename} is ${fileHash}`)
   return fileHash

--- a/index.js
+++ b/index.js
@@ -110,10 +110,10 @@ const lockHash = () => {
   const lockFilename = useYarn()
     ? yarnFilename
     : usePnpm()
-    ? pnpmLockFilename
-    : useNpm()
-    ? packageLockFilename
-    : noLockFile()
+      ? pnpmLockFilename
+      : useNpm()
+        ? packageLockFilename
+        : noLockFile()
   const fileHash = hasha.fromFileSync(lockFilename)
   debug(`Hash from file ${lockFilename} is ${fileHash}`)
   return fileHash

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "@vercel/ncc": "0.38.1",
         "husky": "8.0.3",
         "markdown-link-check": "3.11.1",
-        "prettier": "3.0.3"
+        "prettier": "3.1.1"
       }
     },
     "node_modules/@actions/cache": {
@@ -1341,9 +1341,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.3.tgz",
-      "integrity": "sha512-L/4pUDMxcNa8R/EthV08Zt42WBO4h1rarVtK0K+QJG0X187OLo7l699jWw0GKuwzkPQ//jMFA/8Xm6Fh3J/DAg==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.1.1.tgz",
+      "integrity": "sha512-22UbSzg8luF4UuZtzgiUOfcGM8s4tjBv6dJRT7j275NXsy2jb4aJa4NNveul5x4eqlF1wuhuR2RElK71RvmVaw==",
       "dev": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
@@ -2565,9 +2565,9 @@
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="
     },
     "prettier": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.3.tgz",
-      "integrity": "sha512-L/4pUDMxcNa8R/EthV08Zt42WBO4h1rarVtK0K+QJG0X187OLo7l699jWw0GKuwzkPQ//jMFA/8Xm6Fh3J/DAg==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.1.1.tgz",
+      "integrity": "sha512-22UbSzg8luF4UuZtzgiUOfcGM8s4tjBv6dJRT7j275NXsy2jb4aJa4NNveul5x4eqlF1wuhuR2RElK71RvmVaw==",
       "dev": true
     },
     "process": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@vercel/ncc": "0.38.1",
     "husky": "8.0.3",
     "markdown-link-check": "3.11.1",
-    "prettier": "3.0.3"
+    "prettier": "3.1.1"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
This PR updates Prettier to [3.1.1](https://github.com/prettier/prettier/releases/tag/3.1.1), current latest version.

The previous version, Prettier [3.1.0](https://prettier.io/blog/2023/11/13/3.1.0.html), introduced new formatting for nested JavaScript tenaries to increase readability.

The action source has been reformatted according to the new rules. This causes whitespace changes only.