### PR TITLE
tests(deps): add node.js 23 (current) to tests

### DIFF
--- a/.github/workflows/example-node-versions.yml
+++ b/.github/workflows/example-node-versions.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [18, 20, 22]
+        node: [18, 20, 22, 23]
     name: Cypress E2E on Node v${{ matrix.node }}
     steps:
       - name: Setup Node

--- a/README.md
+++ b/README.md
@@ -529,7 +529,7 @@ jobs:
     # let's make sure our "app" works on several versions of Node
     strategy:
       matrix:
-        node: [18, 20, 22]
+        node: [18, 20, 22, 23]
     name: E2E on Node v${{ matrix.node }}
     steps:
       - name: Setup Node
@@ -1290,7 +1290,7 @@ jobs:
     # let's make sure our "app" works on several versions of Node
     strategy:
       matrix:
-        node: [18, 20, 22]
+        node: [18, 20, 22, 23]
     name: E2E on Node v${{ matrix.node }}
     steps:
       - name: Setup Node
@@ -1324,7 +1324,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        node: [18, 20, 22]
+        node: [18, 20, 22, 23]
     name: E2E on Node v${{ matrix.node }}
     steps:
       - uses: actions/setup-node@v4
@@ -1655,7 +1655,7 @@ jobs:
 
 Node.js is required to run this action. The recommended version `v6` supports:
 
-- **Node.js** 18.x, 20.x and 22.x
+- **Node.js** 18.x, 20.x, 22.x and 23.x
 
 and is generally aligned with [Node.js's release schedule](https://github.com/nodejs/Release).
 


### PR DESCRIPTION
[Node.js 23.0.0](https://nodejs.org/en/blog/release/v23.0.0) was released on Oct 16, 2024.

This PR adds Node.js `23` to the matrix of tested nodes under [.github/workflows/example-node-versions.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-node-versions.yml), to the [README](https://github.com/cypress-io/github-action/blob/master/README.md) examples and to the [README > Node.js > Support](https://github.com/cypress-io/github-action/blob/master/README.md#support) section.