### PR TITLE
tests(deps): update pnpm example node.js to 22

### DIFF
--- a/.github/workflows/example-basic-pnpm.yml
+++ b/.github/workflows/example-basic-pnpm.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: 'pnpm'
           cache-dependency-path: examples/basic-pnpm/pnpm-lock.yaml
 

--- a/README.md
+++ b/README.md
@@ -1144,7 +1144,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: 'pnpm'
           cache-dependency-path: examples/basic-pnpm/pnpm-lock.yaml
       - name: Cypress run


### PR DESCRIPTION
## Issue

With the release of [Node.js v22.11.0](https://nodejs.org/en/blog/release/v22.11.0) (codename 'Jod') the Node.js Long Term Support (LTS) version moved from `v20` to `v22`.

## Change

Update workflow usage to

```yml
node-version: 22
```

in

- [README > pnpm](https://github.com/cypress-io/github-action/blob/master/README.md#pnpm)
- [.github/workflows/example-basic-pnpm.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-basic-pnpm.yml)