### PR TITLE
ci: add ubuntu 24.04 to tested operating systems

### DIFF
--- a/.github/workflows/example-basic.yml
+++ b/.github/workflows/example-basic.yml
@@ -11,6 +11,7 @@ jobs:
 
   basic-ubuntu-20:
     runs-on: ubuntu-20.04
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -30,6 +31,20 @@ jobs:
 
   basic-ubuntu-22:
     runs-on: ubuntu-22.04
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Cypress tests
+        uses: ./
+        with:
+          working-directory: examples/basic
+          build: npx cypress info
+
+  basic-ubuntu-24:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -42,6 +57,7 @@ jobs:
 
   basic-on-windows:
     runs-on: windows-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -54,6 +70,7 @@ jobs:
 
   basic-on-mac:
     runs-on: macos-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -69,6 +86,7 @@ jobs:
   # https://github.com/cypress-io/github-action/issues/327
   basic-without-binary-install:
     runs-on: ubuntu-22.04
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Change

An Ubuntu `24.04` job is added to the workflow [.github/workflows/example-basic.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-basic.yml) to demonstrate the capability of Cypress to run under this OS version. This is in addition to the Ubuntu `20.04` and `22.04` jobs in the workflow.

A `timeout-minutes: 10` of 10 minutes is added to each of the jobs as documented in the [README > Timeouts](https://github.com/cypress-io/github-action/blob/master/README.md#timeouts) section. This is a best practice in any case and is added as a precaution due to the beta status of the Ubuntu `24.04` runner (see below).

Other workflows are not changed at this time.

## Background

- [Ubuntu 24.04](https://canonical.com/blog/canonical-releases-ubuntu-24-04-noble-numbat) LTS was released on April 24, 2024.
- GitHub Actions has made an [Ubuntu 24.04 LTS](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md) runner image available in the overview on [GitHub Actions Runner Images](https://github.com/actions/runner-images) using the YAML Label `ubuntu-24.04`. The Label `ubuntu-latest` remains equivalent to the earlier `ubuntu-22.04`.
- The beta release of the runner was announced on May 14, 2024 [GitHub-hosted runners: Public Beta of Ubuntu 24.04 is available](https://github.blog/changelog/2024-05-14-github-hosted-runners-public-beta-of-ubuntu-24-04-is-now-available/)
- The [Ubuntu 24.04 LTS](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md) runner image currently contains Google Chrome. It does not yet include Microsoft Edge or Mozilla Firefox browsers.
