### PR TITLE
docs: active support v10 and later

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,7 +66,7 @@ The repository is set up with a `git` / `Husky` pre-commit hook which ensures th
 
 ### Adding a new example
 
-1. If you are creating a new example, add this as a new project in the `examples` directory. An example project is a regular npm package with its own `package.json` and Cypress dev dependency. (Note: Legacy `examples/v9` are archived in the [v5](https://github.com/cypress-io/github-action/tree/v5/) branch. It is not expected to create any new `v9` examples.)
+1. If you are creating a new example, add this as a new project in the `examples` directory. An example project is a regular npm package with its own `package.json` and Cypress dev dependency. (Note: Legacy `examples/v9` are archived in the [v5](https://github.com/cypress-io/github-action/tree/v5/) branch and are no longer supported or maintained.)
 1. Add a corresponding `.github/workflows` YAML file that uses this action and runs using your new `examples/X` through the `working-directory` parameter. The example should demonstrate any new feature.
 1. Add a workflow status badge to the [README.md](README.md) file (see [Adding a workflow status badge](https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/adding-a-workflow-status-badge)), like the following:
 

--- a/README.md
+++ b/README.md
@@ -63,13 +63,11 @@
 - Suppress [job summary](#suppress-job-summary)
 - [More examples](#more-examples)
 
-Examples contained in this repository, based on current Cypress versions, can be found in the [examples](./examples) directory. Examples for [Legacy Configuration](https://on.cypress.io/guides/references/legacy-configuration), which use Cypress `9.7.0`, are no longer maintained. They can be referred to in the [examples/v9](https://github.com/cypress-io/github-action/tree/v5/examples/v9) directory of the [v5](https://github.com/cypress-io/github-action/tree/v5/) branch.
+Examples contained in this repository, based on current Cypress versions, can be found in the [examples](./examples) directory.
 
 Live examples, such as [example-basic.yml](.github/workflows/example-basic.yml) are shown together with a status badge. Click on the status badge to read the source code of the workflow, for example
 
 [![End-to-End example](https://github.com/cypress-io/github-action/actions/workflows/example-basic.yml/badge.svg)](.github/workflows/example-basic.yml)
-
-Older **external** examples based on a [Legacy Configuration](https://on.cypress.io/guides/references/legacy-configuration) for Cypress `9` and earlier can be found in the [README](https://github.com/cypress-io/github-action/blob/v5/README.md) for version `v5`.
 
 **Note:** this package assumes that [cypress](https://www.npmjs.com/package/cypress) is declared as a development dependency in the [package.json](https://docs.npmjs.com/creating-a-package-json-file) file. The [cypress npm module](https://www.npmjs.com/package/cypress) is required to run Cypress via its [Module API](https://on.cypress.io/module-api).
 
@@ -1675,7 +1673,7 @@ View the [CHANGELOG](./CHANGELOG.md) document for an overview of version changes
 
 ## Compatibility
 
-- `github-action@v6` is the current recommended version and uses `node20`
+- `github-action@v6` is the current recommended version, uses `node20` and is compatible with Cypress `10` and later.
 - `github-action` versions `v1` to `v5` are unsupported: they rely on Node.js `12` and `16` in End-of-life status.
 
 ## Contributing

--- a/docs/MAINTENANCE.md
+++ b/docs/MAINTENANCE.md
@@ -8,7 +8,7 @@ The [examples](../examples) directory contains examples of the use of Cypress (C
 
 The examples make use of [npm](https://www.npmjs.com/), [pnpm](https://pnpm.io/), [Yarn 1 (Classic)](https://classic.yarnpkg.com/) and [Yarn Modern](https://yarnpkg.com/) (Yarn 2 and later) to define and install the packages being used.
 
-*The previous [examples/v9](https://github.com/cypress-io/github-action/tree/v5/examples/v9) are archived in the [v5](https://github.com/cypress-io/github-action/tree/v5/) branch. This directory contains examples which were set up to use Cypress `9.7.0`, the last version using [Legacy Configuration](https://docs.cypress.io/guides/references/legacy-configuration), covering Cypress 9 and below. These `v9` examples are no longer maintained.
+*The previous [examples/v9](https://github.com/cypress-io/github-action/tree/v5/examples/v9) are archived in the [v5](https://github.com/cypress-io/github-action/tree/v5/) branch. This directory contains examples which were set up to use Cypress `9.7.0`, the last version using Legacy Configuration, covering Cypress 9 and below. These `v9` examples are no longer maintained.
 
 ## Requirements
 


### PR DESCRIPTION
## Issue

References to Cypress `v9` need to be reworked:

- The recent PR https://github.com/cypress-io/cypress-documentation/pull/5949 removed the legacy (Cypress `v9` and lower) configuration documentation content from https://docs.cypress.io/guides/references/legacy-configuration.
- [cypress-io/github-action@v6.1.0](https://github.com/cypress-io/github-action/tree/v6.1.0), from Aug 2023, removed all Cypress `v9` examples and declared them archived in the [cypress-io/github-action@v5](https://github.com/cypress-io/github-action/tree/v5) branch and unmaintained.
- The [README > Compatibility](https://github.com/cypress-io/github-action/blob/master/README.md#compatibility) section states that [cypress-io/github-action@v5](https://github.com/cypress-io/github-action/tree/v5) (and below) are unsupported.

## Change

- Simplify information about legacy Cypress (`v9` and lower) to state only that the action no longer supports these versions.
- Add Cypress `10` to the [README > Compatibility](https://github.com/cypress-io/github-action/blob/master/README.md#compatibility) list for action version `v6`.
