### PR TITLE
docs: remove outdated readme pnpm text

### DIFF
--- a/README.md
+++ b/README.md
@@ -1148,7 +1148,7 @@ If you are using [pnpm workspaces](https://pnpm.io/workspaces) you need to insta
 
 [![pnpm workspaces example](https://github.com/cypress-io/github-action/actions/workflows/example-start-and-pnpm-workspaces.yml/badge.svg)](.github/workflows/example-start-and-pnpm-workspaces.yml)
 
-See the example project [start-and-pnpm-workspaces](examples/start-and-pnpm-workspaces/) and the [example-start-and-pnpm-workspaces.yml](.github/workflows/example-start-and-pnpm-workspaces.yml) workflow for a full working example including pnpm caching.
+See the example project [start-and-pnpm-workspaces](examples/start-and-pnpm-workspaces/) and the [example-start-and-pnpm-workspaces.yml](.github/workflows/example-start-and-pnpm-workspaces.yml) workflow for a full working example.
 
 ### Yarn Classic
 


### PR DESCRIPTION
## Issue

- PR https://github.com/cypress-io/github-action/pull/1188 removed pnpm caching from [pnpm](https://github.com/cypress-io/github-action/blob/master/README.md#pnpm), however [pnpm workspaces](https://github.com/cypress-io/github-action/blob/master/README.md#pnpm-workspaces) still has a reference to pnpm caching.

## Change

Remove the outdated reference in [pnpm workspaces](https://github.com/cypress-io/github-action/blob/master/README.md#pnpm-workspaces) to pnpm caching.
