### PR TITLE
fix(deps): update debug to 4.3.7

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -57551,7 +57551,7 @@ var y = d * 365.25;
  * @api public
  */
 
-module.exports = function(val, options) {
+module.exports = function (val, options) {
   options = options || {};
   var type = typeof val;
   if (type === 'string' && val.length > 0) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@actions/io": "1.1.3",
         "@octokit/core": "4.2.0",
         "argument-vector": "1.0.2",
-        "debug": "4.3.6",
+        "debug": "4.3.7",
         "find-yarn-workspace-root": "2.0.0",
         "got": "11.8.6",
         "hasha": "5.2.2",
@@ -775,12 +775,12 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.6.tgz",
-      "integrity": "sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==",
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
       "license": "MIT",
       "dependencies": {
-        "ms": "2.1.2"
+        "ms": "^2.1.3"
       },
       "engines": {
         "node": ">=6.0"
@@ -1337,12 +1337,6 @@
         "proxy-agent": "^6.4.0"
       }
     },
-    "node_modules/link-check/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true
-    },
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
@@ -1464,9 +1458,10 @@
       }
     },
     "node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
     },
     "node_modules/needle": {
       "version": "3.3.1",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@actions/io": "1.1.3",
     "@octokit/core": "4.2.0",
     "argument-vector": "1.0.2",
-    "debug": "4.3.6",
+    "debug": "4.3.7",
     "find-yarn-workspace-root": "2.0.0",
     "got": "11.8.6",
     "hasha": "5.2.2",


### PR DESCRIPTION
- supersedes PR https://github.com/cypress-io/github-action/pull/1250

## Issue

- npm module [debug](https://www.npmjs.com/package/debug) has released a new version [debug@4.3.7](https://github.com/debug-js/debug/releases/tag/4.3.7).
- Renovate attempted to update in PR https://github.com/cypress-io/github-action/pull/1250 however this fails in CI because the action needs to be re-built.

## Change

- Update to [debug@4.3.7](https://github.com/debug-js/debug/releases/tag/4.3.7) and re-build the action.

There is no functional change to `debug`, only a reformat of one line of code in the [ms](https://www.npmjs.com/package/ms) npm module which was published 4 years ago and has only now been merged into a new `debug` release.