### PR TITLE
test: add binary install debug to example-debug workflow

### DIFF
--- a/.github/workflows/example-basic.yml
+++ b/.github/workflows/example-basic.yml
@@ -63,23 +63,3 @@ jobs:
         with:
           working-directory: examples/basic
           build: npx cypress info
-
-  # skips the binary installation
-  # shows that the job should not fail
-  # https://github.com/cypress-io/github-action/issues/327
-  basic-without-binary-install:
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Cypress tests
-        uses: ./
-        with:
-          working-directory: examples/basic
-          # since we do not install Cypress
-          # we should not attempt to run tests
-          runTests: false
-        env:
-          # skip the binary install
-          CYPRESS_INSTALL_BINARY: 0

--- a/.github/workflows/example-debug.yml
+++ b/.github/workflows/example-debug.yml
@@ -50,3 +50,29 @@ jobs:
         # You can also combine the two debug options into one line
         # to get both action debug and Cypress debug output
         # DEBUG: '@cypress/github-action, cypress:*'
+
+  install-binary-debug:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Cypress npm install
+        # Install only the Cypress npm module
+        uses: ./
+        with:
+          working-directory: examples/basic
+          runTests: false
+        env:
+          # Skip the Cypress binary installation
+          CYPRESS_INSTALL_BINARY: 0
+
+      - name: Cypress binary install
+        # Now install the Cypress binary with debug enabled
+        uses: ./
+        with:
+          working-directory: examples/basic
+          # use --force option to override any cached Cypress binary version
+          command: npx cypress install --force
+        env:
+          DEBUG: 'cypress:cli*'


### PR DESCRIPTION
## Issue

The workflow [.github/workflows/example-debug.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-debug.yml) does not demonstrate debugging installation of the Cypress binary.

## Change

Add a job to [.github/workflows/example-debug.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-debug.yml) to demonstrate separation of Cypress npm module and Cypress binary installations using `DEBUG: 'cypress:cli*'`.

Remove the related job `basic-without-binary-install` from [.github/workflows/example-basic.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-basic.yml) since it is now effectively moved to [.github/workflows/example-debug.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-debug.yml).