### PR TITLE
ci: exclude builds from eslint checks

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -8,7 +8,13 @@ export default [
   pluginCypress.configs.recommended,
   {
     name: 'global-ignores',
-    ignores: ['dist/', 'examples/nextjs/src/app/'],
+    ignores: [
+      'dist/',
+      'examples/component-tests/dist/',
+      'examples/nextjs/.next/',
+      'examples/nextjs/src/app/',
+      'examples/wait-on-vite/dist/',
+    ],
   },
   {
     name: 'all-js',


### PR DESCRIPTION
## Issue

Each of the following examples includes a `build` script definition which, if run, generates additional files, including JavaScript `*.js` files:

- [examples/component-tests](https://github.com/cypress-io/github-action/tree/master/examples/component-tests)
- [examples/nextjs](https://github.com/cypress-io/github-action/tree/master/examples/nextjs)
- [examples/wait-on-vite](https://github.com/cypress-io/github-action/tree/master/examples/wait-on-vite)

## Assessment

ESLint does not respect the `.gitignore` files in the monorepo.

[Including .gitignore Files](https://eslint.org/docs/latest/use/configure/ignore#including-gitignore-files) describes how to use a compatibility utility to work around this restriction, however it is less complicated to use ESLint's global ignore instead, and it requires no additional dependency.

## Change

Add ESLint linting ignore to [eslint.config.mjs](https://github.com/cypress-io/github-action/blob/master/eslint.config.mjs) for:

- `examples/component-tests/dist`
- `examples/nextjs/.next`
- `examples/wait-on-vite/dist`


## Verification

```shell
git clean -xfd
npm ci
cd examples/component-tests
npm ci
npm run build
cd ../nextjs
npm ci
npm run build
cd ../wait-on-vite
npm ci
npm run build
cd ../..
npx eslint
```

Confirm that no linting issues are reported.