### PR TITLE
ci(deps): update internal ci to node.js 20.18.0

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -22,7 +22,11 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20.8.1
+          # Action runs: using: node20 as defined in
+          # https://github.com/cypress-io/github-action/blob/master/action.yml
+          # Node.js minor version is aligned to
+          # https://github.com/actions/runner/blob/main/src/Misc/externals.sh
+          node-version: 20.18.0
       - run: npm ci
       - run: npm run format
       - run: npm run build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
           # https://github.com/cypress-io/github-action/blob/master/action.yml
           # Node.js minor version is aligned to
           # https://github.com/actions/runner/blob/main/src/Misc/externals.sh
-          node-version: 20.13.1
+          node-version: 20.18.0
       - run: npm ci
       - run: npm run format
       - run: npm run build


### PR DESCRIPTION
## Issue

The internal CI workflows

- [.github/workflows/main.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/main.yml) and
- [.github/workflows/check-dist.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/check-dist.yml)

are intended to run with the same Node.js version as defined in https://github.com/actions/runner/blob/main/src/Misc/externals.sh in order to provide a representative CI test.

The GitHub runner is currently using `NODE20_VERSION="20.18.0"`

https://github.com/actions/runner/blob/3d34a3c6d6dfd7599e489b3c04fcf95a8a428434/src/Misc/externals.sh#L9

## Change

Update the internal CI workflows

- [.github/workflows/main.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/main.yml) and
- [.github/workflows/check-dist.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/check-dist.yml)

to use

```yml
node-version: 20.18.0
```
