### PR TITLE
docs: remove section "More Information"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1500,12 +1500,6 @@ pinging url https://example.cypress.io for 30 seconds
   @cypress/github-action pinging https://example.cypress.io has finished ok after 185ms +185ms
 ```
 
-## More information
-
-- Read our blog post [Drastically Simplify Testing on CI with Cypress GitHub Action](https://www.cypress.io/blog/2019/11/20/drastically-simplify-your-testing-with-cypress-github-action/)
-- Read [Test the Preview Vercel Deploys](https://glebbahmutov.com/blog/develop-preview-test/) blog post
-- [Creating actions](https://docs.github.com/en/actions/creating-actions) docs
-
 ## Extras
 
 ### Manual trigger


### PR DESCRIPTION
## Issue

The [README > More Information](https://github.com/cypress-io/github-action/blob/master/README.md#more-information) section is made up of three links:

1. blog post [Drastically Simplify Testing on CI with Cypress GitHub Action](https://www.cypress.io/blog/drastically-simplify-your-testing-with-cypress-github-action) from Nov 2019
2. blog post [Test the Preview Vercel Deploys](https://glebbahmutov.com/blog/develop-preview-test/) from Aug 2020
3. link to GitHub Actions documentation [Creating actions](https://docs.github.com/en/actions/creating-actions) which now redirects to a renamed section [Sharing automations](https://docs.github.com/en/actions/sharing-automations).

The two blog posts are based on now-unsupported legacy versions.

The remaining link to a section of the GitHub Actions documentation would be out of context left on its own. The [README](https://github.com/cypress-io/github-action/blob/master/README.md) already generically links to the [GitHub Actions documentation](https://docs.github.com/en/actions) in its opening paragraph. This covers the linked subsection [Sharing automations](https://docs.github.com/en/actions/sharing-automations), so the link in the [README > More Information](https://github.com/cypress-io/github-action/blob/master/README.md#more-information) section is effectively redundant.

## Change

Remove the outdated section [More Information](https://github.com/cypress-io/github-action/blob/master/README.md#more-information) from the [README](https://github.com/cypress-io/github-action/blob/master/README.md) document.