### PR TITLE
fix: Use correct baseUrl when running in non-public Github instances

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -93693,6 +93693,7 @@ const I = (x) => x
 
 const detectPrNumber = async () => {
   const {
+    GITHUB_API_URL,
     GITHUB_SHA,
     GITHUB_TOKEN,
     GITHUB_RUN_ID,
@@ -93718,7 +93719,8 @@ const detectPrNumber = async () => {
     )
 
     const client = new Octokit({
-      auth: GITHUB_TOKEN
+      auth: GITHUB_TOKEN,
+      baseUrl: GITHUB_API_URL
     })
 
     if (GITHUB_HEAD_REF) {

--- a/index.js
+++ b/index.js
@@ -438,6 +438,7 @@ const I = (x) => x
 
 const detectPrNumber = async () => {
   const {
+    GITHUB_API_URL,
     GITHUB_SHA,
     GITHUB_TOKEN,
     GITHUB_RUN_ID,
@@ -463,7 +464,8 @@ const detectPrNumber = async () => {
     )
 
     const client = new Octokit({
-      auth: GITHUB_TOKEN
+      auth: GITHUB_TOKEN,
+      baseUrl: GITHUB_API_URL
     })
 
     if (GITHUB_HEAD_REF) {


### PR DESCRIPTION
# Issue? 
When running the action against a non-public GH instance, the api request to determine build-id from Github would fail. 

> Bad Credentials

I believe this is due to the incorrect (public) GH instance being contacted.

# How? 
The fix uses: 
- the `baseUrl` constuctor option of Octokit: https://github.com/octokit/octokit.js/blob/main/README.md#constructor-options
- the available `GITHUB_API_URL` environment variable: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables#default-environment-variables