### PR TITLE
test(deps): install pnpm with npm

### DIFF
--- a/.github/workflows/example-basic-pnpm.yml
+++ b/.github/workflows/example-basic-pnpm.yml
@@ -15,9 +15,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v2
-        with:
-          version: 8
+        run: npm install -g pnpm@8
 
       - name: Get pnpm store directory
         shell: bash
@@ -52,9 +50,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v2
-        with:
-          version: 8
+        run: npm install -g pnpm@8
 
       - name: Get pnpm store directory
         shell: bash
@@ -82,9 +78,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v2
-        with:
-          version: 8
+        run: npm install -g pnpm@8
 
       - name: Get pnpm store directory
         shell: bash
@@ -112,9 +106,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v2
-        with:
-          version: 8
+        run: npm install -g pnpm@8
 
       - name: Get pnpm store directory
         shell: bash
@@ -145,9 +137,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v2
-        with:
-          version: 8
+        run: npm install -g pnpm@8
 
       - name: Get pnpm store directory
         shell: bash

--- a/README.md
+++ b/README.md
@@ -1103,7 +1103,7 @@ jobs:
 
 ### pnpm
 
-The package manager `pnpm` is not pre-installed in [GitHub Actions runner images](https://github.com/actions/runner-images) (unlike `npm` and `yarn`): to install `pnpm` include [pnpm/action-setup](https://github.com/pnpm/action-setup) in your workflow. If the action finds a `pnpm-lock.yaml` file, it uses the [pnpm](https://pnpm.io/cli/install) command `pnpm install --frozen-lockfile` by default to install dependencies.
+The package manager `pnpm` is not pre-installed in [GitHub Actions runner images](https://github.com/actions/runner-images) (unlike `npm` and `yarn`) and so it must be installed in a separate workflow step (see below). If the action finds a `pnpm-lock.yaml` file, it uses the [pnpm](https://pnpm.io/cli/install) command `pnpm install --frozen-lockfile` by default to install dependencies.
 At this time the action does not automatically cache dependencies installed by pnpm. The example below includes steps to locate the pnpm store directory and to cache its contents for later use.
 
 ```yaml
@@ -1116,9 +1116,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Install pnpm
-        uses: pnpm/action-setup@v2
-        with:
-          version: 8
+        run: npm install -g pnpm@8
       - name: Get pnpm store directory
         shell: bash
         run: |


### PR DESCRIPTION
This PR removes the dependency on the JavaScript GitHub Action [pnpm/action-setup](https://github.com/pnpm/action-setup).

## Background

[pnpm/action-setup](https://github.com/pnpm/action-setup) was last updated on Jul 26, 2023 to [pnpm/action-setup@v2.4.0](https://github.com/pnpm/action-setup/releases/tag/v2.4.0). This version supports only `node16` version and causes deprecation warnings when run on GitHub:

> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: pnpm/action-setup@v2. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

- https://github.com/pnpm/action-setup/issues/99 was opened to request an update of the pnpm action to support `node20`. There is no clear indication about if / when this issue might be resolved.

The [example-basic-pnpm.yml](https://github.com/cypress-io/github-action/actions/workflows/example-basic-pnpm.yml) workflow does not use any of the parameters of [pnpm/action-setup](https://github.com/pnpm/action-setup) except `version`, so it is easily substituted by `npm install -g pnpm`.


## Changes

In the workflow [example-basic-pnpm.yml](https://github.com/cypress-io/github-action/actions/workflows/example-basic-pnpm.yml) and [README > pnpm](https://github.com/cypress-io/github-action/blob/master/README.md#pnpm), the step

```yml
      - name: Install pnpm
        uses: pnpm/action-setup@v2
        with:
          version: 8
```

is replaced by

```yml
      - name: Install pnpm
        run: npm install -g pnpm@8
```

## Verification

Run [example-basic-pnpm.yml](https://github.com/cypress-io/github-action/actions/workflows/example-basic-pnpm.yml) and check that GitHub does not output any deprecation messages.

## Reference

- [pnpm installation using npm](https://pnpm.io/installation#using-npm)
