### PR TITLE
docs: make README bookmark internal links relative

### DIFF
--- a/README.md
+++ b/README.md
@@ -1669,7 +1669,7 @@ and is generally aligned with [Node.js's release schedule](https://github.com/no
 
 ### Usage
 
-`github-action` command-type options such as [`install-command`](https://github.com/cypress-io/github-action#custom-install-command), [`build`](https://github.com/cypress-io/github-action#build-app), [`start`](https://github.com/cypress-io/github-action#start-server) and [`command`](https://github.com/cypress-io/github-action#custom-test-command) are executed with the runner's version of Node.js. You can use GitHub's [actions/setup-node](https://github.com/actions/setup-node) to install an explicit Node.js version into the runner.
+`github-action` command-type options such as [`install-command`](#custom-install-command), [`build`](#build-app), [`start`](#start-server) and [`command`](#custom-test-command) are executed with the runner's version of Node.js. You can use GitHub's [actions/setup-node](https://github.com/actions/setup-node) to install an explicit Node.js version into the runner.
 
 [![Node versions example](https://github.com/cypress-io/github-action/actions/workflows/example-node-versions.yml/badge.svg)](.github/workflows/example-node-versions.yml)
 


### PR DESCRIPTION
## Issue

Links in the [README > Usage](https://github.com/cypress-io/github-action/blob/master/README.md#usage) section, which refer to bookmarks in the same document, are using absolute URLs instead of relative ones.

This can cause the wrong information to be displayed when the README is accessed in a branch which is not the default `master` branch.

An example is https://github.com/cypress-io/github-action#custom-install-command

## Change

Convert absolute URLs to relative ones in the [README.md](https://github.com/cypress-io/github-action/blob/master/README.md) document, for links which refer to bookmarks in the README document itself.

For example, reduce

`https://github.com/cypress-io/github-action#custom-install-command`

to

`#custom-install-command`

## Verification

```shell
npm ci
npx markdown-link-check README.md
```
