### PR TITLE
chore: migrate yarn modern to npm registry corepack

### DIFF
--- a/.github/workflows/example-yarn-modern-pnp.yml
+++ b/.github/workflows/example-yarn-modern-pnp.yml
@@ -12,13 +12,20 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - run: corepack enable yarn # experimental - see https://nodejs.org/docs/latest/api/corepack.html
+      - name: Enable Corepack # see https://yarnpkg.com/getting-started/install
+        run: |
+          npm install -g corepack
+          corepack enable yarn
       - name: Set up Yarn cache
         uses: actions/setup-node@v4
         with:
           node-version-file: '.node-version'
           cache: yarn
           cache-dependency-path: examples/yarn-modern-pnp/yarn.lock
+      - name: Reinstall Corepack # actions/setup-node may have replaced Corepack with an older version
+        run: |
+          npm install -g corepack
+          corepack enable yarn
       - name: Custom Yarn command
         uses: ./
         with:

--- a/.github/workflows/example-yarn-modern.yml
+++ b/.github/workflows/example-yarn-modern.yml
@@ -12,13 +12,20 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - run: corepack enable yarn # experimental - see https://nodejs.org/docs/latest/api/corepack.html
+      - name: Enable Corepack # see https://yarnpkg.com/getting-started/install
+        run: |
+          npm install -g corepack
+          corepack enable yarn
       - name: Set up Yarn cache
         uses: actions/setup-node@v4
         with:
           node-version-file: '.node-version'
           cache: yarn
           cache-dependency-path: examples/yarn-modern/yarn.lock
+      - name: Reinstall Corepack # actions/setup-node may have replaced Corepack with an older version
+        run: |
+          npm install -g corepack
+          corepack enable yarn
       - name: Custom Yarn command
         uses: ./
         with:

--- a/docs/MAINTENANCE.md
+++ b/docs/MAINTENANCE.md
@@ -20,7 +20,7 @@ _The previous [examples/v9](https://github.com/cypress-io/github-action/tree/v5/
 
 - [npm](https://www.npmjs.com/), which is installed with [Node.js](https://nodejs.org/).
 
-- [corepack](https://github.com/nodejs/corepack), which is installed with [Node.js](https://nodejs.org/).
+- [corepack](https://github.com/nodejs/corepack). This is currently installed with [Node.js](https://nodejs.org/). Due to plans of Node.js to remove it in versions Node.js `25.x` and later, you may need to install it separately with `npm install -g corepack`.
 
 - [pnpm](https://pnpm.io/) installed through:
 

--- a/examples/yarn-modern-pnp/README.md
+++ b/examples/yarn-modern-pnp/README.md
@@ -5,6 +5,7 @@ This example demonstrates installing dependencies using [Yarn Modern v4](https:/
 Run locally with:
 
 ```shell
+npm install -g corepack
 corepack enable yarn
 yarn
 yarn test

--- a/examples/yarn-modern/README.md
+++ b/examples/yarn-modern/README.md
@@ -5,6 +5,7 @@ This example demonstrates installing dependencies using [Yarn Modern v4](https:/
 Run locally with:
 
 ```shell
+npm install -g corepack
 corepack enable yarn
 yarn
 yarn test


### PR DESCRIPTION
## Situation

The current [Yarn Modern Installation](https://yarnpkg.com/getting-started/install) instructions recommend managing Yarn through Corepack and they now instruct to install Corepack through npm instead of using the version currently still distributed with Node.js. The background is that the Node.js Technical Steering Committee [voted](https://github.com/nodejs/TSC/pull/1697#issuecomment-2737093616) to stop distributing the experimental Corepack with Node.js in the long term.

This affects examples, tests and scripts in the repo related to Yarn Modern.

## Change

In the appropriate places add `npm install -g corepack`.

### Examples

In both the examples:

- [examples/yarn-modern](https://github.com/cypress-io/github-action/tree/master/examples/yarn-modern)
- [examples/yarn-modern-pnp](https://github.com/cypress-io/github-action/tree/master/examples/yarn-modern-pnp)

Update the `README.md` file.

In the GitHub Actions workflow scripts:

- [.github/workflows/example-yarn-modern.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-yarn-modern.yml)
- [.github/workflows/example-yarn-modern-pnp.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-yarn-modern-pnp.yml)

Corepack needs to be installed twice. The first time is to ensure that the right version of Corepack is available for Yarn caching in `actions/setup-node`. The second installation is to ensure that Corepack is restored to the latest version in case `actions/setup-node` installs an older version.

Since this is quite complex, this is not added to the examples in the README. There are currently submissions in `actions/setup-node` to directly support Corepack which would make this a lot simpler.

### MAINTENANCE

In [docs/MAINTENANCE.md](https://github.com/cypress-io/github-action/blob/master/docs/MAINTENANCE.md) update the reference to `corepack` to note that in future it is planned to unbundle it from Node.js.