### PR TITLE
test: add jsx linting

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -4,5 +4,8 @@
 
 examples/**/*.js
 examples/**/*.?js
+*.jsx
+!examples/component-tests/src/components/*.jsx
+
 **/package-lock.json
 **/pnpm-lock.yaml

--- a/examples/component-tests/src/components/Stepper.jsx
+++ b/examples/component-tests/src/components/Stepper.jsx
@@ -1,19 +1,22 @@
-import { useState } from "react";
+import { useState } from 'react'
 
-export default function Stepper({ count: _count = 0, onChange = () => {} }) {
-  const [count, setCount] = useState(_count);
+export default function Stepper({
+  count: _count = 0,
+  onChange = () => {}
+}) {
+  const [count, setCount] = useState(_count)
 
   const handleIncrement = () => {
-    const newCount = count + 1;
-    setCount(newCount);
-    onChange(newCount);
-  };
+    const newCount = count + 1
+    setCount(newCount)
+    onChange(newCount)
+  }
 
   const handleDecrement = () => {
-    const newCount = count - 1;
-    setCount(newCount);
-    onChange(newCount);
-  };
+    const newCount = count - 1
+    setCount(newCount)
+    onChange(newCount)
+  }
 
   return (
     <div>
@@ -25,5 +28,5 @@ export default function Stepper({ count: _count = 0, onChange = () => {} }) {
         +
       </button>
     </div>
-  );
+  )
 }


### PR DESCRIPTION
## Situation

- React `*.jsx` files are not currently linted. With the exception of the two `Stepper*.jsx` files in [examples/component-tests/src/components](https://github.com/cypress-io/github-action/tree/master/examples/component-tests/src/components) however, all other `*.jsx` source files are scaffolded by `npm create vite` and should not be linted since the content is externally provided.

## Assessment

- The ESLint npm modules [eslint-plugin-react](https://www.npmjs.com/package/eslint-plugin-react) and [@stylistic/eslint-plugin](https://www.npmjs.com/package/@stylistic/eslint-plugin) both fail when attempting to lint [examples/component-tests/src/components](https://github.com/cypress-io/github-action/tree/master/examples/component-tests/src/components). This appears to be a gap in their functionality.

- [prettier](https://www.npmjs.com/package/prettier) on the other hand is able to successfully lint the formatting of [examples/component-tests/src/components/*.jsx](https://github.com/cypress-io/github-action/tree/master/examples/component-tests/src/components) files.

## Change

For the [.prettierignore](https://prettier.io/docs/ignore) file:

- Add `*.jsx` as an exception
- Allow `examples/component-tests/src/components/*.jsx`

Run the following to correct style of [examples/component-tests/src/components/*.jsx](https://github.com/cypress-io/github-action/tree/master/examples/component-tests/src/components) files:

```shell
npx prettier **/*.jsx --write
```

## Verification

On Ubuntu `24.04.2` LTS, Node.js `22.14.0` LTS

```shell
git clean -xfd
npm ci
npx prettier **/*.jsx --check
```

and confirm the response is:

```text
Checking formatting...
All matched files use Prettier code style!
```
