### PR TITLE
test: update to macos-15

### DIFF
--- a/.github/workflows/example-basic-pnpm.yml
+++ b/.github/workflows/example-basic-pnpm.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04, windows-2025, macos-14]
+        os: [ubuntu-24.04, windows-2025, macos-15]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout

--- a/.github/workflows/example-basic.yml
+++ b/.github/workflows/example-basic.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, ubuntu-24.04, windows-2025, macos-14]
+        os: [ubuntu-22.04, ubuntu-24.04, windows-2025, macos-15]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout

--- a/README.md
+++ b/README.md
@@ -833,7 +833,7 @@ jobs:
       - name: Cypress run
         uses: cypress-io/github-action@v6
         with:
-          # Linux and MacOS
+          # Linux and macOS
           start: npm start
           # Takes precedences on Windows
           start-windows: npm run start:windows:server


### PR DESCRIPTION
## Situation

The following workflows use the GitHub Actions runner image [macos-14](https://github.com/actions/runner-images/blob/main/images/macos/macos-14-arm64-Readme.md):

- [.github/workflows/example-basic.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-basic.yml)
- [.github/workflows/example-basic-pnpm.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-basic-pnpm.yml)

GitHub announced the transition of [Windows 2025 and macOS 15 images to GA status](https://github.blog/changelog/2025-04-10-github-actions-macos-15-and-windows-2025-images-are-now-generally-available/) on Apr 10, 2025.

The GitHub Actions runner image [macos-15](https://github.com/actions/runner-images/blob/main/images/macos/macos-15-arm64-Readme.md) is an `arm64` image and is being deployed to run with macOS `15.4` (Sequoia).

## Change

Migrate the following workflows to use [macos-15](https://github.com/actions/runner-images/blob/main/images/macos/macos-15-arm64-Readme.md):

- [.github/workflows/example-basic.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-basic.yml)
- [.github/workflows/example-basic-pnpm.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-basic-pnpm.yml)