### PR TITLE
test: add yarn modern caching

### DIFF
--- a/.github/workflows/example-yarn-modern-pnp.yml
+++ b/.github/workflows/example-yarn-modern-pnp.yml
@@ -14,6 +14,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - run: corepack enable yarn # experimental - see https://nodejs.org/docs/latest/api/corepack.html
+      - name: Set up Yarn cache
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.node-version'
+          cache: yarn
+          cache-dependency-path: examples/yarn-modern-pnp/yarn.lock
       - name: Custom Yarn command
         uses: ./
         with:

--- a/.github/workflows/example-yarn-modern.yml
+++ b/.github/workflows/example-yarn-modern.yml
@@ -14,6 +14,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - run: corepack enable yarn # experimental - see https://nodejs.org/docs/latest/api/corepack.html
+      - name: Set up Yarn cache
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.node-version'
+          cache: yarn
+          cache-dependency-path: examples/yarn-modern/yarn.lock
       - name: Custom Yarn command
         uses: ./
         with:

--- a/README.md
+++ b/README.md
@@ -1204,7 +1204,9 @@ jobs:
 
 ### Yarn Modern
 
-To install dependencies using a `yarn.lock` file from [Yarn Modern](https://yarnpkg.com/) (Yarn 2 and later) you need to override the default [Yarn 1 (Classic)](https://classic.yarnpkg.com/) installation command `yarn --frozen-lockfile`. You can do this by using the `install-command` parameter and specifying `yarn install` for example:
+To install dependencies using a `yarn.lock` file from [Yarn Modern](https://yarnpkg.com/) (Yarn 2 and later) you need to override the default [Yarn 1 (Classic)](https://classic.yarnpkg.com/) installation command `yarn --frozen-lockfile`. You can do this by using the `install-command` parameter and specifying `yarn install` as in the example below.
+
+The action supports built-in caching of Yarn Classic dependencies only. To cache Yarn Modern dependencies additionally use [actions/setup-node](https://github.com/actions/setup-node) and specify `cache: yarn`.
 
 ```yaml
 name: example-yarn-modern
@@ -1215,6 +1217,13 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - run: corepack enable # (experimental and optional)
+      - name: Set up Yarn cache
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: yarn
+          cache-dependency-path: examples/yarn-modern/yarn.lock
       - name: Cypress run
         uses: cypress-io/github-action@v6
         with:
@@ -1230,6 +1239,8 @@ This example covers the [`.yarnrc.yml`](https://yarnpkg.com/configuration/yarnrc
 ### Yarn Plug'n'Play
 
 When using [Yarn Modern](https://yarnpkg.com/) (Yarn 2 and later) with [Plug'n'Play](https://yarnpkg.com/features/pnp) enabled, you will need to use the `command` parameter to run [`yarn`](https://yarnpkg.com/cli/run) instead of [`npx`](https://docs.npmjs.com/cli/v9/commands/npx).
+
+See the above [Yarn Modern](#yarn-modern) section for information on caching Yarn Modern dependencies.
 
 ```yaml
 name: example-yarn-modern-pnp


### PR DESCRIPTION
## Situation

If `cypress-io/github-action` detects `yarn.lock` it assumes that Yarn v1 Classic is being used and designates `~/.cache/yarn` as the cache folder.

`yarn.lock` is used by both Yarn v1 Classic and by Yarn Modern.

In the case of Yarn Modern, executing `yarn config get cacheFolder` on Linux shows that the cache is located in `~/.yarn/berry/cache`.

`~/.cache/yarn` is the wrong folder for Yarn Modern. `~/.yarn/berry/cache` is the correct folder to use for Yarn Modern.

## Change

For the Yarn Modern examples add [actions/setup-node](https://github.com/actions/setup-node), which offers the built-in optional functionality of caching npm/yarn/pnpm dependencies. It supports Yarn 1 Classic and Yarn Modern.

Workflows:

- [.github/workflows/example-yarn-modern.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-yarn-modern.yml)
- [.github/workflows/example-yarn-modern-pnp.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-yarn-modern-pnp.yml)

README sections

- [Yarn Modern](https://github.com/cypress-io/github-action/blob/master/README.md#yarn-modern)
- [Yarn Plug'n'Play](https://github.com/cypress-io/github-action/blob/master/README.md#yarn-plugnplay)

## Verification

Run workflows manually:

- [.github/workflows/example-yarn-modern.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-yarn-modern.yml)
- [.github/workflows/example-yarn-modern-pnp.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-yarn-modern-pnp.yml)

Check cache for presence of the following, for each of the above two workflows:

```text
cypress-linux-x64*
node-cache-Linux-x64-cache*
```
