### PR TITLE
docs: recommend CYPRESS_INSTALL_BINARY=0 for cypress/included Docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,28 @@ Replace the `latest` tag with a specific version image tag from [`cypress/browse
 
 Include `options: --user 1001` to avoid permissions issues.
 
+When using [cypress/included](https://github.com/cypress-io/cypress-docker-images/tree/master/included) Docker images, set the environment variable `CYPRESS_INSTALL_BINARY=0` to suppress saving the Cypress binary cache, otherwise cache restore errors may occur. The example below shows how to do this:
+
+```yml
+name: Test with Docker cypress/included
+on: push
+jobs:
+  cypress-run:
+    runs-on: ubuntu-22.04
+    container:
+      # Cypress Docker image from https://hub.docker.com/r/cypress/included
+      # with Cypress globally pre-installed
+      image: cypress/included:latest
+      options: --user 1001
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cypress-io/github-action@v6
+        with:
+          browser: chrome
+        env:
+          CYPRESS_INSTALL_BINARY: 0
+```
+
 Refer to [cypress-io/cypress-docker-images](https://github.com/cypress-io/cypress-docker-images) for further information about using Cypress Docker images. Cypress offers the [Cypress Docker Factory](https://github.com/cypress-io/cypress-docker-images/tree/master/factory) to generate additional Docker images with selected components and versions.
 
 [![Docker example](https://github.com/cypress-io/github-action/actions/workflows/example-docker.yml/badge.svg)](.github/workflows/example-docker.yml)


### PR DESCRIPTION
- related to https://github.com/cypress-io/cypress-docker-images/issues/1119

## Issue

If `cypress-io/github-action` is used to run a Cypress Docker image [cypress/included](https://github.com/cypress-io/cypress-docker-images/tree/master/included) as a container with `--user 1001` (as recommended), then GitHub actions may report a caching error:

> Failed to restore: "/usr/bin/tar" failed with error: The process '/usr/bin/tar' failed with exit code 2

## Background

[cypress/included](https://github.com/cypress-io/cypress-docker-images/tree/master/included) Docker images include the Cypress binary installed in `/root/.cache/Cypress` with owner `root` (see environment variable `CYPRESS_CACHE_FOLDER` of Docker image).

By default `cypress-io/github-action` attempts to cache and restore the Cypress binary. Any such restore action fails if the user has been set to a non-root value, since the owner of `$CYPRESS_CACHE_FOLDER` is `root`.

Caching the Cypress binary is superfluous when the Docker image already includes the binary.

If the environment variable `CYPRESS_INSTALL_BINARY=0` is set (see [Skipping installation](https://docs.cypress.io/guides/references/advanced-installation#Skipping-installation)) then `isCypressBinarySkipped` is set internally in the action and no `CYPRESS_BINARY_CACHE` is saved. If no cache is saved, then `restoreCachedCypressBinary` will not be able to restore a cache and will not provoke any error condition.

Note that this is not quite error proof because if a workflow has run without `CYPRESS_INSTALL_BINARY=0` and has stored a cache, then this will be picked up and provoke an error message. This is mitigated by the fact that the error is cosmetic, in that it does not cause the workflow to fail. It is also self-correcting since cache entries which have not been accessed in over 7 days are removed (see [User limits and eviction policy](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#usage-limits-and-eviction-policy)).

## Change

Add advice to [README > Docker image](https://github.com/cypress-io/github-action/blob/master/README.md#docker-image) to set `CYPRESS_INSTALL_BINARY=0` with [cypress/included](https://github.com/cypress-io/cypress-docker-images/tree/master/included) Docker images.
