### PR TITLE
chore: add script lint:fix

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,6 +55,7 @@ To contribute changes, follow these instructions in the order given below:
 
    ```bash
    npm run format:all
+   npm run lint:fix
    ```
 
 1. If you have only modified Markdown documents (`*.md`), then you can alternatively execute the following to format only those documents:

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "format:all": "prettier --write .",
     "format:all:check": "prettier --check .",
     "lint": "eslint",
+    "lint:fix": "eslint --fix",
     "check:markdown-links": "find *.md docs/*.md -print0 | xargs -0 -n1 markdown-link-check",
     "update:cypress": "./scripts/update-cypress-latest.sh",
     "prepare": "husky"


### PR DESCRIPTION
## Situation

- If CI linting finds an ESLinting error in the [.github/workflows/main.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/main.yml) there is no script available to simply correct automatically fixable linting errors.
- There is no mention of ESLinting preparation in the [CONTRIBUTING](https://github.com/cypress-io/github-action/blob/master/CONTRIBUTING.md) document.

## Change

- Add a script `lint:fix` to [package.json](https://github.com/cypress-io/github-action/blob/master/package.json) equivalent to running the following (see [eslint options](https://eslint.org/docs/latest/use/command-line-interface#options)):

  ```shell
  npx eslint --fix
  ```

- Add `lint:fix` to the [CONTRIBUTING > Providing fixes or features](https://github.com/cypress-io/github-action/blob/master/CONTRIBUTING.md#providing-fixes-or-features) document section.

## Verification

Execute

```shell
npm ci
npm run lint:fix
```

and confirm no errors are reported.