### PR TITLE
chore(deps): update axios to 1.7.4

### DIFF
--- a/examples/config/package-lock.json
+++ b/examples/config/package-lock.json
@@ -336,12 +336,13 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.2.tgz",
-      "integrity": "sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==",
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.4.tgz",
+      "integrity": "sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.0",
+        "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
       }


### PR DESCRIPTION
## Issue

Dependabot reports alert [Server-Side Request Forgery in axios](https://github.com/advisories/GHSA-8hc4-vh64-cxmj) for [examples/config/package-lock.json](https://github.com/cypress-io/github-action/blob/master/examples/config/package-lock.json).

[axios](https://www.npmjs.com/package/axios) is a transient dependency of

https://github.com/cypress-io/github-action/blob/a08087f53f35fbade998de761fa13e4d83479306/examples/config/package.json#L17

## Change

Resolve the vulnerability with `npm audit fix` which updates `axios` to `1.7.4`.

## Other

- See https://github.com/jeffbski/wait-on/issues/159