### PR TITLE
test(deps): update vite to 6.2.4 in examples

### DIFF
--- a/examples/component-tests/package-lock.json
+++ b/examples/component-tests/package-lock.json
@@ -16,7 +16,7 @@
         "@types/react-dom": "^19.0.4",
         "@vitejs/plugin-react": "^4.3.4",
         "cypress": "14.2.1",
-        "vite": "^6.2.3"
+        "vite": "^6.2.4"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -3659,9 +3659,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.3.tgz",
-      "integrity": "sha512-IzwM54g4y9JA/xAeBPNaDXiBF8Jsgl3VBQ2YQ/wOY6fyW3xMdSoltIV3Bo59DErdqdE6RxUfv8W69DvUorE4Eg==",
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.4.tgz",
+      "integrity": "sha512-veHMSew8CcRzhL5o8ONjy8gkfmFJAd5Ac16oxBUjlwgX3Gq2Wqr+qNC3TjPIpy7TPV/KporLga5GT9HqdrCizw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/examples/component-tests/package.json
+++ b/examples/component-tests/package.json
@@ -18,6 +18,6 @@
     "@types/react-dom": "^19.0.4",
     "@vitejs/plugin-react": "^4.3.4",
     "cypress": "14.2.1",
-    "vite": "^6.2.3"
+    "vite": "^6.2.4"
   }
 }

--- a/examples/wait-on-vite/package-lock.json
+++ b/examples/wait-on-vite/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.0.0",
       "devDependencies": {
         "cypress": "14.2.1",
-        "vite": "^6.2.3"
+        "vite": "^6.2.4"
       }
     },
     "node_modules/@colors/colors": {
@@ -2995,9 +2995,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.3.tgz",
-      "integrity": "sha512-IzwM54g4y9JA/xAeBPNaDXiBF8Jsgl3VBQ2YQ/wOY6fyW3xMdSoltIV3Bo59DErdqdE6RxUfv8W69DvUorE4Eg==",
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.4.tgz",
+      "integrity": "sha512-veHMSew8CcRzhL5o8ONjy8gkfmFJAd5Ac16oxBUjlwgX3Gq2Wqr+qNC3TjPIpy7TPV/KporLga5GT9HqdrCizw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/examples/wait-on-vite/package.json
+++ b/examples/wait-on-vite/package.json
@@ -11,6 +11,6 @@
   "private": true,
   "devDependencies": {
     "cypress": "14.2.1",
-    "vite": "^6.2.3"
+    "vite": "^6.2.4"
   }
 }


### PR DESCRIPTION
## Issue

Dependabot reports the vulnerability [CVE-2025-31125](https://github.com/advisories/GHSA-4r4m-qw57-chr8) with Moderate severity in [vite@6.2.3](https://github.com/vitejs/vite/releases/tag/v6.2.3) used in:

- [examples/component-tests](https://github.com/cypress-io/github-action/tree/master/examples/component-tests)
- [examples/wait-on-vite](https://github.com/cypress-io/github-action/tree/master/examples/wait-on-vite)

## Change

Update `vite` from [vite@6.2.3](https://github.com/vitejs/vite/releases/tag/v6.2.3) to [vite@6.2.4](https://github.com/vitejs/vite/releases/tag/v6.2.4) in the above examples.