### PR TITLE
test(deps): update github action upload-artifact to v4

### DIFF
--- a/.github/workflows/example-chrome.yml
+++ b/.github/workflows/example-chrome.yml
@@ -32,7 +32,7 @@ jobs:
           # As of Cypress v8.0 the `cypress run` command
           # executes tests in `headless` mode by default
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: screenshots-headless-chrome
           path: examples/browser/cypress/screenshots
@@ -50,7 +50,7 @@ jobs:
           headed: true
           summary-title: 'Chrome headed'
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: screenshots-headed-chrome
           path: examples/browser/cypress/screenshots

--- a/.github/workflows/example-firefox.yml
+++ b/.github/workflows/example-firefox.yml
@@ -24,7 +24,7 @@ jobs:
           browser: firefox
 
       # report screenshot size and store the screenshots as test artifacts
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: screenshots-in-firefox
           path: examples/browser/cypress/screenshots

--- a/README.md
+++ b/README.md
@@ -372,7 +372,7 @@ jobs:
 
 ### Project ID and Record Key
 
-To record the project needs `projectId` and `recordKey`. 
+To record the project needs `projectId` and `recordKey`.
 
 Typically, the `projectId` is stored in the [Cypress Configuration File](https://docs.cypress.io/guides/references/configuration#Configuration-File), while the `recordKey` is set as a [CLI parameter](https://docs.cypress.io/guides/guides/command-line#cypress-run-record-key-lt-record-key-gt). If you want to avoid this, both the `projectId` and `recordKey` can be provided as environment variables using [GitHub secrets](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions).
 
@@ -424,7 +424,7 @@ jobs:
 
 Please refer to the [Cypress Cloud Git information environment variables](https://on.cypress.io/guides/continuous-integration/introduction#Git-information) section in our documentation for more examples.
 
-Please refer to the [default GitHub environment variables](https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables) for additional GitHub examples. 
+Please refer to the [default GitHub environment variables](https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables) for additional GitHub examples.
 
 ### Automatic PR number and URL detection
 
@@ -582,14 +582,14 @@ jobs:
       - uses: actions/checkout@v4
       - uses: cypress-io/github-action@v6
       # after the test run completes store videos and any screenshots
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         # add the line below to store screenshots only on failures
         # if: failure()
         with:
           name: cypress-screenshots
           path: cypress/screenshots
           if-no-files-found: ignore # 'warn' or 'error' are also available, defaults to `warn`
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: cypress-videos
           path: cypress/videos


### PR DESCRIPTION
This PR updates the usage of [actions/upload-artifact](https://github.com/actions/upload-artifact) from `v3` to [actions/upload-artifact@v4](https://github.com/actions/upload-artifact/releases/tag/v4.0.0) in affected [workflows](https://github.com/cypress-io/github-action/tree/master/.github/workflows):

- [example-chrome.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-chrome.yml)
- [example-firefox.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-firefox.yml)

The `v3` version [actions/upload-artifact@v3.1.3](https://github.com/actions/upload-artifact/tree/v3.1.3) was tied to the deprecated Node.js `16` version which entered [end-of-life](https://nodejs.org/en/blog/announcements/nodejs16-eol/) on Sep 9, 2023. The initial `v4` version [actions/upload-artifact@v4.0.0](https://github.com/actions/upload-artifact/releases/tag/v4.0.0) has been migrated to use Node.js `20`, which currently holds [LTS](https://github.com/nodejs/release#release-schedule) (Long Term Support) status.

Migrating the usage of [actions/upload-artifact](https://github.com/actions/upload-artifact) in the Cypress GitHub Action examples from `v3` to `v4` avoids deprecation warnings which would otherwise appear if the workflows continued to depend on Node.js `16`.

## Verification

Examine the workflow run logs and ensure that the expected files are captured and uploaded:

- [example-chrome.yml](https://github.com/cypress-io/github-action/actions/workflows/example-chrome.yml) - files: `screenshots-headed-chrome.zip`, `screenshots-headless-chrome.zip`
- [example-firefox.yml](https://github.com/cypress-io/github-action/actions/workflows/example-firefox.yml) - files: `screenshots-in-firefox.zip`


## References

- Blog Sep 22, 2023: [GitHub Actions: Transitioning from Node 16 to Node 20](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20)
- Blog Dec 14, 2023: [GitHub Actions – Artifacts v4 is now Generally Available](https://github.blog/changelog/2023-12-14-github-actions-artifacts-v4-is-now-generally-available/)