### PR TITLE
ci: remove retiring ubuntu-20.04 from testing

### DIFF
--- a/.github/workflows/example-basic.yml
+++ b/.github/workflows/example-basic.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, ubuntu-22.04, ubuntu-24.04, windows-2022, macos-14]
+        os: [ubuntu-22.04, ubuntu-24.04, windows-2022, macos-14]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout


### PR DESCRIPTION
## Issue

[Ubuntu 20 image is closing down](https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#ubuntu-20-image-is-closing-down) in GitHub Actions.

The [blog post of Dec 5, 2024](https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#ubuntu-20-image-is-closing-down) announces:

> We are beginning the process of closing down the Ubuntu 20 hosted runner image, following our N-1 [OS support policy](https://github.com/actions/runner-images?tab=readme-ov-file#software-and-image-support). This image will be fully retired by April 1, 2025. We recommend updating workflows to use ubuntu-22.04, or ubuntu-24.04.

The workflow [.github/workflows/example-basic.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-basic.yml) includes `ubuntu-20.04` in its testing matrix.

(Other workflows are generally testing against `ubuntu-24.04`.)

## Change

Remove `ubuntu-20.04` from the testing matrix of workflow [.github/workflows/example-basic.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-basic.yml). This leaves the Ubuntu runners `ubuntu-22.04` and `ubuntu-24.04` in this workflow.