### PR TITLE
tests(deps): update docker example node.js to 22.11.0

### DIFF
--- a/.github/workflows/example-docker.yml
+++ b/.github/workflows/example-docker.yml
@@ -15,7 +15,7 @@ jobs:
         browser: [chrome, edge, electron, firefox]
     # from https://hub.docker.com/r/cypress/browsers/tags
     container:
-      image: cypress/browsers:node-20.14.0-chrome-126.0.6478.114-1-ff-127.0.1-edge-126.0.2592.61-1
+      image: cypress/browsers:node-22.11.0-chrome-130.0.6723.69-1-ff-132.0-edge-130.0.2849.56-1
       options: --user 1001
     steps:
       - name: Checkout


### PR DESCRIPTION
## Issue

With the release of [Node.js v22.11.0](https://nodejs.org/en/blog/release/v22.11.0) (codename 'Jod') the Node.js Long Term Support (LTS) version moved from `v20` to `v22`.

The example workflow

- [.github/workflows/example-docker.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-docker.yml)

currently demonstrates using the Cypress Docker image:

`cypress/browsers:node-20.14.0-chrome-126.0.6478.114-1-ff-127.0.1-edge-126.0.2592.61-1`

This image includes Node.js `20.14.0` which is now in the [Node.js category Maintenance LTS](https://github.com/nodejs/release#release-schedule).

## Change

Update Docker example workflow to use a Cypress Docker image built with the Active LTS version Node.js `v22.11.0`:

`cypress/browsers:node-22.11.0-chrome-130.0.6723.69-1-ff-132.0-edge-130.0.2849.56-1`

in

- [.github/workflows/example-docker.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-docker.yml)