### PR TITLE
test(deps): update examples to pnpm 10

### DIFF
--- a/.github/workflows/example-basic-pnpm.yml
+++ b/.github/workflows/example-basic-pnpm.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 9
+          version: 10
 
         # See https://github.com/actions/setup-node
       - name: Install Node.js

--- a/.github/workflows/example-start-and-pnpm-workspaces.yml
+++ b/.github/workflows/example-start-and-pnpm-workspaces.yml
@@ -24,7 +24,7 @@ jobs:
 
         # pnpm is not installed by default on GitHub runners
       - name: Install pnpm
-        run: npm install -g pnpm@9
+        run: npm install -g pnpm@10
 
       - name: Install dependencies
         # with Cypress GitHub Action.
@@ -75,7 +75,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install pnpm
-        run: npm install -g pnpm@9
+        run: npm install -g pnpm@10
 
       - name: Install dependencies
         uses: ./ # approximately equivalent to using cypress-io/github-action@v6

--- a/README.md
+++ b/README.md
@@ -1142,7 +1142,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 9
+          version: 10
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:

--- a/examples/basic-pnpm/package.json
+++ b/examples/basic-pnpm/package.json
@@ -9,5 +9,8 @@
   "private": true,
   "devDependencies": {
     "cypress": "13.17.0"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": ["cypress"]
   }
 }

--- a/examples/start-and-pnpm-workspaces/package.json
+++ b/examples/start-and-pnpm-workspaces/package.json
@@ -2,5 +2,8 @@
   "name": "start-and-pnpm-workspaces",
   "version": "1.0.0",
   "description": "example using pnpm with workspaces",
-  "private": true
+  "private": true,
+  "pnpm": {
+    "onlyBuiltDependencies": ["cypress"]
+  }
 }


### PR DESCRIPTION
This PR updates the version of pnpm used in the workflows:

- [.github/workflows/example-basic-pnpm.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-basic-pnpm.yml)
- [.github/workflows/example-start-and-pnpm-workspaces.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-start-and-pnpm-workspaces.yml)

and in the

- [README > pnpm](https://github.com/cypress-io/github-action/blob/master/README.md#pnpm) section

from pnpm `9` to pnpm `10`.

[pnpm@10.0.0](https://github.com/pnpm/pnpm/releases/tag/v10.0.0) was released on Jan 7, 2025.

Additionally, the `package.json` files for

- [examples/basic-pnpm](https://github.com/cypress-io/github-action/tree/master/examples/basic-pnpm)
- [examples/start-and-pnpm-workspaces](https://github.com/cypress-io/github-action/tree/master/examples/start-and-pnpm-workspaces)

are updated with the following, since `pnpm@10` no longer executes the life cycle script to install the Cypress binary unless it is explicitly declared:

```json
  "pnpm": {
    "onlyBuiltDependencies": ["cypress"]
  }
```

## References

- [pnpm documentation](https://pnpm.io/)
- [pnpm 10.0.0 release](https://github.com/pnpm/pnpm/releases/tag/v10.0.0)

## Verification

### local

On Ubuntu `24.04.1` LTS
Use Node.js `v22.13.0` LTS

```shell
npm ci
npm install pnpm@10 -g
cd examples/basic-pnpm
pnpm install --frozen-lockfile
pnpm test
cd ../..
```

```shell
cd examples/start-and-pnpm-workspaces
pnpm install --frozen-lockfile
cd packages/workspace-1
pnpm start
```

In a separate terminal window set to `examples/start-and-pnpm-workspaces/packages/workspace-1`

```shell
pnpm test
```

kill server from workspace-1

repeat test for workspace-2
```shell
cd ../workspace-2
pnpm start
```

In a separate terminal window set to `examples/start-and-pnpm-workspaces/packages/workspace-2`

```shell
pnpm test
```
