### PR TITLE
test: prettier format example json files

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,7 @@
 /LICENSE.md
+/renovate.json
 
 examples/**/*.js
 examples/**/*.?js
+**/package-lock.json
 **/pnpm-lock.yaml

--- a/examples/start-and-pnpm-workspaces/package.json
+++ b/examples/start-and-pnpm-workspaces/package.json
@@ -4,6 +4,8 @@
   "description": "example using pnpm with workspaces",
   "private": true,
   "pnpm": {
-    "onlyBuiltDependencies": ["cypress"]
+    "onlyBuiltDependencies": [
+      "cypress"
+    ]
   }
 }


### PR DESCRIPTION
## Situation

- There are no linting or formatting checks carried out on `*.json` files which are included in the [.github/workflows](https://github.com/cypress-io/github-action/tree/master/.github/workflows) directory.

- [Prettier](https://prettier.io/docs/) supports [JSON](https://www.json.org/json-en.html) formatting and is available for use in the repo.

## Change

To ensure consistent `JSON` source formatting as part of an overall effort to increase linting coverage in the repo:

- Add [.prettierignore](https://github.com/cypress-io/github-action/blob/master/.prettierignore) exceptions for:
  - generated `package-lock.json` files
  - [renovate.json](https://github.com/cypress-io/github-action/blob/master/renovate.json)

- Use Prettier to check all non-generated `*.json` files in the [examples](https://github.com/cypress-io/github-action/tree/master/examples) directory, and correct where necessary:

```shell
npx prettier --write examples/**/*.json
```