### PR TITLE
docs: correct name in readme ct example

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ This workflow uses the default [test type](https://on.cypress.io/guides/overview
 To use [Cypress Component Testing](https://on.cypress.io/component-testing) add `component: true`
 
 ```yml
-name: End-to-end tests
+name: Component tests
 on: push
 jobs:
   cypress-run:


### PR DESCRIPTION
## Issue

The [example workflow](https://github.com/cypress-io/github-action/blob/master/README.md#component-testing) for Component Testing in the README file uses `name: End-to-end tests`. This is not a fitting name for an example of Component Testing!

## Change

Change to `name: Component tests` in the [Component Testing](https://github.com/cypress-io/github-action/blob/master/README.md#component-testing) section of the README file.