### PR TITLE
fix(deps): update debug to 4.3.6

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -48689,6 +48689,8 @@ function useColors() {
 		return false;
 	}
 
+	let m;
+
 	// Is webkit? http://stackoverflow.com/a/16459606/376773
 	// document is undefined in react-native: https://github.com/facebook/react-native/pull/1632
 	return (typeof document !== 'undefined' && document.documentElement && document.documentElement.style && document.documentElement.style.WebkitAppearance) ||
@@ -48696,7 +48698,7 @@ function useColors() {
 		(typeof window !== 'undefined' && window.console && (window.console.firebug || (window.console.exception && window.console.table))) ||
 		// Is firefox >= v31?
 		// https://developer.mozilla.org/en-US/docs/Tools/Web_Console#Styling_messages
-		(typeof navigator !== 'undefined' && navigator.userAgent && navigator.userAgent.toLowerCase().match(/firefox\/(\d+)/) && parseInt(RegExp.$1, 10) >= 31) ||
+		(typeof navigator !== 'undefined' && navigator.userAgent && (m = navigator.userAgent.toLowerCase().match(/firefox\/(\d+)/)) && parseInt(m[1], 10) >= 31) ||
 		// Double check webkit in userAgent just in case we are in a worker
 		(typeof navigator !== 'undefined' && navigator.userAgent && navigator.userAgent.toLowerCase().match(/applewebkit\/(\d+)/));
 }
@@ -49325,11 +49327,11 @@ function getDate() {
 }
 
 /**
- * Invokes `util.format()` with the specified arguments and writes to stderr.
+ * Invokes `util.formatWithOptions()` with the specified arguments and writes to stderr.
  */
 
 function log(...args) {
-	return process.stderr.write(util.format(...args) + '\n');
+	return process.stderr.write(util.formatWithOptions(exports.inspectOpts, ...args) + '\n');
 }
 
 /**

--- a/examples/install-command/package.json
+++ b/examples/install-command/package.json
@@ -11,6 +11,6 @@
   },
   "dependencies": {
     "arg": "5.0.0",
-    "debug": "4.3.4"
+    "debug": "4.3.6"
   }
 }

--- a/examples/install-command/yarn.lock
+++ b/examples/install-command/yarn.lock
@@ -353,10 +353,10 @@ dayjs@^1.10.4:
   resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.9.tgz#9ca491933fadd0a60a2c19f6c237c03517d71d1a"
   integrity sha512-QvzAURSbQ0pKdIye2txOzNaHmxtUBXerpY0FJsFXUMKbIZeFm5ht1LS/jFsrncjnmtv8HsG0W2g6c0zUjZWmpA==
 
-debug@4.3.4, debug@^4.1.1, debug@^4.3.4:
-  version "4.3.4"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
-  integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
+debug@4.3.6:
+  version "4.3.6"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.6.tgz#2ab2c38fbaffebf8aa95fdfe6d88438c7a13c52b"
+  integrity sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==
   dependencies:
     ms "2.1.2"
 
@@ -366,6 +366,13 @@ debug@^3.1.0:
   integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
   dependencies:
     ms "^2.1.1"
+
+debug@^4.1.1, debug@^4.3.4:
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
+  integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
+  dependencies:
+    ms "2.1.2"
 
 delayed-stream@~1.0.0:
   version "1.0.0"

--- a/examples/install-only/package-lock.json
+++ b/examples/install-only/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "arg": "5.0.0",
-        "debug": "4.3.4"
+        "debug": "4.3.6"
       },
       "devDependencies": {
         "cypress": "13.13.1"
@@ -607,9 +607,10 @@
       "dev": true
     },
     "node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.6.tgz",
+      "integrity": "sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==",
+      "license": "MIT",
       "dependencies": {
         "ms": "2.1.2"
       },

--- a/examples/install-only/package.json
+++ b/examples/install-only/package.json
@@ -8,7 +8,7 @@
   "private": true,
   "dependencies": {
     "arg": "5.0.0",
-    "debug": "4.3.4"
+    "debug": "4.3.6"
   },
   "devDependencies": {
     "cypress": "13.13.1"

--- a/examples/wait-on/package-lock.json
+++ b/examples/wait-on/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "arg": "5.0.0",
-        "debug": "4.3.4"
+        "debug": "4.3.6"
       },
       "devDependencies": {
         "cypress": "13.13.1"
@@ -607,9 +607,10 @@
       "dev": true
     },
     "node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.6.tgz",
+      "integrity": "sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==",
+      "license": "MIT",
       "dependencies": {
         "ms": "2.1.2"
       },

--- a/examples/wait-on/package.json
+++ b/examples/wait-on/package.json
@@ -17,7 +17,7 @@
   "private": true,
   "dependencies": {
     "arg": "5.0.0",
-    "debug": "4.3.4"
+    "debug": "4.3.6"
   },
   "devDependencies": {
     "cypress": "13.13.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@actions/io": "1.1.3",
         "@octokit/core": "4.2.0",
         "argument-vector": "1.0.2",
-        "debug": "4.3.4",
+        "debug": "4.3.6",
         "find-yarn-workspace-root": "2.0.0",
         "got": "11.8.6",
         "hasha": "5.2.2",
@@ -775,9 +775,10 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.6.tgz",
+      "integrity": "sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==",
+      "license": "MIT",
       "dependencies": {
         "ms": "2.1.2"
       },

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@actions/io": "1.1.3",
     "@octokit/core": "4.2.0",
     "argument-vector": "1.0.2",
-    "debug": "4.3.4",
+    "debug": "4.3.6",
     "find-yarn-workspace-root": "2.0.0",
     "got": "11.8.6",
     "hasha": "5.2.2",


### PR DESCRIPTION
- supersedes failed PR https://github.com/cypress-io/github-action/pull/1223

## Issue

- Renovate PR https://github.com/cypress-io/github-action/pull/525 attempts to update [debug](https://github.com/debug-js/debug) from `4.3.4` to [4.3.6](https://github.com/debug-js/debug/releases/tag/4.3.6) in the root [package.json](https://github.com/cypress-io/github-action/blob/master/package.json). This fails because Renovate does not re-build the action, leading to a mismatch.

- Renovate does not update [debug](https://github.com/debug-js/debug) in the [examples](https://github.com/cypress-io/github-action/tree/master/examples) directories

## Change

Using Node.js `20.15.1`.

Update all instances of [debug](https://github.com/debug-js/debug) in the repo from `4.3.4` to [4.3.6](https://github.com/debug-js/debug/releases/tag/4.3.6)

- `package.json`
- `examples/install-command/package.json`
- `examples/install-only/package.json`
- `examples/wait-on/package.json`