### PR TITLE
tests(deps): add node.js 22 (current) to tests

### DIFF
--- a/.github/workflows/example-node-versions.yml
+++ b/.github/workflows/example-node-versions.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [18, 20, 21]
+        node: [18, 20, 21, 22]
     name: Cypress E2E on Node v${{ matrix.node }}
     steps:
       - name: Setup Node

--- a/README.md
+++ b/README.md
@@ -509,7 +509,7 @@ jobs:
     # let's make sure our "app" works on several versions of Node
     strategy:
       matrix:
-        node: [18, 20, 21]
+        node: [18, 20, 21, 22]
     name: E2E on Node v${{ matrix.node }}
     steps:
       - name: Setup Node
@@ -1272,7 +1272,7 @@ jobs:
     # let's make sure our "app" works on several versions of Node
     strategy:
       matrix:
-        node: [18, 20, 21]
+        node: [18, 20, 21, 22]
     name: E2E on Node v${{ matrix.node }}
     steps:
       - name: Setup Node
@@ -1306,7 +1306,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        node: [18, 20, 21]
+        node: [18, 20, 21, 22]
     name: E2E on Node v${{ matrix.node }}
     steps:
       - uses: actions/setup-node@v4


### PR DESCRIPTION
[Node.js 22.0.0](https://nodejs.org/en/blog/release/v22.0.0) was released on Apr 24, 2024.

This PR adds Node.js `22` to the matrix of tested nodes under [.github/workflows/example-node-versions.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-node-versions.yml) and to the [README](https://github.com/cypress-io/github-action/blob/master/README.md) examples.

 According to [Node.js release schedule](https://github.com/nodejs/release#release-schedule) plans, Node.js `22.x` changes from "Current" status to "LTS" status on Oct 29, 2024.