### PR TITLE
ci: rework example-basic

### DIFF
--- a/.github/workflows/example-basic.yml
+++ b/.github/workflows/example-basic.yml
@@ -9,8 +9,12 @@ on:
 
 jobs:
 
-  basic-ubuntu-20:
-    runs-on: ubuntu-20.04
+  basic:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-20.04, ubuntu-22.04, ubuntu-24.04, windows-2022, macos-14]
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -26,40 +30,4 @@ jobs:
           # just for full picture after installing Cypress
           # print information about detected browsers, etc
           # see https://on.cypress.io/command-line#cypress-info
-          build: npx cypress info
-
-  basic-ubuntu-22:
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Cypress tests
-        uses: ./
-        with:
-          working-directory: examples/basic
-          build: npx cypress info
-
-  basic-on-windows:
-    runs-on: windows-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Cypress tests
-        uses: ./
-        with:
-          working-directory: examples/basic
-          build: npx cypress info
-
-  basic-on-mac:
-    runs-on: macos-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Cypress tests
-        uses: ./
-        with:
-          working-directory: examples/basic
           build: npx cypress info


### PR DESCRIPTION
## Change

The workflow [.github/workflows/example-basic.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-basic.yml) is refactored as follows:

- The workflow is converted to use a matrix of operating systems for clarity
- `ubuntu-24.04` is added
- `latest` operating systems are pinned to concrete versions for stability:
  - `windows-latest` changed to [windows-2022](https://github.com/actions/runner-images/blob/main/images/windows/Windows2022-Readme.md) (Windows Server 2022)
  - `macos-latest` changed to [macos-14](https://github.com/actions/runner-images/blob/main/images/macos/macos-14-arm64-Readme.md) (macOS 14 Arm64)