### PR TITLE
chore: add debug output of node.js version

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -94030,6 +94030,7 @@ const runTests = async () => {
   debug(`requiring cypress dependency, cwd is ${process.cwd()}`)
   debug(`working directory ${workingDirectory}`)
   debug(`resolved cypress ${cypressModulePath}`)
+  debug(`GitHub JavaScript Action Node.js version ${process.version}`)
 
   if (core.getInput('group')) {
     cypressOptions.group = core.getInput('group')

--- a/index.js
+++ b/index.js
@@ -767,6 +767,7 @@ const runTests = async () => {
   debug(`requiring cypress dependency, cwd is ${process.cwd()}`)
   debug(`working directory ${workingDirectory}`)
   debug(`resolved cypress ${cypressModulePath}`)
+  debug(`GitHub JavaScript Action Node.js version ${process.version}`)
 
   if (core.getInput('group')) {
     cypressOptions.group = core.getInput('group')


### PR DESCRIPTION
- follows on from https://github.com/cypress-io/github-action/issues/1408

## Situation

If Cypress fails to run using the Module API, for instance due to an issue with the Cypress config file, which was the case with issue https://github.com/cypress-io/github-action/issues/1408, no information about the version of Node.js being used is logged.

The action selects the Node.js major version through the setting for [runs.using](https://docs.github.com/en/actions/sharing-automations/creating-actions/metadata-syntax-for-github-actions#runsusing-for-javascript-actions):

`cypress-io/github-action@v6` selects:

https://github.com/cypress-io/github-action/blob/4b97333793ccb3c4885f89f55db569765b48f18c/action.yml#L102-L104

Based on the  [runs.using](https://docs.github.com/en/actions/sharing-automations/creating-actions/metadata-syntax-for-github-actions#runsusing-for-javascript-actions) setting, [GitHub Actions runner](https://github.com/actions/runner) takes the value of Node.js from https://github.com/actions/runner/blob/main/src/Misc/externals.sh 

[GitHub Actions runner v2.323.0](https://github.com/actions/runner/releases/tag/v2.323.0) is set to:

```js
NODE20_VERSION="20.19.0"
```

Currently only `node20` is allowed for `runs.using`.

This version of Node.js is separate from the one provided by the [GitHub Runner image](https://github.com/actions/runner-images) default Node.js version, for example, currently [windows-2025](https://github.com/actions/runner-images/blob/main/images/windows/Windows2025-Readme.md) sets its default to Node.js `22.14.0`. It is also separate from and uninfluenced by any alternate Node.js version that might be installed into the runner using [actions/setup-node](https://github.com/actions/setup-node).

## Change

Expose Node.js [process.version](https://nodejs.org/docs/latest/api/process.html#processversion) in the debug log when calling the Cypress Module API.

The debug log command outputs the Node.js value if the `DEBUG` environment variable is set as follows:

```yml
  env:
    DEBUG: '@cypress/github-action'
```

see [Debugging](https://github.com/MikeMcC399/github-action/blob/prime/README.md#debugging).

## Verification

View workflow log [workflows/example-debug.yml](https://github.com/cypress-io/github-action/actions/workflows/example-debug.yml), job `action-debug`, step `Cypress action debug logs` and confirm that the Node.js version is displayed, similar to the following:

```text
@cypress/github-action Running Cypress tests using Module API
@cypress/github-action requiring cypress dependency, cwd is /home/runner/work/github-action/github-action
@cypress/github-action working directory /home/runner/work/github-action/github-action/examples/basic
@cypress/github-action resolved cypress /home/runner/work/github-action/github-action/examples/basic/node_modules/cypress/index.js
@cypress/github-action GitHub JavaScript Action Node.js version v20.19.0
@cypress/github-action Cypress options {"headed":false,"record":false,"parallel":false,"quiet":false,"component":false}
```
