### PR TITLE
test: move pnpm onlyBuiltDependencies to pnpm-workspace.yaml

### DIFF
--- a/examples/basic-pnpm/package.json
+++ b/examples/basic-pnpm/package.json
@@ -9,10 +9,5 @@
   "private": true,
   "devDependencies": {
     "cypress": "14.2.1"
-  },
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "cypress"
-    ]
   }
 }

--- a/examples/basic-pnpm/pnpm-workspace.yaml
+++ b/examples/basic-pnpm/pnpm-workspace.yaml
@@ -1,4 +1,2 @@
-packages:
-  - packages/*
 onlyBuiltDependencies:
   - cypress

--- a/examples/start-and-pnpm-workspaces/package.json
+++ b/examples/start-and-pnpm-workspaces/package.json
@@ -2,10 +2,5 @@
   "name": "start-and-pnpm-workspaces",
   "version": "1.0.0",
   "description": "example using pnpm with workspaces",
-  "private": true,
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "cypress"
-    ]
-  }
+  "private": true
 }


### PR DESCRIPTION
## Situation

The pnpm example projects:

- [examples/basic-pnpm](https://github.com/cypress-io/github-action/tree/master/examples/basic-pnpm)
- [examples/start-and-pnpm-workspaces](https://github.com/cypress-io/github-action/tree/master/examples/start-and-pnpm-workspaces)

are configured with `onlyBuiltDependencies` for `cypress` in their respective `package.json` files.

[pnpm@10.5.0](https://github.com/pnpm/pnpm/releases/tag/v10.5.0) moved the default location for this configuration to the `pnpm-workspace.yaml` file.

## Change

To align with the pnpm default location for `onlyBuiltDependencies` in the current version of the `pnpm` package manager move `onlyBuiltDependencies` to a corresponding example `pnpm-workspace.yaml` file.

- [examples/basic-pnpm](https://github.com/cypress-io/github-action/tree/master/examples/basic-pnpm)
- [examples/start-and-pnpm-workspaces](https://github.com/cypress-io/github-action/tree/master/examples/start-and-pnpm-workspaces)