### PR TITLE
ci: exclude prettier checks on generated content

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,11 +1,19 @@
 /eslint.config.*js
 /LICENSE.md
 /renovate.json
+/dist/
 
 examples/**/*.js
 examples/**/*.?js
 *.jsx
 !examples/component-tests/src/components/*.jsx
+examples/component-tests/cypress/
+examples/component-tests/dist/
+examples/component-tests/src/*.jsx
+examples/component-tests/index.html
+examples/nextjs/.next/
+examples/wait-on-vite/dist/
+examples/wait-on-vite/index.html
 
 **/package-lock.json
 **/pnpm-lock.yaml


### PR DESCRIPTION
## Issue

Prettier should not be applied to content created by builds or sourced externally.

### Builds

Each of the following examples includes a `build` script definition which, if run, generates additional files:

- [examples/component-tests](https://github.com/cypress-io/github-action/tree/master/examples/component-tests)
- [examples/nextjs](https://github.com/cypress-io/github-action/tree/master/examples/nextjs)
- [examples/wait-on-vite](https://github.com/cypress-io/github-action/tree/master/examples/wait-on-vite)

The [dist](https://github.com/cypress-io/github-action/tree/master/dist) directory also contains only generated files.

### External sources

Generated by `ncc` through `npm run build`

- [dist](https://github.com/cypress-io/github-action/tree/master/dist)

Scaffolded by Cypress:

- [examples/component-tests/cypress/support/component-index.html](https://github.com/cypress-io/github-action/blob/master/examples/component-tests/cypress/support/component-index.html)

Scaffolded by `npm create vite`:

- [examples/component-tests/index.html](https://github.com/cypress-io/github-action/blob/master/examples/component-tests/index.html)
- [examples/component-tests/src/App.jsx](https://github.com/cypress-io/github-action/blob/master/examples/component-tests/src/App.jsx)
- [examples/component-tests/src/main.jsx](https://github.com/cypress-io/github-action/blob/master/examples/component-tests/src/main.jsx)
- [examples/wait-on-vite/index.html](https://github.com/cypress-io/github-action/blob/master/examples/wait-on-vite/index.html)

## Change

Add to [.prettierignore](https://github.com/cypress-io/github-action/blob/master/.prettierignore) for:

- `examples/component-tests/cypress`
- `examples/component-tests/dist`
- `examples/component-tests/src/*.jsx`
- `examples/component-tests/index.html`
- `examples/nextjs/.next`
- `examples/wait-on-vite/dist`
- `examples/wait-on-vite/index.html`
- `dist`

## Verification

Ubuntu `24.04.2` LTS, Node.js `22.14.0` LTS

```shell
git clean -xfd
npm ci
cd examples/component-tests
npm ci
npm run build
cd ../nextjs
npm ci
npm run build
cd ../wait-on-vite
npm ci
npm run build
cd ../..
npx prettier . --check
```
