### PR TITLE
chore(deps): update husky to 9.0.6

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,6 +1,3 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 echo action source code is being reformatted and recompiled
 npm run format
 npm run build

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
       "devDependencies": {
         "@types/node": "20.11.5",
         "@vercel/ncc": "0.38.1",
-        "husky": "8.0.3",
+        "husky": "9.0.6",
         "markdown-link-check": "3.11.1",
         "prettier": "3.2.4"
       }
@@ -998,15 +998,15 @@
       }
     },
     "node_modules/husky": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.3.tgz",
-      "integrity": "sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==",
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.0.6.tgz",
+      "integrity": "sha512-EEuw/rfTiMjOfuL7pGO/i9otg1u36TXxqjIA6D9qxVjd/UXoDOsLor/BSFf5hTK50shwzCU3aVVwdXDp/lp7RA==",
       "dev": true,
       "bin": {
-        "husky": "lib/bin.js"
+        "husky": "bin.js"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/typicode"
@@ -2319,9 +2319,9 @@
       }
     },
     "husky": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.3.tgz",
-      "integrity": "sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==",
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.0.6.tgz",
+      "integrity": "sha512-EEuw/rfTiMjOfuL7pGO/i9otg1u36TXxqjIA6D9qxVjd/UXoDOsLor/BSFf5hTK50shwzCU3aVVwdXDp/lp7RA==",
       "dev": true
     },
     "iconv-lite": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "format": "prettier --write index.js src/ping.js",
     "check:markdown": "find *.md docs/*.md -print0 | xargs -0 -n1 markdown-link-check -c md-linkcheck.json",
     "update:cypress": "./scripts/update-cypress-latest.sh",
-    "prepare": "husky install"
+    "prepare": "husky"
   },
   "repository": {
     "type": "git",
@@ -48,7 +48,7 @@
   "devDependencies": {
     "@types/node": "20.11.5",
     "@vercel/ncc": "0.38.1",
-    "husky": "8.0.3",
+    "husky": "9.0.6",
     "markdown-link-check": "3.11.1",
     "prettier": "3.2.4"
   },


### PR DESCRIPTION
- This PR migrates the action to [husky@9.0.6](https://github.com/typicode/husky/releases/tag/v9.0.6), replacing the auto-generated, incomplete PR from renovate https://github.com/cypress-io/github-action/pull/1119.

Although Husky `9` is stated to be backwards compatible to Husky `8` (see [husky@9.0.1](https://github.com/typicode/husky/releases/tag/v9.0.1)) the following additional migration steps are taken:

To avoid a deprecation warning when installing dependencies, the prepare script in [package.json](https://github.com/cypress-io/github-action/blob/master/package.json) is changed from

```json
"prepare": "husky install"

```

to

```json
"prepare": "husky"
```

The following lines are removed from [.husky/pre-commit](https://github.com/cypress-io/github-action/blob/master/.husky/pre-commit). These are not needed in Husky `9`:

```shell
#!/usr/bin/env sh
. "$(dirname -- "$0")/_/husky.sh"
```

## Verification

On a Ubuntu 22.04 system with Node.js `20` ...

### Installation

Execute:

```shell
npm ci
```

Ensure that there are no errors or deprecation warnings.

### Hook check

Make a change to `index.js` and commit the change.

Ensure that the Husky hook runs and updates `dist/index.js` automatically.

## References

[Husky documentation](https://typicode.github.io/husky/)
