### PR TITLE
test: remove pnpm store cache loose match restore-keys

### DIFF
--- a/.github/workflows/example-basic-pnpm.yml
+++ b/.github/workflows/example-basic-pnpm.yml
@@ -27,8 +27,6 @@ jobs:
         with:
           path: ${{ env.STORE_PATH }}
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('examples/basic-pnpm/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-store-
 
       - name: Cypress tests
         # normally you would write
@@ -62,8 +60,6 @@ jobs:
         with:
           path: ${{ env.STORE_PATH }}
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('examples/basic-pnpm/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-store-
 
       - name: Cypress tests
         uses: ./
@@ -90,8 +86,6 @@ jobs:
         with:
           path: ${{ env.STORE_PATH }}
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('examples/basic-pnpm/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-store-
 
       - name: Cypress tests
         uses: ./
@@ -118,8 +112,6 @@ jobs:
         with:
           path: ${{ env.STORE_PATH }}
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('examples/basic-pnpm/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-store-
 
       - name: Cypress tests
         uses: ./
@@ -149,8 +141,6 @@ jobs:
         with:
           path: ${{ env.STORE_PATH }}
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('examples/basic-pnpm/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-store-
 
       - name: Cypress tests
         uses: ./

--- a/.github/workflows/example-start-and-pnpm-workspaces.yml
+++ b/.github/workflows/example-start-and-pnpm-workspaces.yml
@@ -39,9 +39,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ env.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('examples/basic-pnpm/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-store-
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('examples/start-and-pnpm-workspaces/pnpm-lock.yaml') }}
 
       - name: Install dependencies
         # with Cypress GitHub Action.
@@ -104,9 +102,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ env.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('examples/basic-pnpm/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-store-
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('examples/start-and-pnpm-workspaces/pnpm-lock.yaml') }}
 
       - name: Install dependencies
         uses: ./ # approximately equivalent to using cypress-io/github-action@v6

--- a/README.md
+++ b/README.md
@@ -1127,8 +1127,6 @@ jobs:
         with:
           path: ${{ env.STORE_PATH }}
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('examples/basic-pnpm/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-store-
       - name: Cypress run
         uses: cypress-io/github-action@v6
         with:


### PR DESCRIPTION
- related to issue https://github.com/cypress-io/github-action/issues/1179

## Issue

pnpm [basic](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-basic-pnpm.yml) and [workspaces](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-start-and-pnpm-workspaces.yml) workflows

- [example-basic-pnpm.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-basic-pnpm.yml)
- [example-start-and-pnpm-workspaces.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-start-and-pnpm-workspaces.yml)

include the use of the GitHub provided [actions/cache](https://github.com/actions/cache) action to cache dependencies installed by pnpm, with the input `restore-keys` set to a loose match in the form:

```yml
          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('examples/xxx/pnpm-lock.yaml') }}
          restore-keys: |
            ${{ runner.os }}-pnpm-store-
```

This leads to non-deterministic outcomes of any jobs in the worksflows running on the same operating system in parallel, since the state of the GitHub caches in the branch concerned depends on the variable timing of other jobs which are running. Jobs which are exposed to this issue are:
- `basic-pnpm-ubuntu-20` and `basic-pnpm-ubuntu-22` jobs in the [example-basic-pnpm.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-basic-pnpm.yml) workflow
- all jobs in the [example-start-and-pnpm-workspaces.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-start-and-pnpm-workspaces.yml) workflow

The non-deterministic behaviour is in contrast to the `cypress-io/github-action` which uses exact cache key matches.

- Possibly this is the cause of issue https://github.com/cypress-io/github-action/issues/1179 and in any case this change is a prerequisite to debugging the issue if it continues.

## Change

Remove the option `restore-keys` from the workflows listed above and from the documentation examples in the [README](https://github.com/cypress-io/github-action/blob/master/README.md).

Correct also an error in [example-start-and-pnpm-workspaces.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-start-and-pnpm-workspaces.yml) where the cache was incorrectly using the lock file from [examples/basic-pnpm](https://github.com/cypress-io/github-action/tree/master/examples/basic-pnpm) instead of from [examples/start-and-pnpm-workspaces](https://github.com/cypress-io/github-action/tree/master/examples/start-and-pnpm-workspaces).

## Related issues

- https://github.com/cypress-io/github-action/issues/1044
- https://github.com/cypress-io/github-action/issues/1179

## Related PRs

- https://github.com/cypress-io/github-action/pull/1043
- https://github.com/cypress-io/github-action/pull/1140

## References

- [actions/cache](https://github.com/actions/cache)

## Verification

Downgrade the pnpm examples to Cypress `13.8.0`
- [examples/basic-pnpm](https://github.com/cypress-io/github-action/tree/master/examples/basic-pnpm)
- [examples/start-and-pnpm-workspaces](https://github.com/cypress-io/github-action/tree/master/examples/start-and-pnpm-workspaces)

Run each workflow twice and confirm no errors.

Revert the pnpm examples to Cypress `13.9.0` and again run each workflow twice with no errors.