### PR TITLE
docs: update link to debug-js/debug repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1439,7 +1439,7 @@ See section [Yarn Modern](#yarn-modern) for information about using Yarn version
 
 ## Debugging
 
-This action uses the [debug](https://github.com/visionmedia/debug#readme) module to output additional verbose logs. You can see these debug messages by setting the following environment variable:
+This action uses the [debug](https://github.com/debug-js/debug#readme) module to output additional verbose logs. You can see these debug messages by setting the following environment variable:
 
 ```yml
 DEBUG: @cypress/github-action


### PR DESCRIPTION
## Issue

The npm [debug](https://www.npmjs.com/package/debug) module's source repo moved:

- from https://github.com/visionmedia/debug
- to https://github.com/debug-js/debug

See release notes [debug@4.3.3](https://github.com/debug-js/debug/releases/tag/4.3.3).

## Change

Replace the link above in the [README > Debugging](https://github.com/cypress-io/github-action/blob/master/README.md#debugging) section according to the repository migration.
