### PR TITLE
test: extend cypress examples linting to javascript styles

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,4 @@
 /LICENSE.md
+
+examples/**/*.js
+examples/**/*.?js

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,6 +1,7 @@
 import globals from 'globals'
 import pluginJs from '@eslint/js'
 import pluginCypress from 'eslint-plugin-cypress/flat'
+import stylistic from '@stylistic/eslint-plugin'
 
 export default [
   pluginJs.configs.recommended,
@@ -16,6 +17,17 @@ export default [
         ...globals.browser,
         ...globals.node
       }
+    }
+  },
+  {
+    name: 'examples-style',
+    files: ['examples/**/*.js'],
+    ...stylistic.configs.recommended,
+    rules: {
+      '@stylistic/indent': ['error', 2],
+      '@stylistic/comma-dangle': ['error', 'always-multiline'],
+      '@stylistic/quotes': ['error', 'single'],
+      '@stylistic/semi': ['error', 'never'],
     }
   }
 ]

--- a/examples/browser/cypress.config.js
+++ b/examples/browser/cypress.config.js
@@ -23,7 +23,7 @@ module.exports = defineConfig({
         log(message) {
           console.log(message)
           return null
-        }
+        },
       })
     },
     supportFile: false,

--- a/examples/browser/cypress/e2e/spec.cy.js
+++ b/examples/browser/cypress/e2e/spec.cy.js
@@ -13,10 +13,10 @@ it('works', () => {
   // log the top window's dimensions
   const resolution = Cypress._.pick(top, [
     'innerWidth',
-    'innerHeight'
+    'innerHeight',
   ])
   cy.task(
     'log',
-    `top window inner w, h is ${resolution.innerWidth}x${resolution.innerHeight}`
+    `top window inner w, h is ${resolution.innerWidth}x${resolution.innerHeight}`,
   )
 })

--- a/examples/component-tests/cypress.config.js
+++ b/examples/component-tests/cypress.config.js
@@ -1,10 +1,10 @@
-import { defineConfig } from "cypress";
+import { defineConfig } from 'cypress'
 
 export default defineConfig({
   component: {
     devServer: {
-      framework: "react",
-      bundler: "vite",
+      framework: 'react',
+      bundler: 'vite',
     },
   },
-});
+})

--- a/examples/config/cypress.config-alternate.js
+++ b/examples/config/cypress.config-alternate.js
@@ -7,6 +7,6 @@ module.exports = defineConfig({
     setupNodeEvents() {
       console.log('\nUsing cypress.config-alternate.js config-file')
     },
-    supportFile: false
+    supportFile: false,
   },
 })

--- a/examples/config/cypress/e2e/spec-a.cy.js
+++ b/examples/config/cypress/e2e/spec-a.cy.js
@@ -2,7 +2,7 @@
 describe('Example config A', () => {
   it('has baseUrl', () => {
     expect(Cypress.config('baseUrl')).to.equal(
-      'http://localhost:3333'
+      'http://localhost:3333',
     )
   })
 

--- a/examples/config/cypress/e2e/spec-b.cy.js
+++ b/examples/config/cypress/e2e/spec-b.cy.js
@@ -2,7 +2,7 @@
 describe('Example config B', () => {
   it('has baseUrl', () => {
     expect(Cypress.config('baseUrl')).to.equal(
-      'http://localhost:3333'
+      'http://localhost:3333',
     )
   })
 

--- a/examples/custom-command/index.js
+++ b/examples/custom-command/index.js
@@ -6,13 +6,13 @@ const fs = require('fs')
 
 cypress.run().then(results => {
   const summary = _.pickBy(results, (value, key) =>
-    key.startsWith('total')
+    key.startsWith('total'),
   )
   console.log(summary)
   fs.writeFileSync(
     'results.json',
     JSON.stringify(summary, null, 2) + '\n',
-    'utf8'
+    'utf8',
   )
   console.log('saved file results.json')
 })

--- a/examples/env/cypress.config.js
+++ b/examples/env/cypress.config.js
@@ -7,7 +7,7 @@ module.exports = defineConfig({
       console.log('logging from cypress.config.js')
       console.log(
         'process.env.CYPRESS_environmentName',
-        process.env.CYPRESS_environmentName
+        process.env.CYPRESS_environmentName,
       )
       console.log('entire config.env', config.env)
     },

--- a/examples/env/cypress/e2e/spec.cy.js
+++ b/examples/env/cypress/e2e/spec.cy.js
@@ -2,23 +2,23 @@ it('has all expected env variables', () => {
   // environmentName is set as workflow environment variable
   // as a precaution we can confirm the variable was set
   expect(Cypress.env('environmentName'), 'environment').to.be.a(
-    'string'
+    'string',
   )
   // and we can confirm its value
   expect(
     Cypress.env('environmentName'),
-    'environment name is staging'
+    'environment name is staging',
   ).to.equal('staging')
 
   // host and port are set via action's "with: env:" parameter
   expect(Cypress.env(), 'full env includes API info').to.deep.include(
     {
       host: 'http://api.dev.local',
-      apiPort: 4222
-    }
+      apiPort: 4222,
+    },
   )
   // we can confirm that host is an url
   expect(Cypress.env('host'), 'host is an URL').to.match(
-    /^https?:\/\//
+    /^https?:\/\//,
   )
 })

--- a/examples/env/cypress/e2e/without-env.cy.js
+++ b/examples/env/cypress/e2e/without-env.cy.js
@@ -2,6 +2,6 @@ it('has all expected env variables', () => {
   // environmentName is set as workflow environment variable
   expect(
     Cypress.env('environmentName'),
-    'has environment name'
+    'has environment name',
   ).to.equal('staging')
 })

--- a/examples/nextjs/cypress.config.js
+++ b/examples/nextjs/cypress.config.js
@@ -1,4 +1,4 @@
-const { defineConfig } = require("cypress");
+const { defineConfig } = require('cypress')
 
 module.exports = defineConfig({
   fixturesFolder: false,
@@ -6,4 +6,4 @@ module.exports = defineConfig({
     supportFile: false,
     baseUrl: 'http://localhost:3000',
   },
-});
+})

--- a/examples/quiet/cypress.config.js
+++ b/examples/quiet/cypress.config.js
@@ -8,7 +8,7 @@ module.exports = defineConfig({
         log(message) {
           console.log(message)
           return null
-        }
+        },
       })
     },
     supportFile: false,

--- a/examples/quiet/cypress/e2e/spec.cy.js
+++ b/examples/quiet/cypress/e2e/spec.cy.js
@@ -13,10 +13,10 @@ it('works', () => {
   // log the top window's dimensions
   const resolution = Cypress._.pick(top, [
     'innerWidth',
-    'innerHeight'
+    'innerHeight',
   ])
   cy.task(
     'log',
-    `top window inner w, h is ${resolution.innerWidth}x${resolution.innerHeight}`
+    `top window inner w, h is ${resolution.innerWidth}x${resolution.innerHeight}`,
   )
 })

--- a/examples/wait-on/index.js
+++ b/examples/wait-on/index.js
@@ -9,7 +9,7 @@ const arg = require('arg')
 
 const args = arg({
   '--port': Number,
-  '--delay': Number
+  '--delay': Number,
 })
 const port = args['--port'] || 3050
 const createServerAfterSeconds = args['--delay'] || 7
@@ -17,7 +17,7 @@ const createServerAfterSeconds = args['--delay'] || 7
 log(
   'starting the server at port %d after %d seconds',
   port,
-  createServerAfterSeconds
+  createServerAfterSeconds,
 )
 
 setTimeout(function () {

--- a/examples/wait-on/index2.js
+++ b/examples/wait-on/index2.js
@@ -9,7 +9,7 @@ const arg = require('arg')
 
 const args = arg({
   '--port': Number,
-  '--delay': Number
+  '--delay': Number,
 })
 const port = args['--port'] || 3050
 const errorPeriodSeconds = args['--delay'] || 10

--- a/examples/wait-on/index3.js
+++ b/examples/wait-on/index3.js
@@ -9,7 +9,7 @@ const arg = require('arg')
 
 const args = arg({
   '--port': Number,
-  '--delay': Number
+  '--delay': Number,
 })
 const port = args['--port'] || 3050
 const errorPeriodSeconds = args['--delay'] || 40

--- a/examples/wait-on/index4.js
+++ b/examples/wait-on/index4.js
@@ -8,7 +8,7 @@ const http = require('http')
 const arg = require('arg')
 
 const args = arg({
-  '--port': Number
+  '--port': Number,
 })
 const port = args['--port'] || 3050
 

--- a/examples/webpack/webpack.config.js
+++ b/examples/webpack/webpack.config.js
@@ -3,12 +3,12 @@ module.exports = {
   entry: './src/index.js',
   output: {
     filename: 'bundle.js',
-    path: path.resolve(__dirname, 'dist')
+    path: path.resolve(__dirname, 'dist'),
   },
   devServer: {
     static: {
-      directory:  __dirname
-    }
+      directory:  __dirname,
+    },
   },
-  mode: 'development'
+  mode: 'development',
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
       },
       "devDependencies": {
         "@eslint/js": "9.21.0",
+        "@stylistic/eslint-plugin": "4.2.0",
         "@types/node": "22.13.5",
         "@vercel/ncc": "0.38.1",
         "eslint": "9.21.0",
@@ -617,6 +618,44 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/@octokit/auth-token": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-5.1.2.tgz",
@@ -829,6 +868,157 @@
         "url": "https://github.com/sindresorhus/is?sponsor=1"
       }
     },
+    "node_modules/@stylistic/eslint-plugin": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin/-/eslint-plugin-4.2.0.tgz",
+      "integrity": "sha512-8hXezgz7jexGHdo5WN6JBEIPHCSFyyU4vgbxevu4YLVS5vl+sxqAAGyXSzfNDyR6xMNSH5H1x67nsXcYMOHtZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/utils": "^8.23.0",
+        "eslint-visitor-keys": "^4.2.0",
+        "espree": "^10.3.0",
+        "estraverse": "^5.3.0",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=9.0.0"
+      }
+    },
+    "node_modules/@stylistic/eslint-plugin/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.25.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.25.0.tgz",
+      "integrity": "sha512-ZPaiAKEZ6Blt/TPAx5Ot0EIB/yGtLI2EsGoY6F7XKklfMxYQyvtL+gT/UCqkMzO0BVFHLDlzvFqQzurYahxv9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.25.0",
+        "@typescript-eslint/visitor-keys": "8.25.0",
+        "debug": "^4.3.4",
+        "fast-glob": "^3.3.2",
+        "is-glob": "^4.0.3",
+        "minimatch": "^9.0.4",
+        "semver": "^7.6.0",
+        "ts-api-utils": "^2.0.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <5.8.0"
+      }
+    },
+    "node_modules/@stylistic/eslint-plugin/node_modules/@typescript-eslint/utils": {
+      "version": "8.25.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.25.0.tgz",
+      "integrity": "sha512-syqRbrEv0J1wywiLsK60XzHnQe/kRViI3zwFALrNEgnntn1l24Ra2KvOAWwWbWZ1lBZxZljPDGOq967dsl6fkA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.4.0",
+        "@typescript-eslint/scope-manager": "8.25.0",
+        "@typescript-eslint/types": "8.25.0",
+        "@typescript-eslint/typescript-estree": "8.25.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <5.8.0"
+      }
+    },
+    "node_modules/@stylistic/eslint-plugin/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@stylistic/eslint-plugin/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@stylistic/eslint-plugin/node_modules/picomatch": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/@stylistic/eslint-plugin/node_modules/semver": {
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@stylistic/eslint-plugin/node_modules/ts-api-utils": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.0.1.tgz",
+      "integrity": "sha512-dnlgjFSVetynI8nzgJ+qF62efpglpWRk8isUEWZGWlJYySCTD6aKvbUDu+zbPeDakk3bg5H4XpitHukgfL1m9w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
+    "node_modules/@stylistic/eslint-plugin/node_modules/typescript": {
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
+      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/@szmarczak/http-timer": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
@@ -905,6 +1095,56 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.25.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.25.0.tgz",
+      "integrity": "sha512-6PPeiKIGbgStEyt4NNXa2ru5pMzQ8OYKO1hX1z53HMomrmiSB+R5FmChgQAP1ro8jMtNawz+TRQo/cSXrauTpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.25.0",
+        "@typescript-eslint/visitor-keys": "8.25.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.25.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.25.0.tgz",
+      "integrity": "sha512-+vUe0Zb4tkNgznQwicsvLUJgZIRs6ITeWSCclX1q85pR1iOiaj+4uZJIUp//Z27QWu5Cseiw3O3AR8hVpax7Aw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.25.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.25.0.tgz",
+      "integrity": "sha512-kCYXKAum9CecGVHGij7muybDfTS2sD3t0L4bJsEZLkyrXUImiCTq1M3LG2SRtOhiHFwMR9wAFplpT6XHYjTkwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.25.0",
+        "eslint-visitor-keys": "^4.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
       }
     },
     "node_modules/@vercel/ncc": {
@@ -1882,6 +2122,36 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -1912,6 +2182,16 @@
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/fastq": {
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
+      "integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
       }
     },
     "node_modules/file-entry-cache": {
@@ -2615,6 +2895,16 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/micromatch": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
@@ -3039,6 +3329,27 @@
         "node": ">=6"
       }
     },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/quick-lru": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
@@ -3083,6 +3394,41 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
       }
     },
     "node_modules/safe-buffer": {

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
   },
   "devDependencies": {
     "@eslint/js": "9.21.0",
+    "@stylistic/eslint-plugin": "4.2.0",
     "@types/node": "22.13.5",
     "@vercel/ncc": "0.38.1",
     "eslint": "9.21.0",


### PR DESCRIPTION
## Situation

- [ESLint](https://eslint.org/docs/) is already used to lint JavaScript files (see [eslint.config.mjs](https://github.com/cypress-io/github-action/blob/master/eslint.config.mjs) for configuration).

- JavaScript source files that are part of the core action are already formatted using [Prettier](https://prettier.io/).

- JavaScript source files in the [examples](https://github.com/cypress-io/github-action/tree/master/examples) directory are not yet linted for formatting.

- ESLint offers a consolidated plugin [@stylistic/eslint-plugin](https://eslint.style/) for Stylistic Formatting.

## Change

- Add linting using [@stylistic/eslint-plugin](https://eslint.style/) using its [recommended rules](https://github.com/eslint-stylistic/eslint-stylistic/blob/main/packages/eslint-plugin/rules.md) for the [examples](https://github.com/cypress-io/github-action/tree/master/examples) directory. Additionally use the following rules for alignment with [.prettierrc.json](https://github.com/cypress-io/github-action/blob/master/.prettierrc.json). In the case of the [comma-dangle](https://eslint.style/rules/default/comma-dangle) rule, this is aligned instead with the settings in [@cypress/eslint-plugin-dev](https://www.npmjs.com/package/@cypress/eslint-plugin-dev) since scaffolded Cypress config files are generated with dangling commas.

  ```js
  '@stylistic/indent': ['error', 2],
  '@stylistic/comma-dangle': ['error', 'always-multiline'],
  '@stylistic/quotes': ['error', 'single'],
  '@stylistic/semi': ['error', 'never'],
  ```

- Use `npx eslint --fix` on [examples](https://github.com/cypress-io/github-action/tree/master/examples) to move to consistent JavaScript formatting.

- Add JavaScript related files in the [examples](https://github.com/cypress-io/github-action/tree/master/examples) directory to [.prettierignore](https://prettier.io/docs/ignore) to avoid a management conflict between ESLint and Prettier. ESLint is responsible for formatting [examples](https://github.com/cypress-io/github-action/tree/master/examples), not Prettier.

## Verify

```shell
npm ci
npm run lint
```

and confirm that no linting errors are reported.

```shell
npx prettier --check examples/**/*.js
```

and confirm that:

- no `*.js` JavaScript files in the [examples](https://github.com/cypress-io/github-action/tree/master/examples) directory are being touched by Prettier
- no changes are being proposed by Prettier
