### PR TITLE
ci: use windows-2025 in basic example workflows

### DIFF
--- a/.github/workflows/example-basic-pnpm.yml
+++ b/.github/workflows/example-basic-pnpm.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04, windows-2022, macos-14]
+        os: [ubuntu-24.04, windows-2025, macos-14]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout

--- a/.github/workflows/example-basic.yml
+++ b/.github/workflows/example-basic.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, ubuntu-24.04, windows-2022, macos-14]
+        os: [ubuntu-22.04, ubuntu-24.04, windows-2025, macos-14]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout


### PR DESCRIPTION
## Situation

The following workflows use the GitHub Actions runner [windows-2022](https://github.com/actions/runner-images/blob/main/images/windows/Windows2022-Readme.md)

- [.github/workflows/example-basic.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-basic.yml)
- [.github/workflows/example-basic-pnpm.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-basic-pnpm.yml)

The latest GitHub Actions runner for the Windows operating system is [windows-2025](https://github.com/actions/runner-images/blob/main/images/windows/Windows2025-Readme.md).

## Change

Update the workflows

- [.github/workflows/example-basic.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-basic.yml)
- [.github/workflows/example-basic-pnpm.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-basic-pnpm.yml)

to use `windows-2025` instead of `windows-2022`.