### PR TITLE
test: prettier format example yml workflows

### DIFF
--- a/.github/workflows/example-basic-pnpm.yml
+++ b/.github/workflows/example-basic-pnpm.yml
@@ -7,7 +7,6 @@ on:
   workflow_dispatch:
 
 jobs:
-
   basic-pnpm:
     strategy:
       fail-fast: false

--- a/.github/workflows/example-basic.yml
+++ b/.github/workflows/example-basic.yml
@@ -8,7 +8,6 @@ on:
   workflow_dispatch:
 
 jobs:
-
   basic:
     strategy:
       fail-fast: false

--- a/.github/workflows/example-chrome.yml
+++ b/.github/workflows/example-chrome.yml
@@ -7,7 +7,6 @@ on:
   workflow_dispatch:
 
 jobs:
-
   tests:
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/example-config.yml
+++ b/.github/workflows/example-config.yml
@@ -7,7 +7,6 @@ on:
   workflow_dispatch:
 
 jobs:
-
   start:
     # example where we pass custom base URL
     runs-on: ubuntu-24.04

--- a/.github/workflows/example-custom-ci-build-id.yml
+++ b/.github/workflows/example-custom-ci-build-id.yml
@@ -38,7 +38,6 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
-
   check-record-key:
     runs-on: ubuntu-24.04
     outputs:

--- a/.github/workflows/example-custom-command.yml
+++ b/.github/workflows/example-custom-command.yml
@@ -7,7 +7,6 @@ on:
   workflow_dispatch:
 
 jobs:
-
   start:
     # example where instead of forming the default "cypress run ..."
     # the user can specify their own command

--- a/.github/workflows/example-env.yml
+++ b/.github/workflows/example-env.yml
@@ -13,7 +13,6 @@ env:
   # see https://on.cypress.io/env
   CYPRESS_environmentName: staging
 jobs:
-
   e2e:
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/example-firefox.yml
+++ b/.github/workflows/example-firefox.yml
@@ -7,7 +7,6 @@ on:
   workflow_dispatch:
 
 jobs:
-
   firefox:
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/example-install-command.yml
+++ b/.github/workflows/example-install-command.yml
@@ -7,7 +7,6 @@ on:
   workflow_dispatch:
 
 jobs:
-
   install-command:
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/example-install-only.yml
+++ b/.github/workflows/example-install-only.yml
@@ -7,7 +7,6 @@ on:
   workflow_dispatch:
 
 jobs:
-
   # do not install every dependency in this example
   # just install Cypress, but make sure to cache it
   install-cypress-only:

--- a/.github/workflows/example-node-versions.yml
+++ b/.github/workflows/example-node-versions.yml
@@ -7,7 +7,6 @@ on:
   workflow_dispatch:
 
 jobs:
-
   cypress-run:
     runs-on: ubuntu-24.04
     # let's make sure Cypress works on several versions of Node

--- a/.github/workflows/example-quiet.yml
+++ b/.github/workflows/example-quiet.yml
@@ -7,7 +7,6 @@ on:
   workflow_dispatch:
 
 jobs:
-
   cypress-run:
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/example-recording.yml
+++ b/.github/workflows/example-recording.yml
@@ -20,7 +20,6 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
-
   check-record-key:
     runs-on: ubuntu-24.04
     outputs:

--- a/.github/workflows/example-start-and-pnpm-workspaces.yml
+++ b/.github/workflows/example-start-and-pnpm-workspaces.yml
@@ -7,8 +7,8 @@ on:
   workflow_dispatch:
 
 jobs:
-    # The example has pnpm workspaces in its "root" folder
-    # examples/start-and-pnpm-workspaces
+  # The example has pnpm workspaces in its "root" folder
+  # examples/start-and-pnpm-workspaces
 
   single-ws:
     # This job installs pnpm,

--- a/.github/workflows/example-start-and-yarn-workspaces.yml
+++ b/.github/workflows/example-start-and-yarn-workspaces.yml
@@ -7,7 +7,6 @@ on:
   workflow_dispatch:
 
 jobs:
-
   single:
     # the example has Yarn workspace in its "root" folder
     # examples/start-and-yarn-workspaces

--- a/.github/workflows/example-start.yml
+++ b/.github/workflows/example-start.yml
@@ -13,7 +13,6 @@ env:
   NO_UPDATE_CHECK: 1
 
 jobs:
-
   start:
     # example with web application build,
     # server start and waiting for the server

--- a/.github/workflows/example-wait-on.yml
+++ b/.github/workflows/example-wait-on.yml
@@ -7,7 +7,6 @@ on:
   workflow_dispatch:
 
 jobs:
-
   wait:
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/example-webpack.yml
+++ b/.github/workflows/example-webpack.yml
@@ -7,7 +7,6 @@ on:
   workflow_dispatch:
 
 jobs:
-
   wait:
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/example-yarn-classic.yml
+++ b/.github/workflows/example-yarn-classic.yml
@@ -7,7 +7,6 @@ on:
   workflow_dispatch:
 
 jobs:
-
   yarn-classic:
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/example-yarn-modern-pnp.yml
+++ b/.github/workflows/example-yarn-modern-pnp.yml
@@ -7,7 +7,6 @@ on:
   workflow_dispatch:
 
 jobs:
-
   yarn-modern-pnp:
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/example-yarn-modern.yml
+++ b/.github/workflows/example-yarn-modern.yml
@@ -7,7 +7,6 @@ on:
   workflow_dispatch:
 
 jobs:
-
   yarn-modern:
     runs-on: ubuntu-24.04
     steps:

--- a/.prettierignore
+++ b/.prettierignore
@@ -2,3 +2,4 @@
 
 examples/**/*.js
 examples/**/*.?js
+**/pnpm-lock.yaml


### PR DESCRIPTION
## Situation

- There are no linting or formatting checks carried out on `*.yml` workflow files which are included in the [.github/workflows](https://github.com/cypress-io/github-action/tree/master/.github/workflows) directory.

- [Prettier](https://prettier.io/docs/) supports [YAML](https://yaml.org/) formatting and is available for use in the repo.

## Change

To ensure consistent `YAML` workflow source formatting as part of an overall effort to increase linting coverage in the repo:

-Add [.prettierignore](https://github.com/cypress-io/github-action/blob/master/.prettierignore) exceptions for:
  - generated `pnpm-lock.yaml` files

- Use Prettier to re-format all `*.yml` workflows in the [.github/workflows](https://github.com/cypress-io/github-action/tree/master/.github/workflows) directory:

```shell
npx prettier --write ".github/workflows/**/*.yml"
```

The changes are to white-space only.