### PR TITLE
fix(deps): update undici to 5.28.5

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -83494,6 +83494,14 @@ const { isUint8Array, isArrayBuffer } = __nccwpck_require__(9830)
 const { File: UndiciFile } = __nccwpck_require__(8511)
 const { parseMIMEType, serializeAMimeType } = __nccwpck_require__(685)
 
+let random
+try {
+  const crypto = __nccwpck_require__(6005)
+  random = (max) => crypto.randomInt(0, max)
+} catch {
+  random = (max) => Math.floor(Math.random(max))
+}
+
 let ReadableStream = globalThis.ReadableStream
 
 /** @type {globalThis['File']} */
@@ -83579,7 +83587,7 @@ function extractBody (object, keepalive = false) {
     // Set source to a copy of the bytes held by object.
     source = new Uint8Array(object.buffer.slice(object.byteOffset, object.byteOffset + object.byteLength))
   } else if (util.isFormDataLike(object)) {
-    const boundary = `----formdata-undici-0${`${Math.floor(Math.random() * 1e11)}`.padStart(11, '0')}`
+    const boundary = `----formdata-undici-0${`${random(1e11)}`.padStart(11, '0')}`
     const prefix = `--${boundary}\r\nContent-Disposition: form-data`
 
     /*! formdata-polyfill. MIT License. Jimmy Wärting <https://jimmy.warting.se/opensource> */
@@ -104832,6 +104840,14 @@ module.exports = require("https");
 
 "use strict";
 module.exports = require("net");
+
+/***/ }),
+
+/***/ 6005:
+/***/ ((module) => {
+
+"use strict";
+module.exports = require("node:crypto");
 
 /***/ }),
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2176,9 +2176,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "5.28.4",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.4.tgz",
-      "integrity": "sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==",
+      "version": "5.28.5",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.5.tgz",
+      "integrity": "sha512-zICwjrDrcrUE0pyyJc1I2QzBkLM8FINsgOrt6WjA+BgajVq9Nxu2PbFFXUrAggLfDXlZGZBVZYw7WNV5KiBiBA==",
       "license": "MIT",
       "dependencies": {
         "@fastify/busboy": "^2.0.0"


### PR DESCRIPTION
## Issue

Dependabot reports the vulnerability [CVE-2025-22150](https://github.com/advisories/GHSA-c76h-2ccp-4975) with Moderate severity in the transient dependency [undici@5.28.4](https://github.com/nodejs/undici/releases/tag/v5.28.4).

```text
$ npm ls undici
@cypress/github-action
└─┬ @actions/cache@4.0.0
  └─┬ @actions/http-client@2.2.3
    └── undici@5.28.4
```

## Change

Update to [undici@5.28.5](https://github.com/nodejs/undici/releases/tag/v5.28.5) by removing [undici@5.28.4](https://github.com/nodejs/undici/releases/tag/v5.28.4) from `package-lock.json`, deleting `node_modules` and running `npm install`.

This resolves the moderate severity vulnerability [CVE-2025-22150](https://github.com/advisories/GHSA-c76h-2ccp-4975).

## Related

- The vulnerability has also been reported in https://github.com/actions/toolkit/issues/1939. It should be easier than described above to update. `npm audit` does not yet detect this vulnerability.