### PR TITLE
test: remove default video: false configuration item

### DIFF
--- a/examples/browser/cypress.config.js
+++ b/examples/browser/cypress.config.js
@@ -27,6 +27,5 @@ module.exports = defineConfig({
       })
     },
     supportFile: false,
-    video: false
   },
 })

--- a/examples/component-tests/cypress.config.js
+++ b/examples/component-tests/cypress.config.js
@@ -1,7 +1,6 @@
 import { defineConfig } from "cypress";
 
 export default defineConfig({
-  video: false,
   component: {
     devServer: {
       framework: "react",


### PR DESCRIPTION
## Situation

[Migrating to Cypress 13.0](https://docs.cypress.io/app/references/migration-guide#Migrating-to-Cypress-130) lists the change that [`video` is set to `false` by default](https://docs.cypress.io/app/references/migration-guide#video-is-set-to-false-by-default).

Two config files in the [examples](https://github.com/cypress-io/github-action/tree/master/examples) directories continue to set:

```js
video: false
```

although this is now a redundant setting.

## Change

Remove `video: false` settings from config files in the [examples](https://github.com/cypress-io/github-action/tree/master/examples) directories.