### PR TITLE
chore(deps): update vite to resolve vulnerability (server.fs.deny)

### DIFF
--- a/examples/component-tests/package-lock.json
+++ b/examples/component-tests/package-lock.json
@@ -16,7 +16,7 @@
         "@types/react-dom": "^18.2.13",
         "@vitejs/plugin-react": "^4.1.0",
         "cypress": "13.6.3",
-        "vite": "4.5.1"
+        "vite": "4.5.2"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -2993,9 +2993,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.1.tgz",
-      "integrity": "sha512-AXXFaAJ8yebyqzoNB9fu2pHoo/nWX+xZlaRwoeYUxEqBO+Zj4msE5G+BhGBll9lYEKv9Hfks52PAF2X7qDYXQA==",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.2.tgz",
+      "integrity": "sha512-tBCZBNSBbHQkaGyhGCDUGqeo2ph8Fstyp6FMSvTtsXeZSPpSMGlviAOav2hxVTqFcx8Hj/twtWKsMJXNY0xI8w==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.18.10",

--- a/examples/component-tests/package.json
+++ b/examples/component-tests/package.json
@@ -18,6 +18,6 @@
     "@types/react-dom": "^18.2.13",
     "@vitejs/plugin-react": "^4.1.0",
     "cypress": "13.6.3",
-    "vite": "4.5.1"
+    "vite": "4.5.2"
   }
 }

--- a/examples/wait-on-vite/package-lock.json
+++ b/examples/wait-on-vite/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.0.0",
       "devDependencies": {
         "cypress": "13.6.3",
-        "vite": "4.5.1"
+        "vite": "4.5.2"
       }
     },
     "node_modules/@colors/colors": {
@@ -2398,9 +2398,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.1.tgz",
-      "integrity": "sha512-AXXFaAJ8yebyqzoNB9fu2pHoo/nWX+xZlaRwoeYUxEqBO+Zj4msE5G+BhGBll9lYEKv9Hfks52PAF2X7qDYXQA==",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.2.tgz",
+      "integrity": "sha512-tBCZBNSBbHQkaGyhGCDUGqeo2ph8Fstyp6FMSvTtsXeZSPpSMGlviAOav2hxVTqFcx8Hj/twtWKsMJXNY0xI8w==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.18.10",

--- a/examples/wait-on-vite/package.json
+++ b/examples/wait-on-vite/package.json
@@ -11,6 +11,6 @@
   "private": true,
   "devDependencies": {
     "cypress": "13.6.3",
-    "vite": "4.5.1"
+    "vite": "4.5.2"
   }
 }


### PR DESCRIPTION
This PR updates the npm module [vite](https://www.npmjs.com/package/vite) to [vite@4.5.2](https://github.com/vitejs/vite/releases/tag/v4.5.2) to resolve a security vulnerability [Vite dev server option `server.fs.deny` can be bypassed when hosted on case-insensitive filesystem](https://github.com/advisories/GHSA-c24v-8rfc-w8vw) reported by GitHub Dependabot.

## Verification

```shell
cd examples/component-tests
npm ci
```

and

```shell
cd examples/wait-on-vite
npm ci
```

No vulnerabilities should be reported.