### PR TITLE
test: correct example-start-and-yarn-workspaces fail-fast comments

### DIFF
--- a/.github/workflows/example-start-and-yarn-workspaces.yml
+++ b/.github/workflows/example-start-and-yarn-workspaces.yml
@@ -32,10 +32,7 @@ jobs:
     # in each Yarn workspaces subfolder
     runs-on: ubuntu-22.04
     strategy:
-      # when one test fails, DO NOT cancel the other
-      # containers, because this will kill Cypress processes
-      # leaving the Cypress Cloud hanging ...
-      # https://github.com/cypress-io/github-action/issues/48
+      # fail-fast: false allows tests for both workspaces to run even if one fails
       fail-fast: false
       matrix:
         cypress:


### PR DESCRIPTION
## Issue

The comments in [.github/workflows/example-start-and-yarn-workspaces.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-start-and-yarn-workspaces.yml)

https://github.com/cypress-io/github-action/blob/4cedef59b86ca68d5698ff837ccd0933e91ac316/.github/workflows/example-start-and-yarn-workspaces.yml#L34-L43

regarding `fail-fast` are out of place, since the workflow does not record to the Cypress Cloud.

## Change

Modify the text to explain about using `fail-fast`. It allows both tests to run independently of any failure of the other test.