### PR TITLE
fix: pass baseUrl into Octokit constructor

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -93785,7 +93785,8 @@ const getCiBuildId = async () => {
     GITHUB_SHA,
     GITHUB_TOKEN,
     GITHUB_RUN_ID,
-    GITHUB_REPOSITORY
+    GITHUB_REPOSITORY,
+    GITHUB_API_URL
   } = process.env
 
   const [owner, repo] = GITHUB_REPOSITORY.split('/')
@@ -93798,7 +93799,8 @@ const getCiBuildId = async () => {
     )
 
     const client = new Octokit({
-      auth: GITHUB_TOKEN
+      auth: GITHUB_TOKEN,
+      baseUrl: GITHUB_API_URL
     })
 
     const resp = await client.request(

--- a/index.js
+++ b/index.js
@@ -522,7 +522,8 @@ const getCiBuildId = async () => {
     GITHUB_SHA,
     GITHUB_TOKEN,
     GITHUB_RUN_ID,
-    GITHUB_REPOSITORY
+    GITHUB_REPOSITORY,
+    GITHUB_API_URL
   } = process.env
 
   const [owner, repo] = GITHUB_REPOSITORY.split('/')
@@ -535,7 +536,8 @@ const getCiBuildId = async () => {
     )
 
     const client = new Octokit({
-      auth: GITHUB_TOKEN
+      auth: GITHUB_TOKEN,
+      baseUrl: GITHUB_API_URL
     })
 
     const resp = await client.request(


### PR DESCRIPTION
Linked to: https://github.com/cypress-io/github-action/pull/1371

Specifically see: https://github.com/cypress-io/github-action/pull/1371#issuecomment-2710086713

In a similar change to the one linked about the Github `baseUrl` parameter is passed into the `Octokit` constructor. This allows for the correct CI Build link to be generated within the Cypress UI. 