### PR TITLE
docs: add install-command lock file prerequisite

### DIFF
--- a/README.md
+++ b/README.md
@@ -927,7 +927,7 @@ Under Node.js version 18 and later, `wait-on` may fail to recognize that a `loca
 
 ### Custom install command
 
-If you want to overwrite the install command
+The action installs dependencies based on a package manager lock file using default commands described in the [Installation](#installation) section below. If you want to overwrite the default install command you can use the `install-command` option:
 
 ```yml
 - uses: cypress-io/github-action@v6
@@ -936,6 +936,8 @@ If you want to overwrite the install command
 ```
 
 See [example-install-command.yml](.github/workflows/example-install-command.yml) workflow file.
+
+If you do not commit a lock file to the repository, you cannot use the action to install dependencies. In this case you must ensure that dependencies are installed before using the action, and you must use the action option setting `install: false`.
 
 ### Command prefix
 


### PR DESCRIPTION
- relates to issue https://github.com/cypress-io/github-action/issues/1308

## Issue

The README section [Custom install command](https://github.com/cypress-io/github-action/blob/master/README.md#custom-install-command) shows only the example `install-command: yarn --frozen-lockfile --silent` as a slightly modified Yarn Classic v1 install command.

It does not specify that the action expects to find a lock file.

## Change

Link to the [Notes > Installation](https://github.com/cypress-io/github-action/blob/master/README.md#installation) section which explains the relationship between lock files and the default installation command that the action uses.

Add the information that if no lock file is provided, then the workflow must ensure that dependencies are installed prior to using the action, and that the action must be called in this case with the option `install: false`.
