### PR TITLE
ci(deps): update main workflow node.js to 20.13.1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
           # https://github.com/cypress-io/github-action/blob/master/action.yml
           # Node.js minor version is aligned to
           # https://github.com/actions/runner/blob/main/src/Misc/externals.sh
-          node-version: 20.8.1
+          node-version: 20.13.1
       - run: npm ci
       - run: npm run format
       - run: npm run build


### PR DESCRIPTION
## Issue

The [.github/workflows/main.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/main.yml) workflow is intended to run with the same Node.js version as defined in https://github.com/actions/runner/blob/main/src/Misc/externals.sh in order to provide a representative CI test.

The workflow currently uses Node.js `20.8.1`

https://github.com/cypress-io/github-action/blob/76647aab959ed8c5508c2a310420a36bb9bf3157/.github/workflows/main.yml#L21

whereas the GitHub runner has been updated to use `NODE20_VERSION="20.13.1"` in the meantime

https://github.com/actions/runner/blob/2a7f327d93fb79326c974f4858ce62c3b81c580a/src/Misc/externals.sh#L11

## Change

Update Node.js in [.github/workflows/main.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/main.yml) from `20.8.1` to `20.13.1`.