### PR TITLE
test: set side-effects-cache=false for pnpm

### DIFF
--- a/README.md
+++ b/README.md
@@ -1128,7 +1128,7 @@ jobs:
 
 The package manager `pnpm` is not pre-installed in [GitHub Actions runner images](https://github.com/actions/runner-images) (unlike `npm` and `yarn`) and so it must be installed in a separate workflow step (see below). If the action finds a `pnpm-lock.yaml` file, it uses the [pnpm](https://pnpm.io/cli/install) command `pnpm install --frozen-lockfile` by default to install dependencies.
 
-The example below follows [pnpm recommendations](https://pnpm.io/continuous-integration#github-actions) for installing pnpm and caching the [pnpm store](https://pnpm.io/cli/store).
+The example below follows [pnpm recommendations](https://pnpm.io/continuous-integration#github-actions) for installing pnpm and caching the [pnpm store](https://pnpm.io/cli/store). Add [side-effects-cache=false](https://pnpm.io/npmrc#side-effects-cache) to an `.npmrc` file in your project to allow pnpm to install the Cypress binary even if the Cypress npm module has been cached by pnpm.
 
 ```yaml
 name: example-basic-pnpm

--- a/examples/basic-pnpm/.npmrc
+++ b/examples/basic-pnpm/.npmrc
@@ -1,0 +1,2 @@
+https://pnpm.io/npmrc#side-effects-cache
+side-effects-cache=false

--- a/examples/start-and-pnpm-workspaces/.npmrc
+++ b/examples/start-and-pnpm-workspaces/.npmrc
@@ -1,0 +1,2 @@
+https://pnpm.io/npmrc#side-effects-cache
+side-effects-cache=false


### PR DESCRIPTION
- closes https://github.com/cypress-io/github-action/issues/1363

## Issue

Caching the pnpm store with default settings leads pnpm to skip running the Cypress postinstall script if the Cypress npm module is already cached. This may lead to failures if the Cypress cache is lost or purged.

Workflows should never depend on the presence of particular caches. They should always be resilient to missing caches.

## Change

Add [side-effects-cache=false](https://pnpm.io/npmrc#side-effects-cache) using an `.npmrc` file to the:

- [README > pnpm](https://github.com/cypress-io/github-action/blob/master/README.md#pnpm) section
- [examples/basic-pnpm](https://github.com/cypress-io/github-action/tree/master/examples/basic-pnpm) project
- [examples/start-and-pnpm-workspaces](https://github.com/cypress-io/github-action/tree/master/examples/start-and-pnpm-workspaces) project

## Verification

1. Run workflow for [basic-pnpm](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-basic-pnpm.yml)
2. Delete Cypress caches `cypress-win23-*` / `cypress-darwin-*` / `cypress-linux-*` in the branch under test
3. Run workflow again and confirm that Cypress tests are run and are successful
