### PR TITLE
test: fix pnpm .npmrc

### DIFF
--- a/examples/basic-pnpm/.npmrc
+++ b/examples/basic-pnpm/.npmrc
@@ -1,2 +1,2 @@
-https://pnpm.io/npmrc#side-effects-cache
+# https://pnpm.io/settings#sideeffectscache
 side-effects-cache=false

--- a/examples/start-and-pnpm-workspaces/.npmrc
+++ b/examples/start-and-pnpm-workspaces/.npmrc
@@ -1,2 +1,2 @@
-https://pnpm.io/npmrc#side-effects-cache
+# https://pnpm.io/settings#sideeffectscache
 side-effects-cache=false


### PR DESCRIPTION
## Issue

The `.npmrc` file in the following projects that implements the pnpm configuration [side-effects-cache=false](https://pnpm.io/9.x/npmrc#side-effects-cache) includes a link `https://pnpm.io/npmrc#side-effects-cache` which should be a comment.

Additionally, this link has moved to https://pnpm.io/settings#sideeffectscache.

- [examples/basic-pnpm](https://github.com/cypress-io/github-action/tree/master/examples/basic-pnpm)
- [examples/start-and-pnpm-workspaces](https://github.com/cypress-io/github-action/tree/master/examples/start-and-pnpm-workspaces)

## Change

Change the pnpm sideEffectsCache documentation link to https://pnpm.io/settings#sideeffectscache in the following projects and ensure that the link is a comment:

- [examples/basic-pnpm](https://github.com/cypress-io/github-action/tree/master/examples/basic-pnpm)
- [examples/start-and-pnpm-workspaces](https://github.com/cypress-io/github-action/tree/master/examples/start-and-pnpm-workspaces)

## Related issue

- https://github.com/pnpm/pnpm/issues/9394