### PR TITLE
chore(deps): update path-to-regexp to 3.3.0

### DIFF
--- a/examples/config/package-lock.json
+++ b/examples/config/package-lock.json
@@ -2106,10 +2106,11 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-2.2.1.tgz",
-      "integrity": "sha512-gu9bD6Ta5bwGrrU8muHzVOBFFREpp2iRkVfhBJahwJ6p6Xw20SjT0MxLnwkjOibQmGSYhiUnf2FLe7k+jcFmGQ==",
-      "dev": true
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-3.3.0.tgz",
+      "integrity": "sha512-qyCH421YQPS2WFDxDjftfc1ZR5WKQzVzqsp4n9M2kQhVOo/ByahFoUNJfl58kOcEGfQ//7weFTDhm+ss8Ecxgw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/pause-stream": {
       "version": "0.0.11",

--- a/examples/config/package.json
+++ b/examples/config/package.json
@@ -15,5 +15,10 @@
     "cypress": "13.14.2",
     "serve": "14.2.1",
     "start-server-and-test": "2.0.3"
+  },
+  "overrides": {
+    "serve": {
+      "path-to-regexp": "3.3.0"
+    }
   }
 }

--- a/examples/start-and-pnpm-workspaces/package.json
+++ b/examples/start-and-pnpm-workspaces/package.json
@@ -2,5 +2,10 @@
   "name": "start-and-pnpm-workspaces",
   "version": "1.0.0",
   "description": "example using pnpm with workspaces",
-  "private": true
+  "private": true,
+  "pnpm": {
+    "overrides": {
+      "path-to-regexp": "3.3.0"
+    }
+  }
 }

--- a/examples/start-and-pnpm-workspaces/pnpm-lock.yaml
+++ b/examples/start-and-pnpm-workspaces/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  path-to-regexp: 3.3.0
+
 importers:
 
   .: {}
@@ -634,8 +637,8 @@ packages:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
 
-  path-to-regexp@2.2.1:
-    resolution: {integrity: sha512-gu9bD6Ta5bwGrrU8muHzVOBFFREpp2iRkVfhBJahwJ6p6Xw20SjT0MxLnwkjOibQmGSYhiUnf2FLe7k+jcFmGQ==}
+  path-to-regexp@3.3.0:
+    resolution: {integrity: sha512-qyCH421YQPS2WFDxDjftfc1ZR5WKQzVzqsp4n9M2kQhVOo/ByahFoUNJfl58kOcEGfQ//7weFTDhm+ss8Ecxgw==}
 
   pend@1.2.0:
     resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
@@ -1519,7 +1522,7 @@ snapshots:
 
   path-key@3.1.1: {}
 
-  path-to-regexp@2.2.1: {}
+  path-to-regexp@3.3.0: {}
 
   pend@1.2.0: {}
 
@@ -1603,7 +1606,7 @@ snapshots:
       mime-types: 2.1.18
       minimatch: 3.1.2
       path-is-inside: 1.0.2
-      path-to-regexp: 2.2.1
+      path-to-regexp: 3.3.0
       range-parser: 1.2.0
 
   serve@14.2.1:

--- a/examples/start-and-yarn-workspaces/package.json
+++ b/examples/start-and-yarn-workspaces/package.json
@@ -3,5 +3,8 @@
   "workspaces": [
     "workspace-1",
     "workspace-2"
-  ]
+  ],
+  "resolutions": {
+    "path-to-regexp": "3.3.0"
+  }
 }

--- a/examples/start-and-yarn-workspaces/yarn.lock
+++ b/examples/start-and-yarn-workspaces/yarn.lock
@@ -1076,10 +1076,10 @@ path-key@^3.0.0, path-key@^3.1.0:
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-3.1.1.tgz#581f6ade658cbba65a0d3380de7753295054f375"
   integrity sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
 
-path-to-regexp@2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-2.2.1.tgz#90b617025a16381a879bc82a38d4e8bdeb2bcf45"
-  integrity sha512-gu9bD6Ta5bwGrrU8muHzVOBFFREpp2iRkVfhBJahwJ6p6Xw20SjT0MxLnwkjOibQmGSYhiUnf2FLe7k+jcFmGQ==
+path-to-regexp@2.2.1, path-to-regexp@3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-3.3.0.tgz#f7f31d32e8518c2660862b644414b6d5c63a611b"
+  integrity sha512-qyCH421YQPS2WFDxDjftfc1ZR5WKQzVzqsp4n9M2kQhVOo/ByahFoUNJfl58kOcEGfQ//7weFTDhm+ss8Ecxgw==
 
 pend@~1.2.0:
   version "1.2.0"

--- a/examples/start/package-lock.json
+++ b/examples/start/package-lock.json
@@ -1974,10 +1974,11 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-2.2.1.tgz",
-      "integrity": "sha512-gu9bD6Ta5bwGrrU8muHzVOBFFREpp2iRkVfhBJahwJ6p6Xw20SjT0MxLnwkjOibQmGSYhiUnf2FLe7k+jcFmGQ==",
-      "dev": true
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-3.3.0.tgz",
+      "integrity": "sha512-qyCH421YQPS2WFDxDjftfc1ZR5WKQzVzqsp4n9M2kQhVOo/ByahFoUNJfl58kOcEGfQ//7weFTDhm+ss8Ecxgw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/pend": {
       "version": "1.2.0",

--- a/examples/start/package.json
+++ b/examples/start/package.json
@@ -13,5 +13,10 @@
   "devDependencies": {
     "cypress": "13.14.2",
     "serve": "14.2.1"
+  },
+  "overrides": {
+    "serve": {
+      "path-to-regexp": "3.3.0"
+    }
   }
 }


### PR DESCRIPTION
- Closes https://github.com/cypress-io/github-action/issues/1254

## Issue

The following example directories report high severity vulnerabilities due to their transient dependency usage of `path-to-regexp@2.2.1`:

Check with `npm audit`:

-  [examples/config](https://github.com/cypress-io/github-action/tree/master/examples/config)
-  [examples/start](https://github.com/cypress-io/github-action/tree/master/examples/start)

Check with `pnpm audit`:

- [examples/start-and-pnpm-workspaces/packages](https://github.com/cypress-io/github-action/tree/master/examples/start-and-pnpm-workspaces/packages)

`yarn audit` shows no issue, however Dependabot reports the vulnerability:

- [examples/start-and-yarn-workspaces/packages](https://github.com/cypress-io/github-action/tree/master/examples/start-and-yarn-workspaces/packages)


## Change

Pin to [path-to-regexp@3.3.0](https://github.com/pillarjs/path-to-regexp/releases/tag/v3.3.0) using the appropriate option according to the package manager being used:

- npm `package.json` option [overrides](https://docs.npmjs.com/cli/v10/configuring-npm/package-json#overrides)
- [pnpm.overrides](https://pnpm.io/package_json#pnpmoverrides)
- Yarn Classic v1 [resolutions](https://classic.yarnpkg.com/lang/en/docs/selective-version-resolutions/)