### PR TITLE
fix(deps): update cycjimmy/semantic-release-action to v4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,7 +38,7 @@ jobs:
       - run: npm ci
       # https://github.com/cycjimmy/semantic-release-action
       - name: Semantic Release
-        uses: cycjimmy/semantic-release-action@v3
+        uses: cycjimmy/semantic-release-action@v4
         id: semantic
         with:
           branches: master


### PR DESCRIPTION
This PR updates the use of [cycjimmy/semantic-release-action](https://github.com/cycjimmy/semantic-release-action) in the [release workflow (`main.yml`)](https://github.com/cypress-io/github-action/blob/master/.github/workflows/main.yml) from `@v3` to `@v4`.

The branch [cycjimmy/semantic-release-action@v3](https://github.com/cycjimmy/semantic-release-action/tree/v3) of this JavaScript Action relied on the deprecated `node16` version.

With the release of [cycjimmy/semantic-release-action@v4.0.0](https://github.com/cycjimmy/semantic-release-action/releases/tag/v4.0.0) compatibility with `node20` is available.

To avoid deprecation warnings from GitHub runners, Cypress GitHub Action `cypress-io/github-action` is migrated to use the [cycjimmy/semantic-release-action@v4](https://github.com/cycjimmy/semantic-release-action/tree/v4) branch in the workflow:

- [main.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/main.yml)

## Background

1. Node.js 16 entered [end-of-life](https://nodejs.org/en/blog/announcements/nodejs16-eol) on Sep 11, 2023.
2. [GitHub Actions: Transitioning from Node 16 to Node 20](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/) announced on Sep 22, 2023 the beginning of the deprecation process for `node16` actions.
3. [`node16` warnings](https://github.com/actions/runner/discussions/2704) will be re-enabled in the next couple of weeks in GitHub runners.