### PR TITLE
ci: self-lint eslint config style

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,4 @@
+/eslint.config.*js
 /LICENSE.md
 /renovate.json
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -8,26 +8,26 @@ export default [
   pluginCypress.configs.recommended,
   {
     name: 'global-ignores',
-    ignores: ['dist/', 'examples/nextjs/src/app/']
+    ignores: ['dist/', 'examples/nextjs/src/app/'],
   },
   {
     name: 'all-js',
     languageOptions: {
       globals: {
         ...globals.browser,
-        ...globals.node
-      }
-    }
+        ...globals.node,
+      },
+    },
   },
   {
-    name: 'examples-style',
-    files: ['examples/**/*.js'],
+    name: 'style',
+    files: ['eslint.config.mjs', 'examples/**/*.js'],
     ...stylistic.configs.recommended,
     rules: {
       '@stylistic/indent': ['error', 2],
       '@stylistic/comma-dangle': ['error', 'always-multiline'],
       '@stylistic/quotes': ['error', 'single'],
       '@stylistic/semi': ['error', 'never'],
-    }
-  }
+    },
+  },
 ]


### PR DESCRIPTION
## Issue

For styling consistency with the rest of the repo, [eslint.config.mjs](https://github.com/cypress-io/github-action/blob/master/eslint.config.mjs) should not be linted by Prettier.

## Change

- Add [eslint.config.mjs](https://github.com/cypress-io/github-action/blob/master/eslint.config.mjs) to [.prettierignore](https://github.com/cypress-io/github-action/blob/master/.prettierignore)

- Add [eslint.config.mjs](https://github.com/cypress-io/github-action/blob/master/eslint.config.mjs) with [@stylistic/eslint-plugin](https://www.npmjs.com/package/@stylistic/eslint-plugin) to itself

- Use `npx eslint eslint.config.mjs --fix` to fix trailing commas

## Verification

Execute the following and confirm that no errors are reported or changes suggested:

```shell
git clean -xfd
npm ci
npx eslint
npx prettier eslint.config.mjs --check # should be ignored
```
