### PR TITLE
docs: add resultsurl restriction for command-prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1515,7 +1515,7 @@ If you configure a `workflow_dispatch` event in your own workflows, you will be 
 
 ### Outputs
 
-This action sets a GitHub step output `resultsUrl` if the run was recorded on [Cypress Cloud](https://on.cypress.io/cloud-introduction) using the action parameter setting `record: true` (see [Record test results on Cypress Cloud](#record-test-results-on-cypress-cloud)). Note that using a [Custom test command](#custom-test-command) with the `command` parameter overrides the `record` parameter and in this case no `resultsUrl` step output is saved.
+This action sets a GitHub step output `resultsUrl` if the run was recorded on [Cypress Cloud](https://on.cypress.io/cloud-introduction) using the action parameter setting `record: true` (see [Record test results on Cypress Cloud](#record-test-results-on-cypress-cloud)). Note that if a custom test command with the [command](#custom-test-command) option or the [command-prefix](#command-prefix) option are used then no `resultsUrl` step output is saved.
 
 This is an example of using the step output `resultsUrl`:
 


### PR DESCRIPTION
- closes #1377

## Change

Added [command-prefix](https://github.com/cypress-io/github-action/blob/master/README.md#command-prefix) to the restrictions for using `resultsUrl` in the [README > Outputs](https://github.com/cypress-io/github-action/blob/master/README.md#outputs) section.

In this case Cypress is not run using the [Cypress Module API](https://docs.cypress.io/app/references/module-api) and therefore `resultsUrl` is not available.

https://github.com/cypress-io/github-action/blob/master/README.md#outputs
