### PR TITLE
refactor: remove unused @actions/core from ping.js

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -100501,7 +100501,6 @@ function wrappy (fn, cb) {
 /***/ 9390:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-const core = __nccwpck_require__(2186)
 const got = __nccwpck_require__(3061)
 const debug = __nccwpck_require__(8237)('@cypress/github-action')
 

--- a/src/ping.js
+++ b/src/ping.js
@@ -1,4 +1,3 @@
-const core = require('@actions/core')
 const got = require('got')
 const debug = require('debug')('@cypress/github-action')
 


### PR DESCRIPTION
## Issue

Offline linting shows that the following code line is unused

https://github.com/cypress-io/github-action/blob/8c73325c9895fe38d7846f65923bd6e6cd487137/src/ping.js#L1

## Change

Remove `const core = require('@actions/core')` from [src/ping.js](https://github.com/cypress-io/github-action/blob/master/src/ping.js).
