### PR TITLE
ci: add overall prettier check to ci

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,9 +20,12 @@ jobs:
           # https://github.com/actions/runner/blob/main/src/Misc/externals.sh
           node-version: 20.18.0
       - run: npm ci
-      - run: npm run format
-      - run: npm run build
-      - run: npm run lint
+      # Core action code
+      - run: npm run format # Prettier formats core action code
+      - run: npm run build # builds core action code into dist/
+      # All repo
+      - run: npm run lint # ESLint
+      - run: npm run format:all:check # Prettier formatting check
 
   release:
     runs-on: ubuntu-24.04

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,7 +43,7 @@ To contribute changes, follow these instructions in the order given below:
 1. Clone the repository
 1. Create a new branch with a meaningful name e.g. `fix/my-bug` based on the current `master` branch.
 1. Make the necessary source code changes, including additions or changes to the [README.md](./README.md) documentation if parameters are added or affected.
-1. Execute the following in the root directory of the cloned repository
+1. Execute the following in the root directory of the cloned repository to install dependencies, then to format and build the action from the main source code elements (see above):
 
    ```bash
    npm install
@@ -51,13 +51,19 @@ To contribute changes, follow these instructions in the order given below:
    npm run build
    ```
 
-1. If you have modified any Markdown documents (`*.md`) then execute
+1. If you have modified any other files, such as examples, then execute:
+
+   ```bash
+   npm run format:all
+   ```
+
+1. If you have only modified Markdown documents (`*.md`), then you can alternatively execute the following to format only those documents:
 
    ```bash
    npm run format:markdown
    ```
 
-1. Commit the change. (If you are working on Microsoft Windows, see [Windows users](#windows-users) below.)
+1. Commit any changes. (If you are working on Microsoft Windows, see [Windows users](#windows-users) below.)
 1. Push to the repository.
 1. If you are working in a fork, ensure actions are enabled.
 1. Refer to [Manually running a workflow](https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow) to use this to test any particular workflow affected by your change.

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "format": "prettier --write index.js src/ping.js action.yml",
     "format:markdown": "prettier --write \"**/*.md\"",
     "format:markdown:check": "prettier --check \"**/*.md\"",
+    "format:all": "prettier --write .",
+    "format:all:check": "prettier --check .",
     "lint": "eslint",
     "check:markdown-links": "find *.md docs/*.md -print0 | xargs -0 -n1 markdown-link-check",
     "update:cypress": "./scripts/update-cypress-latest.sh",


### PR DESCRIPTION
## Situation

- Previous PRs have made incremental changes to the scope of [Prettier](https://prettier.io/docs/) formatting and checks

- Running `npx prettier . --check` now returns success

- Scripts to run Prettier across the whole repo and in CI are missing

- The use of Prettier is not documented

## Change

- Add script
  - `format:all` to fix all required formatting with Prettier
  - `format:all:check` to check all required formatting with Prettier
- Add instructions to [CONTRIBUTING](https://github.com/cypress-io/github-action/blob/master/CONTRIBUTING.md)
- Add `format:all:check` to [.github/workflows/main.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/main.yml)

## Verification

On Ubuntu `24.04.2` LTS, Node.js `22.14.0` LTS

```shell
npm ci
npm run format:all:check
```

and confirm the response is:

```text
Checking formatting...
All matched files use Prettier code style!
```
