### PR TITLE
docs: fix readme links for cypress documentation restructuring

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ jobs:
 
 The workflow file [example-basic.yml](.github/workflows/example-basic.yml) shows how Cypress runs on GH Actions using Ubuntu (20 and 22), Windows, and macOS without additional OS dependencies necessary.
 
-This workflow uses the default [test type](https://on.cypress.io/guides/overview/why-cypress#Test-types) of [End-to-End (E2E) Testing](https://on.cypress.io/guides/overview/why-cypress#End-to-end). Alternatively, [Component Testing](https://on.cypress.io/guides/overview/why-cypress#Component) can be utilized by referencing the [Component Testing](#component-testing) section below.
+This workflow uses the default [test type](https://on.cypress.io/choosing-testing-type) of [End-to-End (E2E) Testing](https://docs.cypress.io/app/core-concepts/testing-types#What-is-E2E-Testing). Alternatively, [Component Testing](https://docs.cypress.io/app/core-concepts/testing-types#What-is-Component-Testing) can be utilized by referencing the [Component Testing](#component-testing) section below.
 
 ### Component Testing
 
@@ -743,7 +743,7 @@ During staged rollout of a new GitHub-hosted runner version, GitHub may provide 
 
 ### Component and E2E Testing
 
-[Component Testing](https://on.cypress.io/guides/overview/why-cypress#Component) and [End-to-End (E2E) Testing](https://on.cypress.io/guides/overview/why-cypress#End-to-end) types can be combined in the same job using separate steps
+[Component Testing](https://docs.cypress.io/app/core-concepts/testing-types#What-is-Component-Testing) and [End-to-End (E2E) Testing](https://docs.cypress.io/app/core-concepts/testing-types#What-is-E2E-Testing) types can be combined in the same job using separate steps
 
 ```yml
 - name: Run E2E tests

--- a/README.md
+++ b/README.md
@@ -743,7 +743,7 @@ During staged rollout of a new GitHub-hosted runner version, GitHub may provide 
 
 ### Component and E2E Testing
 
-[Component Testing](https://docs.cypress.io/app/core-concepts/testing-types#What-is-Component-Testing) and [End-to-End (E2E) Testing](https://docs.cypress.io/app/core-concepts/testing-types#What-is-E2E-Testing) types can be combined in the same job using separate steps
+[Component Testing](https://on.cypress.io/app/core-concepts/testing-types#What-is-Component-Testing) and [End-to-End (E2E) Testing](https://on.cypress.io/app/core-concepts/testing-types#What-is-E2E-Testing) types can be combined in the same job using separate steps
 
 ```yml
 - name: Run E2E tests

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ jobs:
 
 The workflow file [example-basic.yml](.github/workflows/example-basic.yml) shows how Cypress runs on GH Actions using Ubuntu (20 and 22), Windows, and macOS without additional OS dependencies necessary.
 
-This workflow uses the default [test type](https://on.cypress.io/choosing-testing-type) of [End-to-End (E2E) Testing](https://docs.cypress.io/app/core-concepts/testing-types#What-is-E2E-Testing). Alternatively, [Component Testing](https://docs.cypress.io/app/core-concepts/testing-types#What-is-Component-Testing) can be utilized by referencing the [Component Testing](#component-testing) section below.
+This workflow uses the default [test type](https://on.cypress.io/choosing-testing-type) of [End-to-End (E2E) Testing](https://on.cypress.io/app/core-concepts/testing-types#What-is-E2E-Testing). Alternatively, [Component Testing](https://on.cypress.io/app/core-concepts/testing-types#What-is-Component-Testing) can be utilized by referencing the [Component Testing](#component-testing) section below.
 
 ### Component Testing
 


### PR DESCRIPTION
## Issue

Some links to https://on.cypress.io/, used in the [README](https://github.com/cypress-io/github-action/blob/master/README.md) document, no longer bring up the intended content.

The site https://docs.cypress.io/ was restructured in October 2024 and the use of https://on.cypress.io/ links has not redirected all links to approprate replacement content.

## Change

In the [README](https://github.com/cypress-io/github-action/blob/master/README.md) document, replace links to https://on.cypress.io/ that are not showing required content, using either other https://on.cypress.io/ links or instead https://docs.cypress.io/ with appropriate pages and bookmarks.

## Verification

```shell
npm ci
npx markdown-link-check README.md
```
