### PR TITLE
chore: extend linting to cypress examples

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,11 +1,16 @@
 import globals from 'globals'
 import pluginJs from '@eslint/js'
+import pluginCypress from 'eslint-plugin-cypress/flat'
 
 export default [
   pluginJs.configs.recommended,
-  { name: 'global-ignores', ignores: ['dist/', 'examples/'] },
+  pluginCypress.configs.recommended,
   {
-    name: `all-js`,
+    name: 'global-ignores',
+    ignores: ['dist/', 'examples/nextjs/src/app/']
+  },
+  {
+    name: 'all-js',
     languageOptions: {
       globals: {
         ...globals.browser,

--- a/examples/basic-pnpm/cypress.config.js
+++ b/examples/basic-pnpm/cypress.config.js
@@ -3,7 +3,6 @@ const { defineConfig } = require('cypress')
 module.exports = defineConfig({
   fixturesFolder: false,
   e2e: {
-    setupNodeEvents(on, config) {},
     supportFile: false,
   },
 })

--- a/examples/basic/cypress.config.js
+++ b/examples/basic/cypress.config.js
@@ -3,7 +3,6 @@ const { defineConfig } = require('cypress')
 module.exports = defineConfig({
   fixturesFolder: false,
   e2e: {
-    setupNodeEvents(on, config) {},
     supportFile: false,
   },
 })

--- a/examples/browser/cypress.config.js
+++ b/examples/browser/cypress.config.js
@@ -4,7 +4,7 @@ const os = require('os')
 module.exports = defineConfig({
   fixturesFolder: false,
   e2e: {
-    setupNodeEvents(on, config) {
+    setupNodeEvents(on) {
       on('before:browser:launch', (browser, launchOptions) => {
         console.log('before launching browser')
         console.log(browser)

--- a/examples/config/cypress.config-alternate.js
+++ b/examples/config/cypress.config-alternate.js
@@ -4,7 +4,7 @@ module.exports = defineConfig({
   fixturesFolder: false,
   e2e: {
     baseUrl: 'http://localhost:3333',
-    setupNodeEvents(on, config) {
+    setupNodeEvents() {
       console.log('\nUsing cypress.config-alternate.js config-file')
     },
     supportFile: false

--- a/examples/config/cypress.config.js
+++ b/examples/config/cypress.config.js
@@ -3,7 +3,6 @@ const { defineConfig } = require('cypress')
 module.exports = defineConfig({
   fixturesFolder: false,
   e2e: {
-    setupNodeEvents(on, config) {},
     supportFile: false,
   },
 })

--- a/examples/custom-command/cypress.config.js
+++ b/examples/custom-command/cypress.config.js
@@ -3,7 +3,6 @@ const { defineConfig } = require('cypress')
 module.exports = defineConfig({
   fixturesFolder: false,
   e2e: {
-    setupNodeEvents(on, config) {},
     supportFile: false,
   },
 })

--- a/examples/install-command/cypress.config.js
+++ b/examples/install-command/cypress.config.js
@@ -3,7 +3,6 @@ const { defineConfig } = require('cypress')
 module.exports = defineConfig({
   fixturesFolder: false,
   e2e: {
-    setupNodeEvents(on, config) {},
     supportFile: false,
     baseUrl: 'https://example.cypress.io/',
   },

--- a/examples/install-only/cypress.config.js
+++ b/examples/install-only/cypress.config.js
@@ -3,7 +3,6 @@ const { defineConfig } = require('cypress')
 module.exports = defineConfig({
   fixturesFolder: false,
   e2e: {
-    setupNodeEvents(on, config) {},
     supportFile: false,
     baseUrl: 'https://example.cypress.io/',
   },

--- a/examples/node-versions/cypress.config.js
+++ b/examples/node-versions/cypress.config.js
@@ -3,7 +3,6 @@ const { defineConfig } = require('cypress')
 module.exports = defineConfig({
   fixturesFolder: false,
   e2e: {
-    setupNodeEvents(on, config) {},
     supportFile: false,
   },
 })

--- a/examples/quiet/cypress.config.js
+++ b/examples/quiet/cypress.config.js
@@ -3,7 +3,7 @@ const { defineConfig } = require('cypress')
 module.exports = defineConfig({
   fixturesFolder: false,
   e2e: {
-    setupNodeEvents(on, config) {
+    setupNodeEvents(on) {
       on('task', {
         log(message) {
           console.log(message)

--- a/examples/recording/cypress.config.js
+++ b/examples/recording/cypress.config.js
@@ -4,7 +4,6 @@ module.exports = defineConfig({
   fixturesFolder: false,
   projectId: '3tb7jn',
   e2e: {
-    setupNodeEvents(on, config) {},
     supportFile: false,
   },
 })

--- a/examples/recording/cypress/e2e/spec-a.cy.js
+++ b/examples/recording/cypress/e2e/spec-a.cy.js
@@ -1,4 +1,5 @@
 it('spec-A works', () => {
   expect(42).to.equal(21 + 21)
+  // eslint-disable-next-line cypress/no-unnecessary-waiting
   cy.visit('https://example.cypress.io').wait(2000)
 })

--- a/examples/recording/cypress/e2e/spec-b.cy.js
+++ b/examples/recording/cypress/e2e/spec-b.cy.js
@@ -1,4 +1,5 @@
 it('spec-B works', () => {
   expect(42).to.equal(21 + 21)
+  // eslint-disable-next-line cypress/no-unnecessary-waiting
   cy.visit('https://example.cypress.io').wait(5000)
 })

--- a/examples/recording/cypress/e2e/spec-c.cy.js
+++ b/examples/recording/cypress/e2e/spec-c.cy.js
@@ -1,4 +1,5 @@
 it('spec-C works', () => {
   expect(42).to.equal(21 + 21)
+  // eslint-disable-next-line cypress/no-unnecessary-waiting
   cy.visit('https://example.cypress.io').wait(4000)
 })

--- a/examples/recording/cypress/e2e/spec-d.cy.js
+++ b/examples/recording/cypress/e2e/spec-d.cy.js
@@ -1,4 +1,5 @@
 it('spec-D works', () => {
   expect(42).to.equal(21 + 21)
+  // eslint-disable-next-line cypress/no-unnecessary-waiting
   cy.visit('https://example.cypress.io').wait(3600)
 })

--- a/examples/start-and-pnpm-workspaces/packages/workspace-1/cypress.config.js
+++ b/examples/start-and-pnpm-workspaces/packages/workspace-1/cypress.config.js
@@ -3,7 +3,6 @@ const { defineConfig } = require('cypress')
 module.exports = defineConfig({
   fixturesFolder: false,
   e2e: {
-    setupNodeEvents(on, config) {},
     supportFile: false,
     baseUrl: 'http://localhost:5000',
   },

--- a/examples/start-and-pnpm-workspaces/packages/workspace-2/cypress.config.js
+++ b/examples/start-and-pnpm-workspaces/packages/workspace-2/cypress.config.js
@@ -3,7 +3,6 @@ const { defineConfig } = require('cypress')
 module.exports = defineConfig({
   fixturesFolder: false,
   e2e: {
-    setupNodeEvents(on, config) {},
     supportFile: false,
     baseUrl: 'http://localhost:5000',
   },

--- a/examples/start-and-yarn-workspaces/workspace-1/cypress.config.js
+++ b/examples/start-and-yarn-workspaces/workspace-1/cypress.config.js
@@ -3,7 +3,6 @@ const { defineConfig } = require('cypress')
 module.exports = defineConfig({
   fixturesFolder: false,
   e2e: {
-    setupNodeEvents(on, config) {},
     supportFile: false,
     baseUrl: 'http://localhost:5000',
   },

--- a/examples/start-and-yarn-workspaces/workspace-2/cypress.config.js
+++ b/examples/start-and-yarn-workspaces/workspace-2/cypress.config.js
@@ -3,7 +3,6 @@ const { defineConfig } = require('cypress')
 module.exports = defineConfig({
   fixturesFolder: false,
   e2e: {
-    setupNodeEvents(on, config) {},
     supportFile: false,
     baseUrl: 'http://localhost:5000',
   },

--- a/examples/start/cypress.config.js
+++ b/examples/start/cypress.config.js
@@ -3,7 +3,6 @@ const { defineConfig } = require('cypress')
 module.exports = defineConfig({
   fixturesFolder: false,
   e2e: {
-    setupNodeEvents(on, config) {},
     supportFile: false,
     baseUrl: 'http://localhost:3000',
   },

--- a/examples/wait-on-vite/cypress.config.js
+++ b/examples/wait-on-vite/cypress.config.js
@@ -3,7 +3,6 @@ const { defineConfig } = require('cypress')
 module.exports = defineConfig({
   fixturesFolder: false,
   e2e: {
-    setupNodeEvents(on, config) {},
     supportFile: false,
     baseUrl: 'http://localhost:5173',
   },

--- a/examples/wait-on/cypress.config.js
+++ b/examples/wait-on/cypress.config.js
@@ -3,7 +3,6 @@ const { defineConfig } = require('cypress')
 module.exports = defineConfig({
   fixturesFolder: false,
   e2e: {
-    setupNodeEvents(on, config) {},
     supportFile: false,
     baseUrl: 'http://localhost:3050',
   },

--- a/examples/webpack/cypress.config.js
+++ b/examples/webpack/cypress.config.js
@@ -3,7 +3,6 @@ const { defineConfig } = require('cypress')
 module.exports = defineConfig({
   fixturesFolder: false,
   e2e: {
-    setupNodeEvents(on, config) {},
     supportFile: false,
     baseUrl: 'http://localhost:8080',
   },

--- a/examples/yarn-classic/cypress.config.js
+++ b/examples/yarn-classic/cypress.config.js
@@ -3,7 +3,6 @@ const { defineConfig } = require('cypress')
 module.exports = defineConfig({
   fixturesFolder: false,
   e2e: {
-    setupNodeEvents(on, config) {},
     supportFile: false,
     baseUrl: 'https://example.cypress.io/',
   },

--- a/examples/yarn-modern-pnp/cypress.config.js
+++ b/examples/yarn-modern-pnp/cypress.config.js
@@ -3,7 +3,6 @@ const { defineConfig } = require('cypress')
 module.exports = defineConfig({
   fixturesFolder: false,
   e2e: {
-    setupNodeEvents(on, config) {},
     supportFile: false,
     baseUrl: 'https://example.cypress.io/',
   },

--- a/examples/yarn-modern/cypress.config.js
+++ b/examples/yarn-modern/cypress.config.js
@@ -3,7 +3,6 @@ const { defineConfig } = require('cypress')
 module.exports = defineConfig({
   fixturesFolder: false,
   e2e: {
-    setupNodeEvents(on, config) {},
     supportFile: false,
     baseUrl: 'https://example.cypress.io/',
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "@types/node": "22.13.5",
         "@vercel/ncc": "0.38.1",
         "eslint": "9.21.0",
+        "eslint-plugin-cypress": "4.1.0",
         "globals": "16.0.0",
         "husky": "9.1.7",
         "markdown-link-check": "3.13.6",
@@ -1674,6 +1675,32 @@
         "jiti": {
           "optional": true
         }
+      }
+    },
+    "node_modules/eslint-plugin-cypress": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-cypress/-/eslint-plugin-cypress-4.1.0.tgz",
+      "integrity": "sha512-JhqkMY02mw74USwK9OFhectx3YSj6Co1NgWBxlGdKvlqiAp9vdEuQqt33DKGQFvvGS/NWtduuhWXWNnU29xDSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "globals": "^15.11.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=9"
+      }
+    },
+    "node_modules/eslint-plugin-cypress/node_modules/globals": {
+      "version": "15.15.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-15.15.0.tgz",
+      "integrity": "sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/eslint-scope": {

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "@types/node": "22.13.5",
     "@vercel/ncc": "0.38.1",
     "eslint": "9.21.0",
+    "eslint-plugin-cypress": "4.1.0",
     "globals": "16.0.0",
     "husky": "9.1.7",
     "markdown-link-check": "3.13.6",


### PR DESCRIPTION
## Situation

- The core ESLint JavaScript linting, added through PR https://github.com/cypress-io/github-action/pull/1370, excludes [examples](https://github.com/cypress-io/github-action/tree/master/examples).

## Change

- Remove the linting exclusion from [examples](https://github.com/cypress-io/github-action/tree/master/examples) and limit this to the third-party generated [examples/nextjs/src/app/](https://github.com/cypress-io/github-action/tree/master/examples/nextjs/src/app) directory.

- Add linting using [eslint-plugin-cypress](https://www.npmjs.com/package/eslint-plugin-cypress) using the recommended rules.

- Disable the lint rule [cypress/no-unnecessary-waiting](https://github.com/cypress-io/eslint-plugin-cypress/blob/HEAD/docs/rules/no-unnecessary-waiting.md) applied to [.wait()](https://docs.cypress.io/api/commands/wait) in examples where it is  being used for demonstration purposes.

- Remove unused parameters of [setupNodeEvents()](https://docs.cypress.io/api/node-events/overview#setupNodeEvents) or remove the complete usage if the function call is empty.

## Verify

```shell
npm ci
npm run lint
```

and confirm that no linting errors are reported.