### PR TITLE
chore(deps): update cypress to 14.3.0

### DIFF
--- a/.github/workflows/example-install-only.yml
+++ b/.github/workflows/example-install-only.yml
@@ -29,7 +29,7 @@ jobs:
           key: my-cache-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
 
       - name: Install Cypress 📥
-        run: npm install cypress@14.2.1 --save-dev
+        run: npm install cypress@14.3.0 --save-dev
 
       - name: Cypress tests 🧪
         uses: ./

--- a/examples/basic-pnpm/package.json
+++ b/examples/basic-pnpm/package.json
@@ -8,6 +8,6 @@
   },
   "private": true,
   "devDependencies": {
-    "cypress": "14.2.1"
+    "cypress": "14.3.0"
   }
 }

--- a/examples/basic-pnpm/pnpm-lock.yaml
+++ b/examples/basic-pnpm/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     devDependencies:
       cypress:
-        specifier: 14.2.1
-        version: 14.2.1
+        specifier: 14.3.0
+        version: 14.3.0
 
 packages:
 
@@ -177,8 +177,8 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
-  cypress@14.2.1:
-    resolution: {integrity: sha512-5xd0E7fUp0pjjib1D7ljkmCwFDgMkWuW06jWiz8dKrI7MNRrDo0C65i4Sh+oZ9YHjMHZRJBR0XZk1DfekOhOUw==}
+  cypress@14.3.0:
+    resolution: {integrity: sha512-rRfPl9Z0/CczuYybBEoLbDVuT1OGkhYaJ0+urRCshgiDRz6QnoA0KQIQnPx7MJ3zy+VCsbUU1pV74n+6cbJEdg==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
 
@@ -821,7 +821,7 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
-  cypress@14.2.1:
+  cypress@14.3.0:
     dependencies:
       '@cypress/request': 3.0.8
       '@cypress/xvfb': 1.2.4(supports-color@8.1.1)

--- a/examples/basic/package-lock.json
+++ b/examples/basic/package-lock.json
@@ -8,7 +8,7 @@
       "name": "example-basic",
       "version": "1.0.0",
       "devDependencies": {
-        "cypress": "14.2.1"
+        "cypress": "14.3.0"
       }
     },
     "node_modules/@colors/colors": {
@@ -555,9 +555,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "14.2.1",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-14.2.1.tgz",
-      "integrity": "sha512-5xd0E7fUp0pjjib1D7ljkmCwFDgMkWuW06jWiz8dKrI7MNRrDo0C65i4Sh+oZ9YHjMHZRJBR0XZk1DfekOhOUw==",
+      "version": "14.3.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-14.3.0.tgz",
+      "integrity": "sha512-rRfPl9Z0/CczuYybBEoLbDVuT1OGkhYaJ0+urRCshgiDRz6QnoA0KQIQnPx7MJ3zy+VCsbUU1pV74n+6cbJEdg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",

--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -8,6 +8,6 @@
   },
   "private": true,
   "devDependencies": {
-    "cypress": "14.2.1"
+    "cypress": "14.3.0"
   }
 }

--- a/examples/browser/package-lock.json
+++ b/examples/browser/package-lock.json
@@ -8,7 +8,7 @@
       "name": "example-browser",
       "version": "1.1.0",
       "devDependencies": {
-        "cypress": "14.2.1",
+        "cypress": "14.3.0",
         "image-size": "^1.0.2"
       }
     },
@@ -556,9 +556,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "14.2.1",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-14.2.1.tgz",
-      "integrity": "sha512-5xd0E7fUp0pjjib1D7ljkmCwFDgMkWuW06jWiz8dKrI7MNRrDo0C65i4Sh+oZ9YHjMHZRJBR0XZk1DfekOhOUw==",
+      "version": "14.3.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-14.3.0.tgz",
+      "integrity": "sha512-rRfPl9Z0/CczuYybBEoLbDVuT1OGkhYaJ0+urRCshgiDRz6QnoA0KQIQnPx7MJ3zy+VCsbUU1pV74n+6cbJEdg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",

--- a/examples/browser/package.json
+++ b/examples/browser/package.json
@@ -13,7 +13,7 @@
   },
   "private": true,
   "devDependencies": {
-    "cypress": "14.2.1",
+    "cypress": "14.3.0",
     "image-size": "^1.0.2"
   }
 }

--- a/examples/component-tests/package-lock.json
+++ b/examples/component-tests/package-lock.json
@@ -15,7 +15,7 @@
         "@types/react": "^19.0.10",
         "@types/react-dom": "^19.0.4",
         "@vitejs/plugin-react": "^4.3.4",
-        "cypress": "14.2.1",
+        "cypress": "14.3.0",
         "vite": "^6.2.5"
       }
     },
@@ -1788,9 +1788,9 @@
       "license": "MIT"
     },
     "node_modules/cypress": {
-      "version": "14.2.1",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-14.2.1.tgz",
-      "integrity": "sha512-5xd0E7fUp0pjjib1D7ljkmCwFDgMkWuW06jWiz8dKrI7MNRrDo0C65i4Sh+oZ9YHjMHZRJBR0XZk1DfekOhOUw==",
+      "version": "14.3.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-14.3.0.tgz",
+      "integrity": "sha512-rRfPl9Z0/CczuYybBEoLbDVuT1OGkhYaJ0+urRCshgiDRz6QnoA0KQIQnPx7MJ3zy+VCsbUU1pV74n+6cbJEdg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",

--- a/examples/component-tests/package.json
+++ b/examples/component-tests/package.json
@@ -17,7 +17,7 @@
     "@types/react": "^19.0.10",
     "@types/react-dom": "^19.0.4",
     "@vitejs/plugin-react": "^4.3.4",
-    "cypress": "14.2.1",
+    "cypress": "14.3.0",
     "vite": "^6.2.5"
   }
 }

--- a/examples/config/package-lock.json
+++ b/examples/config/package-lock.json
@@ -8,7 +8,7 @@
       "name": "example-config",
       "version": "1.0.0",
       "devDependencies": {
-        "cypress": "14.2.1",
+        "cypress": "14.3.0",
         "serve": "14.2.4"
       }
     },
@@ -910,9 +910,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "14.2.1",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-14.2.1.tgz",
-      "integrity": "sha512-5xd0E7fUp0pjjib1D7ljkmCwFDgMkWuW06jWiz8dKrI7MNRrDo0C65i4Sh+oZ9YHjMHZRJBR0XZk1DfekOhOUw==",
+      "version": "14.3.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-14.3.0.tgz",
+      "integrity": "sha512-rRfPl9Z0/CczuYybBEoLbDVuT1OGkhYaJ0+urRCshgiDRz6QnoA0KQIQnPx7MJ3zy+VCsbUU1pV74n+6cbJEdg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",

--- a/examples/config/package.json
+++ b/examples/config/package.json
@@ -11,7 +11,7 @@
   },
   "private": true,
   "devDependencies": {
-    "cypress": "14.2.1",
+    "cypress": "14.3.0",
     "serve": "14.2.4"
   }
 }

--- a/examples/custom-command/package-lock.json
+++ b/examples/custom-command/package-lock.json
@@ -8,7 +8,7 @@
       "name": "example-custom-command",
       "version": "1.0.0",
       "devDependencies": {
-        "cypress": "14.2.1",
+        "cypress": "14.3.0",
         "lodash": "4.17.21"
       }
     },
@@ -556,9 +556,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "14.2.1",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-14.2.1.tgz",
-      "integrity": "sha512-5xd0E7fUp0pjjib1D7ljkmCwFDgMkWuW06jWiz8dKrI7MNRrDo0C65i4Sh+oZ9YHjMHZRJBR0XZk1DfekOhOUw==",
+      "version": "14.3.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-14.3.0.tgz",
+      "integrity": "sha512-rRfPl9Z0/CczuYybBEoLbDVuT1OGkhYaJ0+urRCshgiDRz6QnoA0KQIQnPx7MJ3zy+VCsbUU1pV74n+6cbJEdg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",

--- a/examples/custom-command/package.json
+++ b/examples/custom-command/package.json
@@ -9,7 +9,7 @@
   },
   "private": true,
   "devDependencies": {
-    "cypress": "14.2.1",
+    "cypress": "14.3.0",
     "lodash": "4.17.21"
   }
 }

--- a/examples/env/package-lock.json
+++ b/examples/env/package-lock.json
@@ -8,7 +8,7 @@
       "name": "example-env",
       "version": "1.0.0",
       "devDependencies": {
-        "cypress": "14.2.1"
+        "cypress": "14.3.0"
       }
     },
     "node_modules/@colors/colors": {
@@ -555,9 +555,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "14.2.1",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-14.2.1.tgz",
-      "integrity": "sha512-5xd0E7fUp0pjjib1D7ljkmCwFDgMkWuW06jWiz8dKrI7MNRrDo0C65i4Sh+oZ9YHjMHZRJBR0XZk1DfekOhOUw==",
+      "version": "14.3.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-14.3.0.tgz",
+      "integrity": "sha512-rRfPl9Z0/CczuYybBEoLbDVuT1OGkhYaJ0+urRCshgiDRz6QnoA0KQIQnPx7MJ3zy+VCsbUU1pV74n+6cbJEdg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",

--- a/examples/env/package.json
+++ b/examples/env/package.json
@@ -8,6 +8,6 @@
   },
   "private": true,
   "devDependencies": {
-    "cypress": "14.2.1"
+    "cypress": "14.3.0"
   }
 }

--- a/examples/install-command/package.json
+++ b/examples/install-command/package.json
@@ -7,7 +7,7 @@
   },
   "private": true,
   "devDependencies": {
-    "cypress": "14.2.1"
+    "cypress": "14.3.0"
   },
   "dependencies": {
     "arg": "5.0.0",

--- a/examples/install-command/yarn.lock
+++ b/examples/install-command/yarn.lock
@@ -301,10 +301,10 @@ cross-spawn@^7.0.0:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
-cypress@14.2.1:
-  version "14.2.1"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-14.2.1.tgz#2628696588d3d3961bf0ea0ad87baeb359790dcd"
-  integrity sha512-5xd0E7fUp0pjjib1D7ljkmCwFDgMkWuW06jWiz8dKrI7MNRrDo0C65i4Sh+oZ9YHjMHZRJBR0XZk1DfekOhOUw==
+cypress@14.3.0:
+  version "14.3.0"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-14.3.0.tgz#720923501ca0e371d344b810572cea58d5b50aec"
+  integrity sha512-rRfPl9Z0/CczuYybBEoLbDVuT1OGkhYaJ0+urRCshgiDRz6QnoA0KQIQnPx7MJ3zy+VCsbUU1pV74n+6cbJEdg==
   dependencies:
     "@cypress/request" "^3.0.8"
     "@cypress/xvfb" "^1.2.4"

--- a/examples/install-only/package-lock.json
+++ b/examples/install-only/package-lock.json
@@ -12,7 +12,7 @@
         "debug": "4.3.6"
       },
       "devDependencies": {
-        "cypress": "14.2.1"
+        "cypress": "14.3.0"
       }
     },
     "node_modules/@colors/colors": {
@@ -564,9 +564,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "14.2.1",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-14.2.1.tgz",
-      "integrity": "sha512-5xd0E7fUp0pjjib1D7ljkmCwFDgMkWuW06jWiz8dKrI7MNRrDo0C65i4Sh+oZ9YHjMHZRJBR0XZk1DfekOhOUw==",
+      "version": "14.3.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-14.3.0.tgz",
+      "integrity": "sha512-rRfPl9Z0/CczuYybBEoLbDVuT1OGkhYaJ0+urRCshgiDRz6QnoA0KQIQnPx7MJ3zy+VCsbUU1pV74n+6cbJEdg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",

--- a/examples/install-only/package.json
+++ b/examples/install-only/package.json
@@ -11,6 +11,6 @@
     "debug": "4.3.6"
   },
   "devDependencies": {
-    "cypress": "14.2.1"
+    "cypress": "14.3.0"
   }
 }

--- a/examples/nextjs/package-lock.json
+++ b/examples/nextjs/package-lock.json
@@ -13,7 +13,7 @@
         "react-dom": "^19.0.0"
       },
       "devDependencies": {
-        "cypress": "14.2.1",
+        "cypress": "14.3.0",
         "postcss": "^8.5.3",
         "tailwindcss": "^3.4.17"
       }
@@ -1529,9 +1529,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "14.2.1",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-14.2.1.tgz",
-      "integrity": "sha512-5xd0E7fUp0pjjib1D7ljkmCwFDgMkWuW06jWiz8dKrI7MNRrDo0C65i4Sh+oZ9YHjMHZRJBR0XZk1DfekOhOUw==",
+      "version": "14.3.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-14.3.0.tgz",
+      "integrity": "sha512-rRfPl9Z0/CczuYybBEoLbDVuT1OGkhYaJ0+urRCshgiDRz6QnoA0KQIQnPx7MJ3zy+VCsbUU1pV74n+6cbJEdg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",

--- a/examples/nextjs/package.json
+++ b/examples/nextjs/package.json
@@ -15,7 +15,7 @@
     "react-dom": "^19.0.0"
   },
   "devDependencies": {
-    "cypress": "14.2.1",
+    "cypress": "14.3.0",
     "postcss": "^8.5.3",
     "tailwindcss": "^3.4.17"
   }

--- a/examples/node-versions/package-lock.json
+++ b/examples/node-versions/package-lock.json
@@ -8,7 +8,7 @@
       "name": "example-node-versions",
       "version": "1.0.0",
       "devDependencies": {
-        "cypress": "14.2.1"
+        "cypress": "14.3.0"
       }
     },
     "node_modules/@colors/colors": {
@@ -555,9 +555,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "14.2.1",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-14.2.1.tgz",
-      "integrity": "sha512-5xd0E7fUp0pjjib1D7ljkmCwFDgMkWuW06jWiz8dKrI7MNRrDo0C65i4Sh+oZ9YHjMHZRJBR0XZk1DfekOhOUw==",
+      "version": "14.3.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-14.3.0.tgz",
+      "integrity": "sha512-rRfPl9Z0/CczuYybBEoLbDVuT1OGkhYaJ0+urRCshgiDRz6QnoA0KQIQnPx7MJ3zy+VCsbUU1pV74n+6cbJEdg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",

--- a/examples/node-versions/package.json
+++ b/examples/node-versions/package.json
@@ -8,6 +8,6 @@
   },
   "private": true,
   "devDependencies": {
-    "cypress": "14.2.1"
+    "cypress": "14.3.0"
   }
 }

--- a/examples/quiet/package-lock.json
+++ b/examples/quiet/package-lock.json
@@ -8,7 +8,7 @@
       "name": "example-quiet",
       "version": "1.0.0",
       "devDependencies": {
-        "cypress": "14.2.1",
+        "cypress": "14.3.0",
         "image-size": "0.8.3"
       }
     },
@@ -556,9 +556,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "14.2.1",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-14.2.1.tgz",
-      "integrity": "sha512-5xd0E7fUp0pjjib1D7ljkmCwFDgMkWuW06jWiz8dKrI7MNRrDo0C65i4Sh+oZ9YHjMHZRJBR0XZk1DfekOhOUw==",
+      "version": "14.3.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-14.3.0.tgz",
+      "integrity": "sha512-rRfPl9Z0/CczuYybBEoLbDVuT1OGkhYaJ0+urRCshgiDRz6QnoA0KQIQnPx7MJ3zy+VCsbUU1pV74n+6cbJEdg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",

--- a/examples/quiet/package.json
+++ b/examples/quiet/package.json
@@ -9,7 +9,7 @@
   },
   "private": true,
   "devDependencies": {
-    "cypress": "14.2.1",
+    "cypress": "14.3.0",
     "image-size": "0.8.3"
   }
 }

--- a/examples/recording/package-lock.json
+++ b/examples/recording/package-lock.json
@@ -8,7 +8,7 @@
       "name": "example-recording",
       "version": "1.0.0",
       "devDependencies": {
-        "cypress": "14.2.1"
+        "cypress": "14.3.0"
       }
     },
     "node_modules/@colors/colors": {
@@ -555,9 +555,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "14.2.1",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-14.2.1.tgz",
-      "integrity": "sha512-5xd0E7fUp0pjjib1D7ljkmCwFDgMkWuW06jWiz8dKrI7MNRrDo0C65i4Sh+oZ9YHjMHZRJBR0XZk1DfekOhOUw==",
+      "version": "14.3.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-14.3.0.tgz",
+      "integrity": "sha512-rRfPl9Z0/CczuYybBEoLbDVuT1OGkhYaJ0+urRCshgiDRz6QnoA0KQIQnPx7MJ3zy+VCsbUU1pV74n+6cbJEdg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",

--- a/examples/recording/package.json
+++ b/examples/recording/package.json
@@ -9,6 +9,6 @@
   },
   "private": true,
   "devDependencies": {
-    "cypress": "14.2.1"
+    "cypress": "14.3.0"
   }
 }

--- a/examples/start-and-pnpm-workspaces/packages/workspace-1/package.json
+++ b/examples/start-and-pnpm-workspaces/packages/workspace-1/package.json
@@ -10,7 +10,7 @@
   },
   "private": true,
   "devDependencies": {
-    "cypress": "14.2.1",
+    "cypress": "14.3.0",
     "serve": "14.2.4"
   }
 }

--- a/examples/start-and-pnpm-workspaces/packages/workspace-2/package.json
+++ b/examples/start-and-pnpm-workspaces/packages/workspace-2/package.json
@@ -10,7 +10,7 @@
   },
   "private": true,
   "devDependencies": {
-    "cypress": "14.2.1",
+    "cypress": "14.3.0",
     "serve": "14.2.4"
   }
 }

--- a/examples/start-and-pnpm-workspaces/pnpm-lock.yaml
+++ b/examples/start-and-pnpm-workspaces/pnpm-lock.yaml
@@ -11,8 +11,8 @@ importers:
   packages/workspace-1:
     devDependencies:
       cypress:
-        specifier: 14.2.1
-        version: 14.2.1
+        specifier: 14.3.0
+        version: 14.3.0
       serve:
         specifier: 14.2.4
         version: 14.2.4
@@ -20,8 +20,8 @@ importers:
   packages/workspace-2:
     devDependencies:
       cypress:
-        specifier: 14.2.1
-        version: 14.2.1
+        specifier: 14.3.0
+        version: 14.3.0
       serve:
         specifier: 14.2.4
         version: 14.2.4
@@ -39,8 +39,8 @@ packages:
   '@cypress/xvfb@1.2.4':
     resolution: {integrity: sha512-skbBzPggOVYCbnGgV+0dmBdW/s77ZkAOXIC1knS8NagwDjBrNC1LuXtQJeiN6l+m7lzmHtaoUw/ctJKdqkG57Q==}
 
-  '@types/node@22.13.13':
-    resolution: {integrity: sha512-ClsL5nMwKaBRwPcCvH8E7+nU4GxHVx1axNvMZTFHMEfNI7oahimt26P5zjVCRrjiIWj6YFXfE1v3dEp94wLcGQ==}
+  '@types/node@22.14.0':
+    resolution: {integrity: sha512-Kmpl+z84ILoG+3T/zQFyAJsU6EPTmOCj8/2+83fSN6djd6I4o7uOuGIH6vq3PrjY5BGitSbFuMN18j3iknubbA==}
 
   '@types/sinonjs__fake-timers@8.1.1':
     resolution: {integrity: sha512-0kSuKjAS0TrGLJ0M/+8MaFkGsQhZpB6pxOmvS3K8FYI72K//YmdfoW9X2qPsAKh1mkwxGD5zib9s1FIFed6E8g==}
@@ -264,8 +264,8 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
-  cypress@14.2.1:
-    resolution: {integrity: sha512-5xd0E7fUp0pjjib1D7ljkmCwFDgMkWuW06jWiz8dKrI7MNRrDo0C65i4Sh+oZ9YHjMHZRJBR0XZk1DfekOhOUw==}
+  cypress@14.3.0:
+    resolution: {integrity: sha512-rRfPl9Z0/CczuYybBEoLbDVuT1OGkhYaJ0+urRCshgiDRz6QnoA0KQIQnPx7MJ3zy+VCsbUU1pV74n+6cbJEdg==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
 
@@ -845,8 +845,8 @@ packages:
     resolution: {integrity: sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==}
     engines: {node: '>=12.20'}
 
-  undici-types@6.20.0:
-    resolution: {integrity: sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==}
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
   universalify@2.0.1:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
@@ -934,9 +934,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@types/node@22.13.13':
+  '@types/node@22.14.0':
     dependencies:
-      undici-types: 6.20.0
+      undici-types: 6.21.0
     optional: true
 
   '@types/sinonjs__fake-timers@8.1.1': {}
@@ -945,7 +945,7 @@ snapshots:
 
   '@types/yauzl@2.10.3':
     dependencies:
-      '@types/node': 22.13.13
+      '@types/node': 22.14.0
     optional: true
 
   '@zeit/schemas@2.36.0': {}
@@ -1146,7 +1146,7 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
-  cypress@14.2.1:
+  cypress@14.3.0:
     dependencies:
       '@cypress/request': 3.0.8
       '@cypress/xvfb': 1.2.4(supports-color@8.1.1)
@@ -1754,7 +1754,7 @@ snapshots:
 
   type-fest@2.19.0: {}
 
-  undici-types@6.20.0:
+  undici-types@6.21.0:
     optional: true
 
   universalify@2.0.1: {}

--- a/examples/start-and-yarn-workspaces/workspace-1/package.json
+++ b/examples/start-and-yarn-workspaces/workspace-1/package.json
@@ -10,7 +10,7 @@
   },
   "private": true,
   "devDependencies": {
-    "cypress": "14.2.1",
+    "cypress": "14.3.0",
     "serve": "14.2.4"
   }
 }

--- a/examples/start-and-yarn-workspaces/workspace-2/package.json
+++ b/examples/start-and-yarn-workspaces/workspace-2/package.json
@@ -10,7 +10,7 @@
   },
   "private": true,
   "devDependencies": {
-    "cypress": "14.2.1",
+    "cypress": "14.3.0",
     "serve": "14.2.4"
   }
 }

--- a/examples/start-and-yarn-workspaces/yarn.lock
+++ b/examples/start-and-yarn-workspaces/yarn.lock
@@ -439,10 +439,10 @@ cross-spawn@^7.0.0, cross-spawn@^7.0.3:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
-cypress@14.2.1:
-  version "14.2.1"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-14.2.1.tgz#2628696588d3d3961bf0ea0ad87baeb359790dcd"
-  integrity sha512-5xd0E7fUp0pjjib1D7ljkmCwFDgMkWuW06jWiz8dKrI7MNRrDo0C65i4Sh+oZ9YHjMHZRJBR0XZk1DfekOhOUw==
+cypress@14.3.0:
+  version "14.3.0"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-14.3.0.tgz#720923501ca0e371d344b810572cea58d5b50aec"
+  integrity sha512-rRfPl9Z0/CczuYybBEoLbDVuT1OGkhYaJ0+urRCshgiDRz6QnoA0KQIQnPx7MJ3zy+VCsbUU1pV74n+6cbJEdg==
   dependencies:
     "@cypress/request" "^3.0.8"
     "@cypress/xvfb" "^1.2.4"

--- a/examples/start/package-lock.json
+++ b/examples/start/package-lock.json
@@ -8,7 +8,7 @@
       "name": "example-start",
       "version": "1.0.0",
       "devDependencies": {
-        "cypress": "14.2.1",
+        "cypress": "14.3.0",
         "serve": "14.2.4"
       }
     },
@@ -910,9 +910,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "14.2.1",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-14.2.1.tgz",
-      "integrity": "sha512-5xd0E7fUp0pjjib1D7ljkmCwFDgMkWuW06jWiz8dKrI7MNRrDo0C65i4Sh+oZ9YHjMHZRJBR0XZk1DfekOhOUw==",
+      "version": "14.3.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-14.3.0.tgz",
+      "integrity": "sha512-rRfPl9Z0/CczuYybBEoLbDVuT1OGkhYaJ0+urRCshgiDRz6QnoA0KQIQnPx7MJ3zy+VCsbUU1pV74n+6cbJEdg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",

--- a/examples/start/package.json
+++ b/examples/start/package.json
@@ -11,7 +11,7 @@
   },
   "private": true,
   "devDependencies": {
-    "cypress": "14.2.1",
+    "cypress": "14.3.0",
     "serve": "14.2.4"
   }
 }

--- a/examples/wait-on-vite/package-lock.json
+++ b/examples/wait-on-vite/package-lock.json
@@ -8,7 +8,7 @@
       "name": "example-wait-on-vite",
       "version": "2.0.0",
       "devDependencies": {
-        "cypress": "14.2.1",
+        "cypress": "14.3.0",
         "vite": "^6.2.5"
       }
     },
@@ -1289,9 +1289,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "14.2.1",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-14.2.1.tgz",
-      "integrity": "sha512-5xd0E7fUp0pjjib1D7ljkmCwFDgMkWuW06jWiz8dKrI7MNRrDo0C65i4Sh+oZ9YHjMHZRJBR0XZk1DfekOhOUw==",
+      "version": "14.3.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-14.3.0.tgz",
+      "integrity": "sha512-rRfPl9Z0/CczuYybBEoLbDVuT1OGkhYaJ0+urRCshgiDRz6QnoA0KQIQnPx7MJ3zy+VCsbUU1pV74n+6cbJEdg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",

--- a/examples/wait-on-vite/package.json
+++ b/examples/wait-on-vite/package.json
@@ -10,7 +10,7 @@
   },
   "private": true,
   "devDependencies": {
-    "cypress": "14.2.1",
+    "cypress": "14.3.0",
     "vite": "^6.2.5"
   }
 }

--- a/examples/wait-on/package-lock.json
+++ b/examples/wait-on/package-lock.json
@@ -12,7 +12,7 @@
         "debug": "4.3.6"
       },
       "devDependencies": {
-        "cypress": "14.2.1"
+        "cypress": "14.3.0"
       }
     },
     "node_modules/@colors/colors": {
@@ -564,9 +564,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "14.2.1",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-14.2.1.tgz",
-      "integrity": "sha512-5xd0E7fUp0pjjib1D7ljkmCwFDgMkWuW06jWiz8dKrI7MNRrDo0C65i4Sh+oZ9YHjMHZRJBR0XZk1DfekOhOUw==",
+      "version": "14.3.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-14.3.0.tgz",
+      "integrity": "sha512-rRfPl9Z0/CczuYybBEoLbDVuT1OGkhYaJ0+urRCshgiDRz6QnoA0KQIQnPx7MJ3zy+VCsbUU1pV74n+6cbJEdg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",

--- a/examples/wait-on/package.json
+++ b/examples/wait-on/package.json
@@ -20,6 +20,6 @@
     "debug": "4.3.6"
   },
   "devDependencies": {
-    "cypress": "14.2.1"
+    "cypress": "14.3.0"
   }
 }

--- a/examples/webpack/package-lock.json
+++ b/examples/webpack/package-lock.json
@@ -8,7 +8,7 @@
       "name": "example-webpack",
       "version": "1.0.0",
       "devDependencies": {
-        "cypress": "14.2.1",
+        "cypress": "14.3.0",
         "webpack": "5.94.0",
         "webpack-cli": "5.1.4",
         "webpack-dev-server": "5.2.0"
@@ -1527,9 +1527,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "14.2.1",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-14.2.1.tgz",
-      "integrity": "sha512-5xd0E7fUp0pjjib1D7ljkmCwFDgMkWuW06jWiz8dKrI7MNRrDo0C65i4Sh+oZ9YHjMHZRJBR0XZk1DfekOhOUw==",
+      "version": "14.3.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-14.3.0.tgz",
+      "integrity": "sha512-rRfPl9Z0/CczuYybBEoLbDVuT1OGkhYaJ0+urRCshgiDRz6QnoA0KQIQnPx7MJ3zy+VCsbUU1pV74n+6cbJEdg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",

--- a/examples/webpack/package.json
+++ b/examples/webpack/package.json
@@ -8,7 +8,7 @@
   },
   "private": true,
   "devDependencies": {
-    "cypress": "14.2.1",
+    "cypress": "14.3.0",
     "webpack": "5.94.0",
     "webpack-cli": "5.1.4",
     "webpack-dev-server": "5.2.0"

--- a/examples/yarn-classic/package.json
+++ b/examples/yarn-classic/package.json
@@ -7,6 +7,6 @@
   },
   "private": true,
   "devDependencies": {
-    "cypress": "14.2.1"
+    "cypress": "14.3.0"
   }
 }

--- a/examples/yarn-classic/yarn.lock
+++ b/examples/yarn-classic/yarn.lock
@@ -298,10 +298,10 @@ cross-spawn@^7.0.0:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
-cypress@14.2.1:
-  version "14.2.1"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-14.2.1.tgz#2628696588d3d3961bf0ea0ad87baeb359790dcd"
-  integrity sha512-5xd0E7fUp0pjjib1D7ljkmCwFDgMkWuW06jWiz8dKrI7MNRrDo0C65i4Sh+oZ9YHjMHZRJBR0XZk1DfekOhOUw==
+cypress@14.3.0:
+  version "14.3.0"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-14.3.0.tgz#720923501ca0e371d344b810572cea58d5b50aec"
+  integrity sha512-rRfPl9Z0/CczuYybBEoLbDVuT1OGkhYaJ0+urRCshgiDRz6QnoA0KQIQnPx7MJ3zy+VCsbUU1pV74n+6cbJEdg==
   dependencies:
     "@cypress/request" "^3.0.8"
     "@cypress/xvfb" "^1.2.4"

--- a/examples/yarn-modern-pnp/package.json
+++ b/examples/yarn-modern-pnp/package.json
@@ -6,8 +6,8 @@
     "test": "cypress run"
   },
   "private": true,
-  "packageManager": "yarn@4.7.0",
+  "packageManager": "yarn@4.8.1",
   "devDependencies": {
-    "cypress": "14.2.1"
+    "cypress": "14.3.0"
   }
 }

--- a/examples/yarn-modern-pnp/yarn.lock
+++ b/examples/yarn-modern-pnp/yarn.lock
@@ -393,9 +393,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cypress@npm:14.2.1":
-  version: 14.2.1
-  resolution: "cypress@npm:14.2.1"
+"cypress@npm:14.3.0":
+  version: 14.3.0
+  resolution: "cypress@npm:14.3.0"
   dependencies:
     "@cypress/request": "npm:^3.0.8"
     "@cypress/xvfb": "npm:^1.2.4"
@@ -442,7 +442,7 @@ __metadata:
     yauzl: "npm:^2.10.0"
   bin:
     cypress: bin/cypress
-  checksum: 10c0/d6fb64193098a9d4e55c42d81f427c42eaf1fc015179a4d17706f8c808fe672e1f400bdac90ea280dc8da7c3c80feaf58aa3b230e90877e04199e3c1394381be
+  checksum: 10c0/c331d748498c4b309aa5c94c1372723c690deb6d7c644167cd45fd2079dc8b9a2c32fe4f4a64a0828449faac32e62fbe680ee048e623488b903c2c9742683f07
   languageName: node
   linkType: hard
 
@@ -578,7 +578,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "example-yarn-modern-pnp@workspace:."
   dependencies:
-    cypress: "npm:14.2.1"
+    cypress: "npm:14.3.0"
   languageName: unknown
   linkType: soft
 

--- a/examples/yarn-modern/package.json
+++ b/examples/yarn-modern/package.json
@@ -6,8 +6,8 @@
     "test": "cypress run"
   },
   "private": true,
-  "packageManager": "yarn@4.7.0",
+  "packageManager": "yarn@4.8.1",
   "devDependencies": {
-    "cypress": "14.2.1"
+    "cypress": "14.3.0"
   }
 }

--- a/examples/yarn-modern/yarn.lock
+++ b/examples/yarn-modern/yarn.lock
@@ -393,9 +393,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cypress@npm:14.2.1":
-  version: 14.2.1
-  resolution: "cypress@npm:14.2.1"
+"cypress@npm:14.3.0":
+  version: 14.3.0
+  resolution: "cypress@npm:14.3.0"
   dependencies:
     "@cypress/request": "npm:^3.0.8"
     "@cypress/xvfb": "npm:^1.2.4"
@@ -442,7 +442,7 @@ __metadata:
     yauzl: "npm:^2.10.0"
   bin:
     cypress: bin/cypress
-  checksum: 10c0/d6fb64193098a9d4e55c42d81f427c42eaf1fc015179a4d17706f8c808fe672e1f400bdac90ea280dc8da7c3c80feaf58aa3b230e90877e04199e3c1394381be
+  checksum: 10c0/c331d748498c4b309aa5c94c1372723c690deb6d7c644167cd45fd2079dc8b9a2c32fe4f4a64a0828449faac32e62fbe680ee048e623488b903c2c9742683f07
   languageName: node
   linkType: hard
 
@@ -578,7 +578,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "example-yarn-modern@workspace:."
   dependencies:
-    cypress: "npm:14.2.1"
+    cypress: "npm:14.3.0"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
This PR updates the [examples](https://github.com/cypress-io/github-action/tree/master/examples) to [Cypress 14.3.0](https://docs.cypress.io/app/references/changelog#14-3-0) released Apr 8, 2025.

## Yarn Modern

Yarn Modern is updated to [yarn@4.8.1](https://github.com/yarnpkg/berry/releases/tag/%40yarnpkg%2Fcli%2F4.8.1).