### PR TITLE
chore(deps): update follow-redirects to resolve vulnerability

### DIFF
--- a/examples/config/package-lock.json
+++ b/examples/config/package-lock.json
@@ -1260,9 +1260,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.3",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.3.tgz",
-      "integrity": "sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==",
+      "version": "1.15.4",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.4.tgz",
+      "integrity": "sha512-Cr4D/5wlrb0z9dgERpUL3LrmPKVDsETIJhaCMeDfuFYcqa5bldGV6wBsAN6X/vxlXQtFBMrXdXxdL8CbDTGniw==",
       "dev": true,
       "funding": [
         {

--- a/examples/webpack/package-lock.json
+++ b/examples/webpack/package-lock.json
@@ -2096,9 +2096,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
-      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
+      "version": "1.15.4",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.4.tgz",
+      "integrity": "sha512-Cr4D/5wlrb0z9dgERpUL3LrmPKVDsETIJhaCMeDfuFYcqa5bldGV6wBsAN6X/vxlXQtFBMrXdXxdL8CbDTGniw==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
This PR updates the npm transient dependency [follow-redirects](https://www.npmjs.com/package/follow-redirects) to [follow-redirects@1.15.4](https://github.com/follow-redirects/follow-redirects/releases/tag/v1.15.4) to resolve a security vulnerability [Follow Redirects improperly handles URLs in the url.parse() function](https://github.com/advisories/GHSA-jchw-25xp-jwwc) reported by GitHub Dependabot.

## Verification

```shell
cd examples/webpack
npm ci
```

and

```shell
cd examples/config
npm ci
```

No vulnerabilities should be reported.