### PR TITLE
test(deps): update example-docker image version to node-20.14.0

### DIFF
--- a/.github/workflows/example-docker.yml
+++ b/.github/workflows/example-docker.yml
@@ -15,13 +15,15 @@ jobs:
         browser: [chrome, edge, electron, firefox]
     # from https://hub.docker.com/r/cypress/browsers/tags
     container:
-      image: cypress/browsers:node-20.5.0-chrome-114.0.5735.133-1-ff-114.0.2-edge-114.0.1823.51-1
+      image: cypress/browsers:node-20.14.0-chrome-126.0.6478.114-1-ff-127.0.1-edge-126.0.2592.61-1
       options: --user 1001
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
       # replace with the following for regular use:
       # uses: cypress-io/github-action@v6
-      - uses: ./
+      - name: Cypress tests
+        uses: ./
         with:
           working-directory: examples/basic
           browser: ${{ matrix.browser }}


### PR DESCRIPTION
## Issue

[.github/workflows/example-docker.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-docker.yml) uses

- [cypress/browsers:node-20.5.0-chrome-114.0.5735.133-1-ff-114.0.2-edge-114.0.1823.51-1](https://hub.docker.com/layers/cypress/browsers/node-20.5.0-chrome-114.0.5735.133-1-ff-114.0.2-edge-114.0.1823.51-1/images/sha256-fdfca094938a3f97f82e57f209d494968b4f46e36c74efd2adca91a69aedc8ef) published on Sep 1, 2023.

This is outdated.

## Change

update the [cypress/browsers Docker image](https://hub.docker.com/r/cypress/browsers) in [.github/workflows/example-docker.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-docker.yml) to

- [cypress/browsers:node-20.14.0-chrome-126.0.6478.114-1-ff-127.0.1-edge-126.0.2592.61-1] (https://hub.docker.com/layers/cypress/browsers/node-20.14.0-chrome-126.0.6478.114-1-ff-127.0.1-edge-126.0.2592.61-1/images/sha256-2d861960dadb4fe650d99bad6fca692cd61982ac584983a1af4de7c42ef595c1)

Add names to steps for better log file readability.

## Verification

Check that the workflow is successful.

Note that the Node.js version reported by Cypress comes from https://github.com/actions/runner/blob/main/src/Misc/externals.sh (currently `NODE20_VERSION="20.13.1"`) as explained in [README > Node.js > Usage](https://github.com/cypress-io/github-action/blob/master/README.md#usage).