### PR TITLE
feat(deps): remove node.js 21

### DIFF
--- a/.github/workflows/example-node-versions.yml
+++ b/.github/workflows/example-node-versions.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [18, 20, 21, 22]
+        node: [18, 20, 22]
     name: Cypress E2E on Node v${{ matrix.node }}
     steps:
       - name: Setup Node

--- a/README.md
+++ b/README.md
@@ -509,7 +509,7 @@ jobs:
     # let's make sure our "app" works on several versions of Node
     strategy:
       matrix:
-        node: [18, 20, 21, 22]
+        node: [18, 20, 22]
     name: E2E on Node v${{ matrix.node }}
     steps:
       - name: Setup Node
@@ -1261,7 +1261,7 @@ jobs:
     # let's make sure our "app" works on several versions of Node
     strategy:
       matrix:
-        node: [18, 20, 21, 22]
+        node: [18, 20, 22]
     name: E2E on Node v${{ matrix.node }}
     steps:
       - name: Setup Node
@@ -1295,7 +1295,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        node: [18, 20, 21, 22]
+        node: [18, 20, 22]
     name: E2E on Node v${{ matrix.node }}
     steps:
       - uses: actions/setup-node@v4
@@ -1624,8 +1624,7 @@ jobs:
 
 Node.js is required to run this action. The recommended version `v6` supports:
 
-- **Node.js** 18.x
-- **Node.js** 20.x and above
+- **Node.js** 18.x, 20.x and 22.x
 
 and is generally aligned with [Node.js's release schedule](https://github.com/nodejs/Release).
 


### PR DESCRIPTION
According to [Node.js release schedule](https://github.com/nodejs/release#release-schedule) plans, Node.js `21.x` reached End-of-life status on June 1, 2024.

This PR removes Node.js `21`

- from the matrix of tested nodes under [.github/workflows/example-node-versions.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-node-versions.yml) and
- from the [README](https://github.com/cypress-io/github-action/blob/master/README.md).

Supported versions are now `18.x`, `20.x` and `22.x`.

## Version usage

There is no change to the action itself.

- `cypress-io/github-action@v6` continues to use `node20`

See [README > Usage](https://github.com/cypress-io/github-action#usage) for a more detailed explanation.

## References

- Node.js [Release schedule](https://github.com/nodejs/release#release-schedule)
- GitHub [runs.using for JavaScript actions](https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#runsusing-for-javascript-actions)

