### PR TITLE
ci: remove code.visualstudio.com from markdown-link-check

### DIFF
--- a/docs/MAINTENANCE.md
+++ b/docs/MAINTENANCE.md
@@ -32,6 +32,7 @@ npm install pnpm@latest -g
 npm install yarn@latest -g
 ```
 
+<!-- markdown-link-check-disable-next-line -->
 - [Visual Studio Code](https://code.visualstudio.com/) or other editor
 
 Under Microsoft Windows it may be necessary to also execute the following preparatory command:


### PR DESCRIPTION
## Issue

[markdown-link-check](https://github.com/tcort/markdown-link-check) has started to fail with [HTTP 403 Forbidden](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/403) checking the hyperlink https://code.visualstudio.com/
located in [docs/MAINTENANCE.md](https://github.com/cypress-io/github-action/blob/master/docs/MAINTENANCE.md).

```text
FILE: docs/MAINTENANCE.md
  [✓] ../examples
  [✓] https://docs.cypress.io/guides/references/configuration
  [✓] https://github.com/cypress-io/github-action
  [✓] https://www.npmjs.com/
  [✓] https://pnpm.io/
  [✓] https://classic.yarnpkg.com/
  [✓] https://yarnpkg.com/
  [✓] https://github.com/cypress-io/github-action/tree/v5/examples/v9
  [✓] https://github.com/cypress-io/github-action/tree/v5/
  [✓] https://ubuntu.com/
  [✓] https://www.apple.com/macos/
  [✓] https://nodejs.org/en/
  [✓] ../CONTRIBUTING.md#requirements
  [✓] https://git-scm.com/
  [✓] https://nodejs.org/
  [✖] https://code.visualstudio.com/
  [✓] https://docs.cypress.io/guides/references/changelog
  [✓] ../.github/workflows/example-install-only.yml

  18 links checked.

  ERROR: 1 dead links found!
  [✖] https://code.visualstudio.com/ → Status: 403
```

## Change

Use [markdown-link-check > Disable comments](https://github.com/tcort/markdown-link-check?tab=readme-ov-file#disable-comments) to disable link checking of https://code.visualstudio.com/ in [docs/MAINTENANCE.md > Requirements](https://github.com/cypress-io/github-action/blob/master/docs/MAINTENANCE.md#requirements).

## Verification

Execute the following locally

```shell
npx markdown-link-check -c md-linkcheck.json docs/MAINTENANCE.md
```

and confirm `17 links checked.` successfully.

Execute

```shell
npm run check:markdown
```

and confirm that all links in all checked files are successfully checked.