### PR TITLE
 chore: fix results formatting for missing totalDuration

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -104947,7 +104947,7 @@ const generateSummary = async (testResults) => {
     `${testResults.totalFailed}`,
     `${testResults.totalPending}`,
     `${testResults.totalSkipped}`,
-    `${testResults.totalDuration / 1000}s` || ''
+    `${(testResults.totalDuration || 0) / 1000}s`
   ]
 
   const summaryTitle = core.getInput('summary-title')

--- a/index.js
+++ b/index.js
@@ -899,7 +899,7 @@ const generateSummary = async (testResults) => {
     `${testResults.totalFailed}`,
     `${testResults.totalPending}`,
     `${testResults.totalSkipped}`,
-    `${testResults.totalDuration / 1000}s` || ''
+    `${(testResults.totalDuration || 0) / 1000}s`
   ]
 
   const summaryTitle = core.getInput('summary-title')


### PR DESCRIPTION
## Issue

Offline linting shows a violation of the ESLint rule [no-constant-binary-expression](https://eslint.org/docs/latest/rules/no-constant-binary-expression) for

https://github.com/cypress-io/github-action/blob/8c73325c9895fe38d7846f65923bd6e6cd487137/index.js#L902

If `testResults.totalDuration` is undefined, then

``${testResults.totalDuration / 1000}s` || ''`

produces `NaNs` not an empty string.

## Change

If `testResults.totalDuration` is undefined, then fallback to default of displaying `0s`.