### PR TITLE
test: implement example pnpm workflow caching

### DIFF
--- a/.github/workflows/example-basic-pnpm.yml
+++ b/.github/workflows/example-basic-pnpm.yml
@@ -18,8 +18,19 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+        # See https://github.com/pnpm/action-setup
       - name: Install pnpm
-        run: npm install -g pnpm@9
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+        # See https://github.com/actions/setup-node
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+          cache-dependency-path: examples/basic-pnpm/pnpm-lock.yaml
 
       - name: Cypress tests
         # if you copy this workflow to another repository

--- a/README.md
+++ b/README.md
@@ -1127,7 +1127,8 @@ jobs:
 ### pnpm
 
 The package manager `pnpm` is not pre-installed in [GitHub Actions runner images](https://github.com/actions/runner-images) (unlike `npm` and `yarn`) and so it must be installed in a separate workflow step (see below). If the action finds a `pnpm-lock.yaml` file, it uses the [pnpm](https://pnpm.io/cli/install) command `pnpm install --frozen-lockfile` by default to install dependencies.
-At this time, the action does not automatically cache dependencies installed by pnpm. We advise against attempting to work around this restriction, by caching the pnpm store directory through additional workflow steps, as this can lead to the action skipping installation of the Cypress binary, causing workflow failure.
+
+The example below follows [pnpm recommendations](https://pnpm.io/continuous-integration#github-actions) for installing pnpm and caching the [pnpm store](https://pnpm.io/cli/store).
 
 ```yaml
 name: example-basic-pnpm
@@ -1139,7 +1140,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Install pnpm
-        run: npm install -g pnpm@9
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+          cache-dependency-path: examples/basic-pnpm/pnpm-lock.yaml
       - name: Cypress run
         uses: cypress-io/github-action@v6
         with:


### PR DESCRIPTION
- resolves issue https://github.com/cypress-io/github-action/issues/1227 for non-workspace configuration

## Issue

- PR https://github.com/cypress-io/github-action/pull/1188 removed pnpm caching due to reliability issues.
- The enhancement request https://github.com/cypress-io/github-action/issues/1044 remains open and at this time there is no native pnpm caching implemented in `cypress-io/github-action`.
- Lack of pnpm caching can cause a performance impact on workflows, negatively affecting the usability of `cypress-io/github-action`.

## Background

[pnpm Continuous Integration > GitHub Actions](https://pnpm.io/continuous-integration#github-actions) documentation recommends installing [pnpm](https://pnpm.io/) with [pnpm/action-setup](https://github.com/pnpm/action-setup) and caching pnpm with GitHub's [actions/setup-node](https://github.com/actions/setup-node).

## Change

In workflow:

- [.github/workflows/example-basic-pnpm.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-basic-pnpm.yml)

make the following changes:

- install pnpm with [pnpm/action-setup](https://github.com/pnpm/action-setup)
- install Node.js `20` with [actions/setup-node](https://github.com/actions/setup-node) and select `pnpm`. Note that `cache-dependency-path: examples/basic-pnpm/pnpm-lock.yaml` is necessary, since this is a monorepo and `actions/setup-node` does not support the use of `working-directory` at this time.

In the [README > pnpm](https://github.com/cypress-io/github-action/blob/master/README.md#pnpm) section, add the steps as above and refer to the [pnpm Continuous Integration > GitHub Actions](https://pnpm.io/continuous-integration#github-actions) documentation.

## Verification

Delete Actions caches

Run workflow `example-basic-pnpm`
Note completion time (4m 5s)

Record cache sizes

| Cache                   | Size   | Usage          |
| ----------------------- | ------ | -------------- |
| node-cache-Windows-pnpm | 6 MB   | pnpm cache     |
| cypress-win32-x64       | 170 MB | Cypress binary |
| pnpm-win32-x64          | 773 B  | not relevant   |
| node-cache-macOS-pnpm   | 6.1 MB | pnpm cache     |
| cypress-darwin-arm64    | 140 MB | Cypress binary |
| pnpm-darwin-arm64       | 757 B  | not relevant   |
| node-cache-Linux-pnpm   | 6.1 MB | pnpm cache     |
| cypress-linux-x64       | 170 MB | Cypress binary |
| pnpm-linux-x64          | 783 B  | not relevant   |

Run workflow `example-basic-pnpm` a second time
Note completion time (2m 31s) (faster than first time)

Check caches. There should be no (significant) growth.

| Job          | First run | Second run |
| ------------ | --------- | ---------- |
| macos-14     | 49s       | 43s        |
| ubuntu-22.04 | 37s       | 21s        |
| windows-2022 | 3m 43s    | 2m 18s     |
