### PR TITLE
fix(deps): update to semantic-release 24.1.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,6 +41,8 @@ jobs:
         uses: cycjimmy/semantic-release-action@v4
         id: semantic
         with:
+          # https://github.com/semantic-release/semantic-release
+          semantic_version: 24.1.0
           branches: master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Issue

Although nothing was changed in the `release` job in the [main](https://github.com/cypress-io/github-action/blob/master/.github/workflows/main.yml) workflow, there have been two recent failures releasing a new version of the action:

| PR                                                                       | Release                                                                                             | Job |
| ------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------- | --- |
#1239 | [6.7.3](https://github.com/cypress-io/github-action/releases/tag/v6.7.3) | [29311414268](https://github.com/cypress-io/github-action/actions/runs/10579296146/job/29311414268) |
#1242 | [6.7.4](https://github.com/cypress-io/github-action/releases/tag/v6.7.4) | [29370524987](https://github.com/cypress-io/github-action/actions/runs/10598278439/job/29370524987) |

In both cases a release tag was created, the release was added to the [Releases list](https://github.com/cypress-io/github-action/releases) and then the action [cycjimmy/semantic-release-action](https://github.com/cycjimmy/semantic-release-action) failed in the step adding https://github.com/cypress-io/github-action/labels/released labels driven by [@semantic-release/github](https://github.com/semantic-release/github).

The GitHub API error was:

> Request quota exhausted for request GET /search/issues

The consequences are:

1. Some closed issues may be missing a bot comment showing in which release the issue was resolved. Also a corresponding label https://github.com/cypress-io/github-action/labels/released may be missing.
2. The commits belonging to the release were not copied to the [v6](https://github.com/cypress-io/github-action/tree/v6) branch, so the recommended invocation `cypress-io/github-action@v6` pulls in the older [v6.7.2](https://github.com/cypress-io/github-action/releases/tag/v6.7.2) instead of the latest `v6` tag.
3. The CI badge shows `failing`.

## Background

- The GitHub API quota issue is resolved in [@semantic-release/github@10.0.7](https://github.com/semantic-release/github/releases/tag/v10.0.7)
- [semantic-release@24.1.0](https://github.com/semantic-release/semantic-release/releases/tag/v24.1.0) is required to pull in the above fix through the dependency [@semantic-release/github@10.1.4](https://github.com/semantic-release/github/releases/tag/v10.1.4)

## Change

Add the option `semantic_version: 24.1.0` to the parameters calling [cycjimmy/semantic-release-action](https://github.com/cycjimmy/semantic-release-action/blob/main/README.md#inputs) in the [main](https://github.com/cypress-io/github-action/blob/master/.github/workflows/main.yml) workflow.
