### PR TITLE
chore(deps): update serve to 14.2.3

### DIFF
--- a/examples/config/package-lock.json
+++ b/examples/config/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "devDependencies": {
         "cypress": "13.14.2",
-        "serve": "14.2.1",
+        "serve": "14.2.3",
         "start-server-and-test": "2.0.3"
       }
     },
@@ -138,10 +138,11 @@
       }
     },
     "node_modules/@zeit/schemas": {
-      "version": "2.29.0",
-      "resolved": "https://registry.npmjs.org/@zeit/schemas/-/schemas-2.29.0.tgz",
-      "integrity": "sha512-g5QiLIfbg3pLuYUJPlisNKY+epQJTcMDsOnVNkscrDP1oi7vmJnzOANYJI/1pZcVJ6umUkBv3aFtlg1UvUHGzA==",
-      "dev": true
+      "version": "2.36.0",
+      "resolved": "https://registry.npmjs.org/@zeit/schemas/-/schemas-2.36.0.tgz",
+      "integrity": "sha512-7kjMwcChYEzMKjeex9ZFXkt1AyNov9R5HZtjBKVsmVpw7pa7ZtlCGvCBC2vnnXctaYN+aRI61HjIqeetZW5ROg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/accepts": {
       "version": "1.3.8",
@@ -170,10 +171,11 @@
       }
     },
     "node_modules/ajv": {
-      "version": "8.11.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
-      "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -1280,7 +1282,8 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fast-url-parser": {
       "version": "1.1.3",
@@ -1771,7 +1774,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/json-stringify-safe": {
       "version": "5.0.1",
@@ -2294,6 +2298,7 @@
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2362,13 +2367,14 @@
       }
     },
     "node_modules/serve": {
-      "version": "14.2.1",
-      "resolved": "https://registry.npmjs.org/serve/-/serve-14.2.1.tgz",
-      "integrity": "sha512-48er5fzHh7GCShLnNyPBRPEjs2I6QBozeGr02gaacROiyS/8ARADlj595j39iZXAqBbJHH/ivJJyPRWY9sQWZA==",
+      "version": "14.2.3",
+      "resolved": "https://registry.npmjs.org/serve/-/serve-14.2.3.tgz",
+      "integrity": "sha512-VqUFMC7K3LDGeGnJM9h56D3XGKb6KGgOw0cVNtA26yYXHCcpxf3xwCTUaQoWlVS7i8Jdh3GjQkOB23qsXyjoyQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@zeit/schemas": "2.29.0",
-        "ajv": "8.11.0",
+        "@zeit/schemas": "2.36.0",
+        "ajv": "8.12.0",
         "arg": "5.0.2",
         "boxen": "7.0.0",
         "chalk": "5.0.1",
@@ -2802,6 +2808,7 @@
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
       }

--- a/examples/config/package.json
+++ b/examples/config/package.json
@@ -13,7 +13,7 @@
   "private": true,
   "devDependencies": {
     "cypress": "13.14.2",
-    "serve": "14.2.1",
+    "serve": "14.2.3",
     "start-server-and-test": "2.0.3"
   },
   "overrides": {

--- a/examples/start-and-pnpm-workspaces/packages/workspace-1/package.json
+++ b/examples/start-and-pnpm-workspaces/packages/workspace-1/package.json
@@ -11,6 +11,6 @@
   "private": true,
   "devDependencies": {
     "cypress": "13.14.2",
-    "serve": "14.2.1"
+    "serve": "14.2.3"
   }
 }

--- a/examples/start-and-pnpm-workspaces/packages/workspace-2/package.json
+++ b/examples/start-and-pnpm-workspaces/packages/workspace-2/package.json
@@ -11,6 +11,6 @@
   "private": true,
   "devDependencies": {
     "cypress": "13.14.2",
-    "serve": "14.2.1"
+    "serve": "14.2.3"
   }
 }

--- a/examples/start-and-pnpm-workspaces/pnpm-lock.yaml
+++ b/examples/start-and-pnpm-workspaces/pnpm-lock.yaml
@@ -17,8 +17,8 @@ importers:
         specifier: 13.14.2
         version: 13.14.2
       serve:
-        specifier: 14.2.1
-        version: 14.2.1
+        specifier: 14.2.3
+        version: 14.2.3
 
   packages/workspace-2:
     devDependencies:
@@ -26,8 +26,8 @@ importers:
         specifier: 13.14.2
         version: 13.14.2
       serve:
-        specifier: 14.2.1
-        version: 14.2.1
+        specifier: 14.2.3
+        version: 14.2.3
 
 packages:
 
@@ -54,8 +54,8 @@ packages:
   '@types/yauzl@2.10.3':
     resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
 
-  '@zeit/schemas@2.29.0':
-    resolution: {integrity: sha512-g5QiLIfbg3pLuYUJPlisNKY+epQJTcMDsOnVNkscrDP1oi7vmJnzOANYJI/1pZcVJ6umUkBv3aFtlg1UvUHGzA==}
+  '@zeit/schemas@2.36.0':
+    resolution: {integrity: sha512-7kjMwcChYEzMKjeex9ZFXkt1AyNov9R5HZtjBKVsmVpw7pa7ZtlCGvCBC2vnnXctaYN+aRI61HjIqeetZW5ROg==}
 
   accepts@1.3.8:
     resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
@@ -65,8 +65,8 @@ packages:
     resolution: {integrity: sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==}
     engines: {node: '>=8'}
 
-  ajv@8.11.0:
-    resolution: {integrity: sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==}
+  ajv@8.12.0:
+    resolution: {integrity: sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==}
 
   ansi-align@3.0.1:
     resolution: {integrity: sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==}
@@ -733,8 +733,8 @@ packages:
   serve-handler@6.1.5:
     resolution: {integrity: sha512-ijPFle6Hwe8zfmBxJdE+5fta53fdIY0lHISJvuikXB3VYFafRjMRpOffSPvCYsbKyBA7pvy9oYr/BT1O3EArlg==}
 
-  serve@14.2.1:
-    resolution: {integrity: sha512-48er5fzHh7GCShLnNyPBRPEjs2I6QBozeGr02gaacROiyS/8ARADlj595j39iZXAqBbJHH/ivJJyPRWY9sQWZA==}
+  serve@14.2.3:
+    resolution: {integrity: sha512-VqUFMC7K3LDGeGnJM9h56D3XGKb6KGgOw0cVNtA26yYXHCcpxf3xwCTUaQoWlVS7i8Jdh3GjQkOB23qsXyjoyQ==}
     engines: {node: '>= 14'}
     hasBin: true
 
@@ -943,7 +943,7 @@ snapshots:
       '@types/node': 22.5.3
     optional: true
 
-  '@zeit/schemas@2.29.0': {}
+  '@zeit/schemas@2.36.0': {}
 
   accepts@1.3.8:
     dependencies:
@@ -955,7 +955,7 @@ snapshots:
       clean-stack: 2.2.0
       indent-string: 4.0.0
 
-  ajv@8.11.0:
+  ajv@8.12.0:
     dependencies:
       fast-deep-equal: 3.1.3
       json-schema-traverse: 1.0.0
@@ -1609,10 +1609,10 @@ snapshots:
       path-to-regexp: 3.3.0
       range-parser: 1.2.0
 
-  serve@14.2.1:
+  serve@14.2.3:
     dependencies:
-      '@zeit/schemas': 2.29.0
-      ajv: 8.11.0
+      '@zeit/schemas': 2.36.0
+      ajv: 8.12.0
       arg: 5.0.2
       boxen: 7.0.0
       chalk: 5.0.1

--- a/examples/start-and-yarn-workspaces/workspace-1/package.json
+++ b/examples/start-and-yarn-workspaces/workspace-1/package.json
@@ -11,6 +11,6 @@
   "private": true,
   "devDependencies": {
     "cypress": "13.14.2",
-    "serve": "14.2.1"
+    "serve": "14.2.3"
   }
 }

--- a/examples/start-and-yarn-workspaces/workspace-2/package.json
+++ b/examples/start-and-yarn-workspaces/workspace-2/package.json
@@ -11,6 +11,6 @@
   "private": true,
   "devDependencies": {
     "cypress": "13.14.2",
-    "serve": "14.2.1"
+    "serve": "14.2.3"
   }
 }

--- a/examples/start-and-yarn-workspaces/yarn.lock
+++ b/examples/start-and-yarn-workspaces/yarn.lock
@@ -61,10 +61,10 @@
   dependencies:
     "@types/node" "*"
 
-"@zeit/schemas@2.29.0":
-  version "2.29.0"
-  resolved "https://registry.yarnpkg.com/@zeit/schemas/-/schemas-2.29.0.tgz#a59ae6ebfdf4ddc66a876872dd736baa58b6696c"
-  integrity sha512-g5QiLIfbg3pLuYUJPlisNKY+epQJTcMDsOnVNkscrDP1oi7vmJnzOANYJI/1pZcVJ6umUkBv3aFtlg1UvUHGzA==
+"@zeit/schemas@2.36.0":
+  version "2.36.0"
+  resolved "https://registry.yarnpkg.com/@zeit/schemas/-/schemas-2.36.0.tgz#7a1b53f4091e18d0b404873ea3e3c83589c765f2"
+  integrity sha512-7kjMwcChYEzMKjeex9ZFXkt1AyNov9R5HZtjBKVsmVpw7pa7ZtlCGvCBC2vnnXctaYN+aRI61HjIqeetZW5ROg==
 
 accepts@~1.3.5:
   version "1.3.8"
@@ -82,10 +82,10 @@ aggregate-error@^3.0.0:
     clean-stack "^2.0.0"
     indent-string "^4.0.0"
 
-ajv@8.11.0:
-  version "8.11.0"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.11.0.tgz#977e91dd96ca669f54a11e23e378e33b884a565f"
-  integrity sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==
+ajv@8.12.0:
+  version "8.12.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.12.0.tgz#d1a0527323e22f53562c567c00991577dfbe19d1"
+  integrity sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==
   dependencies:
     fast-deep-equal "^3.1.1"
     json-schema-traverse "^1.0.0"
@@ -1249,13 +1249,13 @@ serve-handler@6.1.5:
     path-to-regexp "2.2.1"
     range-parser "1.2.0"
 
-serve@14.2.1:
-  version "14.2.1"
-  resolved "https://registry.yarnpkg.com/serve/-/serve-14.2.1.tgz#3f078d292ed5e7b2c5a64f957af2765b0459798b"
-  integrity sha512-48er5fzHh7GCShLnNyPBRPEjs2I6QBozeGr02gaacROiyS/8ARADlj595j39iZXAqBbJHH/ivJJyPRWY9sQWZA==
+serve@14.2.3:
+  version "14.2.3"
+  resolved "https://registry.yarnpkg.com/serve/-/serve-14.2.3.tgz#047ba2b349354255bc09e0332cd41a92787836c9"
+  integrity sha512-VqUFMC7K3LDGeGnJM9h56D3XGKb6KGgOw0cVNtA26yYXHCcpxf3xwCTUaQoWlVS7i8Jdh3GjQkOB23qsXyjoyQ==
   dependencies:
-    "@zeit/schemas" "2.29.0"
-    ajv "8.11.0"
+    "@zeit/schemas" "2.36.0"
+    ajv "8.12.0"
     arg "5.0.2"
     boxen "7.0.0"
     chalk "5.0.1"

--- a/examples/start/package-lock.json
+++ b/examples/start/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "devDependencies": {
         "cypress": "13.14.2",
-        "serve": "14.2.1"
+        "serve": "14.2.3"
       }
     },
     "node_modules/@colors/colors": {
@@ -101,10 +101,11 @@
       }
     },
     "node_modules/@zeit/schemas": {
-      "version": "2.29.0",
-      "resolved": "https://registry.npmjs.org/@zeit/schemas/-/schemas-2.29.0.tgz",
-      "integrity": "sha512-g5QiLIfbg3pLuYUJPlisNKY+epQJTcMDsOnVNkscrDP1oi7vmJnzOANYJI/1pZcVJ6umUkBv3aFtlg1UvUHGzA==",
-      "dev": true
+      "version": "2.36.0",
+      "resolved": "https://registry.npmjs.org/@zeit/schemas/-/schemas-2.36.0.tgz",
+      "integrity": "sha512-7kjMwcChYEzMKjeex9ZFXkt1AyNov9R5HZtjBKVsmVpw7pa7ZtlCGvCBC2vnnXctaYN+aRI61HjIqeetZW5ROg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/accepts": {
       "version": "1.3.8",
@@ -133,10 +134,11 @@
       }
     },
     "node_modules/ajv": {
-      "version": "8.11.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
-      "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -1193,7 +1195,8 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fast-url-parser": {
       "version": "1.1.3",
@@ -1645,7 +1648,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/json-stringify-safe": {
       "version": "5.0.1",
@@ -2138,6 +2142,7 @@
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2206,13 +2211,14 @@
       }
     },
     "node_modules/serve": {
-      "version": "14.2.1",
-      "resolved": "https://registry.npmjs.org/serve/-/serve-14.2.1.tgz",
-      "integrity": "sha512-48er5fzHh7GCShLnNyPBRPEjs2I6QBozeGr02gaacROiyS/8ARADlj595j39iZXAqBbJHH/ivJJyPRWY9sQWZA==",
+      "version": "14.2.3",
+      "resolved": "https://registry.npmjs.org/serve/-/serve-14.2.3.tgz",
+      "integrity": "sha512-VqUFMC7K3LDGeGnJM9h56D3XGKb6KGgOw0cVNtA26yYXHCcpxf3xwCTUaQoWlVS7i8Jdh3GjQkOB23qsXyjoyQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@zeit/schemas": "2.29.0",
-        "ajv": "8.11.0",
+        "@zeit/schemas": "2.36.0",
+        "ajv": "8.12.0",
         "arg": "5.0.2",
         "boxen": "7.0.0",
         "chalk": "5.0.1",
@@ -2557,6 +2563,7 @@
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
       }

--- a/examples/start/package.json
+++ b/examples/start/package.json
@@ -12,7 +12,7 @@
   "private": true,
   "devDependencies": {
     "cypress": "13.14.2",
-    "serve": "14.2.1"
+    "serve": "14.2.3"
   },
   "overrides": {
     "serve": {


### PR DESCRIPTION
## Issue

The following example directories are using [serve@14.2.1](https://github.com/vercel/serve/releases/tag/14.2.1):

- [examples/config](https://github.com/cypress-io/github-action/tree/master/examples/config)
- [examples/start](https://github.com/cypress-io/github-action/tree/master/examples/start)
- [examples/start-and-pnpm-workspaces/packages/workspace-1](https://github.com/cypress-io/github-action/tree/master/examples/start-and-pnpm-workspaces/packages/workspace-1)
- [examples/start-and-pnpm-workspaces/packages/workspace-2](https://github.com/cypress-io/github-action/tree/master/examples/start-and-pnpm-workspaces/packages/workspace-2)
- [examples/start-and-yarn-workspaces/packages/workspace-1](https://github.com/cypress-io/github-action/tree/master/examples/start-and-yarn-workspaces/packages/workspace-1)
- [examples/start-and-yarn-workspaces/packages/workspace-2](https://github.com/cypress-io/github-action/tree/master/examples/start-and-yarn-workspaces/packages/workspace-2)

When started, `serve` raises the following warning:

>  UPDATE  The latest version of `serve` is 14.2.3

## Change

Update to [serve@14.2.3](https://github.com/vercel/serve/releases/tag/14.2.3) in the above example directories.