### PR TITLE
ci: enable eslint linting

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
       - run: npm ci
       - run: npm run format
       - run: npm run build
-      - run: npm test
+      - run: npm run lint
 
   release:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
## Change

- Add `npm run lint` (which executes `npx eslint`) to [.github/workflows/main.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/main.yml)

- Remove `npm run test` which runs the unneeded default script `"test": "echo \"There are no tests :(\""`