### PR TITLE
docs: correct and extend ping debug instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1478,16 +1478,26 @@ If you have a problem with `wait-on` not working, you can check the [src/ping.js
 - start your server
 - from another terminal call the `ping` yourself to validate the server is responding:
 
-```
-$ node src/ping-cli.js <url>
+```shell
+node src/ping-cli.js <url>
 ```
 
-For example
+For example:
 
-```
+```text
 $ node src/ping-cli.js https://example.cypress.io
 pinging url https://example.cypress.io for 30 seconds
-::debug::pinging https://example.cypress.io has finished ok
+```
+
+You can also enable debug logs by setting the environment variable `DEBUG='@cypress/github-action'`, for example:
+
+```text
+$ DEBUG='@cypress/github-action' node src/ping-cli.js https://example.cypress.io
+pinging url https://example.cypress.io for 30 seconds
+  @cypress/github-action total ping timeout 60000 +0ms
+  @cypress/github-action individual ping timeout 30000ms +0ms
+  @cypress/github-action retries limit 2 +0ms
+  @cypress/github-action pinging https://example.cypress.io has finished ok after 185ms +185ms
 ```
 
 ## More information


### PR DESCRIPTION
## Issue

The [README > Debugging waiting for URL to respond](https://github.com/cypress-io/github-action/blob/master/README.md#debugging-waiting-for-url-to-respond) contains an example:

```
$ node src/ping-cli.js https://example.cypress.io
pinging url https://example.cypress.io for 30 seconds
::debug::pinging https://example.cypress.io has finished ok
```

where the last line of the example is incorrect.

Without debugging enabled, the output under Node.js `v20.18.0` LTS appears as:

```text
$ node src/ping-cli.js https://example.cypress.io
pinging url https://example.cypress.io for 30 seconds
```

With debugging enabled, the output is as follows:

```text
$ DEBUG='@cypress/github-action' node src/ping-cli.js https://example.cypress.io
pinging url https://example.cypress.io for 30 seconds
  @cypress/github-action total ping timeout 60000 +0ms
  @cypress/github-action individual ping timeout 30000ms +0ms
  @cypress/github-action retries limit 2 +0ms
  @cypress/github-action pinging https://example.cypress.io has finished ok after 185ms +185ms
```

## Change

Provide correct instructions in [README > Debugging waiting for URL to respond](https://github.com/cypress-io/github-action/blob/master/README.md#debugging-waiting-for-url-to-respond) for running `node src/ping-cli.js` in debug and non-debug mode.
