### PR TITLE
test: convert pnpm workflow to os matrix

### DIFF
--- a/.github/workflows/example-basic-pnpm.yml
+++ b/.github/workflows/example-basic-pnpm.yml
@@ -8,8 +8,12 @@ on:
 
 jobs:
 
-  basic-pnpm-ubuntu-20:
-    runs-on: ubuntu-20.04
+  basic-pnpm:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-22.04, windows-2022, macos-14]
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -18,82 +22,12 @@ jobs:
         run: npm install -g pnpm@9
 
       - name: Cypress tests
-        # normally you would write
+        # if you copy this workflow to another repository
+        # take the next line as replacement for ./
         # uses: cypress-io/github-action@v6
         uses: ./
-        # the parameters below are only necessary
-        # because we are running these examples in a monorepo
         with:
           working-directory: examples/basic-pnpm
-          # just for full picture after installing Cypress
           # print information about detected browsers, etc
           # see https://on.cypress.io/command-line#cypress-info
-          build: npx cypress info
-
-  basic-pnpm-ubuntu-22:
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Install pnpm
-        run: npm install -g pnpm@9
-
-      - name: Cypress tests
-        uses: ./
-        with:
-          working-directory: examples/basic-pnpm
-          build: npx cypress info
-
-  basic-pnpm-on-windows:
-    runs-on: windows-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Install pnpm
-        run: npm install -g pnpm@9
-
-      - name: Cypress tests
-        uses: ./
-        with:
-          working-directory: examples/basic-pnpm
-          build: npx cypress info
-
-  basic-pnpm-on-mac:
-    runs-on: macos-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Install pnpm
-        run: npm install -g pnpm@9
-
-      - name: Cypress tests
-        uses: ./
-        with:
-          working-directory: examples/basic-pnpm
-          build: npx cypress info
-
-  # skips the binary installation
-  # shows that the job should not fail
-  # https://github.com/cypress-io/github-action/issues/327
-  basic-pnpm-without-binary-install:
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Install pnpm
-        run: npm install -g pnpm@9
-
-      - name: Cypress tests
-        uses: ./
-        with:
-          working-directory: examples/basic-pnpm
-          # since we do not install Cypress
-          # we should not attempt to run tests
-          runTests: false
-        env:
-          # skip the binary install
-          CYPRESS_INSTALL_BINARY: 0
+          build: pnpm exec cypress info


### PR DESCRIPTION
## Issues

Several jobs in the workflow [.github/workflows/example-basic-pnpm.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-basic-pnpm.yml) are repeated with the only difference being the operating system:

- `ubuntu-20.04`
- `ubuntu-22.04`
- `windows-latest`
- `macos-latest`

The final job `basic-pnpm-without-binary-install` is proof that issue https://github.com/cypress-io/github-action/issues/327 from 2021 was resolved. This job is redundant, since it was copied from [.github/workflows/example-basic.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-basic.yml) and it does not correspond to an actual full use-case, since no tests are run.

The jobs use `npx` which is not a native `pnpm` command.

## Change

1. Convert the workflow into a [GitHub Actions matrix](https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs) for the following operating systems, preferring fixed versions from the available [GitHub Actions runner images](https://github.com/actions/runner-images), equivalent to current `latest` tags:

   - `ubuntu-22.04`
   - `windows-2022`
   - `macos-14`

2. Replace npx using [pnpm exec](https://pnpm.io/cli/exec).

3. Drop the job `basic-pnpm-without-binary-install`.
