### PR TITLE
chore: correct package.json repository.url protocol to git+https

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/cypress-io/github-action.git"
+    "url": "git+https://github.com/cypress-io/github-action.git"
   },
   "keywords": [
     "actions",


### PR DESCRIPTION
## Issue

[package.json](https://github.com/cypress-io/github-action/blob/master/package.json) specifies an invalid protocol for the `repository.url` key.

https://github.com/cypress-io/github-action/blob/257570a2f3389e224be9630256c77777dcbb99ae/package.json#L20-L23

Valid protocols, as listed in the [Git URLs as Dependencies](https://docs.npmjs.com/cli/v10/configuring-npm/package-json#git-urls-as-dependencies) npm documentation section, are defined as follows:

> `<protocol>` is one of `git`, `git+ssh`, `git+http`, `git+https`, or `git+file`.

## Change

Using Node.js `20.16.0` LTS, execute the following in root of repo:

```shell
npm pkg fix
```

Since this repo is not published as an npm package, no new version needs to be created.