### PR TITLE
test: remove pnpm store caching

### DIFF
--- a/.github/workflows/example-basic-pnpm.yml
+++ b/.github/workflows/example-basic-pnpm.yml
@@ -17,17 +17,6 @@ jobs:
       - name: Install pnpm
         run: npm install -g pnpm@9
 
-      - name: Get pnpm store directory
-        shell: bash
-        run: |
-          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
-
-      - name: Setup pnpm cache
-        uses: actions/cache@v4
-        with:
-          path: ${{ env.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('examples/basic-pnpm/pnpm-lock.yaml') }}
-
       - name: Cypress tests
         # normally you would write
         # uses: cypress-io/github-action@v6
@@ -50,17 +39,6 @@ jobs:
       - name: Install pnpm
         run: npm install -g pnpm@9
 
-      - name: Get pnpm store directory
-        shell: bash
-        run: |
-          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
-
-      - name: Setup pnpm cache
-        uses: actions/cache@v4
-        with:
-          path: ${{ env.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('examples/basic-pnpm/pnpm-lock.yaml') }}
-
       - name: Cypress tests
         uses: ./
         with:
@@ -76,17 +54,6 @@ jobs:
       - name: Install pnpm
         run: npm install -g pnpm@9
 
-      - name: Get pnpm store directory
-        shell: bash
-        run: |
-          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
-
-      - name: Setup pnpm cache
-        uses: actions/cache@v4
-        with:
-          path: ${{ env.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('examples/basic-pnpm/pnpm-lock.yaml') }}
-
       - name: Cypress tests
         uses: ./
         with:
@@ -101,17 +68,6 @@ jobs:
 
       - name: Install pnpm
         run: npm install -g pnpm@9
-
-      - name: Get pnpm store directory
-        shell: bash
-        run: |
-          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
-
-      - name: Setup pnpm cache
-        uses: actions/cache@v4
-        with:
-          path: ${{ env.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('examples/basic-pnpm/pnpm-lock.yaml') }}
 
       - name: Cypress tests
         uses: ./
@@ -130,17 +86,6 @@ jobs:
 
       - name: Install pnpm
         run: npm install -g pnpm@9
-
-      - name: Get pnpm store directory
-        shell: bash
-        run: |
-          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
-
-      - name: Setup pnpm cache
-        uses: actions/cache@v4
-        with:
-          path: ${{ env.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('examples/basic-pnpm/pnpm-lock.yaml') }}
 
       - name: Cypress tests
         uses: ./

--- a/.github/workflows/example-start-and-pnpm-workspaces.yml
+++ b/.github/workflows/example-start-and-pnpm-workspaces.yml
@@ -13,7 +13,6 @@ jobs:
   single-ws:
     # This job installs pnpm,
     # installs all dependencies,
-    # caches the pnpm store,
     # caches the Cypress binary cache,
     # then runs Cypress tests in the single workspace
     # of the subfolder "packages/workspace-1".
@@ -26,20 +25,6 @@ jobs:
         # pnpm is not installed by default on GitHub runners
       - name: Install pnpm
         run: npm install -g pnpm@9
-
-        # locate the pnpm store directory where pnpm dependencies are installed
-      - name: Get pnpm store directory
-        shell: bash
-        run: |
-          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
-
-        # Cypress github-action does not cache pnpm dependencies by default.
-        # Cache the dependencies.
-      - name: Setup pnpm cache
-        uses: actions/cache@v4
-        with:
-          path: ${{ env.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('examples/start-and-pnpm-workspaces/pnpm-lock.yaml') }}
 
       - name: Install dependencies
         # with Cypress GitHub Action.
@@ -75,7 +60,6 @@ jobs:
   multiple-ws:
     # This job installs pnpm,
     # installs all dependencies,
-    # caches the pnpm store,
     # caches the Cypress binary cache,
     # then runs Cypress tests in each of the workspaces.
     runs-on: ubuntu-22.04
@@ -92,17 +76,6 @@ jobs:
 
       - name: Install pnpm
         run: npm install -g pnpm@9
-
-      - name: Get pnpm store directory
-        shell: bash
-        run: |
-          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
-
-      - name: Setup pnpm cache
-        uses: actions/cache@v4
-        with:
-          path: ${{ env.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('examples/start-and-pnpm-workspaces/pnpm-lock.yaml') }}
 
       - name: Install dependencies
         uses: ./ # approximately equivalent to using cypress-io/github-action@v6

--- a/README.md
+++ b/README.md
@@ -1105,7 +1105,7 @@ jobs:
 ### pnpm
 
 The package manager `pnpm` is not pre-installed in [GitHub Actions runner images](https://github.com/actions/runner-images) (unlike `npm` and `yarn`) and so it must be installed in a separate workflow step (see below). If the action finds a `pnpm-lock.yaml` file, it uses the [pnpm](https://pnpm.io/cli/install) command `pnpm install --frozen-lockfile` by default to install dependencies.
-At this time the action does not automatically cache dependencies installed by pnpm. The example below includes steps to locate the pnpm store directory and to cache its contents for later use.
+At this time, the action does not automatically cache dependencies installed by pnpm. We advise against attempting to work around this restriction, by caching the pnpm store directory through additional workflow steps, as this can lead to the action skipping installation of the Cypress binary, causing workflow failure.
 
 ```yaml
 name: example-basic-pnpm
@@ -1118,15 +1118,6 @@ jobs:
         uses: actions/checkout@v4
       - name: Install pnpm
         run: npm install -g pnpm@9
-      - name: Get pnpm store directory
-        shell: bash
-        run: |
-          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
-      - name: Setup pnpm cache
-        uses: actions/cache@v4
-        with:
-          path: ${{ env.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('examples/basic-pnpm/pnpm-lock.yaml') }}
       - name: Cypress run
         uses: cypress-io/github-action@v6
         with:


### PR DESCRIPTION
- closes https://github.com/cypress-io/github-action/issues/1179

## Issue

Workflows such as [.github/workflows/example-basic-pnpm.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-basic-pnpm.yml), which attempt to cache the contents of the pnpm store, fail sporadically, especially after there has been a change in the version of Cypress and where pnpm workflow jobs are running in parallel.

If the cache of the pnpm store cache is loaded with the `cypress` module, through steps outside of the Cypress GitHub action, and the Cypress binary has not been successfully cached by the action, then Cypress fails with a verification error.

There is no mechanism available to coordinate these two different caching mechanisms. (See also https://github.com/cypress-io/github-action/issues/1179#issuecomment-2125265169 for further explanation.)

## Change

pnpm store caching is removed from the documentation:

[README > pnpm](https://github.com/cypress-io/github-action/blob/master/README.md#pnpm)

and replaced by text which recommends against this caching.

The following workflows are amended accordingly:

- [.github/workflows/example-basic-pnpm.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-basic-pnpm.yml)
- [.github/workflows/example-start-and-pnpm-workspaces.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-start-and-pnpm-workspaces.yml)

## Related

- https://github.com/cypress-io/github-action/issues/1044
