### PR TITLE
test: move side-effects-cache=false for pnpm

### DIFF
--- a/README.md
+++ b/README.md
@@ -1147,7 +1147,7 @@ jobs:
 
 The package manager `pnpm` is not pre-installed in [GitHub Actions runner images](https://github.com/actions/runner-images) (unlike `npm` and `yarn`) and so it must be installed in a separate workflow step (see below). If the action finds a `pnpm-lock.yaml` file, it uses the [pnpm](https://pnpm.io/cli/install) command `pnpm install --frozen-lockfile` by default to install dependencies.
 
-The example below follows [pnpm recommendations](https://pnpm.io/continuous-integration#github-actions) for installing pnpm and caching the [pnpm store](https://pnpm.io/cli/store). Add [side-effects-cache=false](https://pnpm.io/npmrc#side-effects-cache) to an `.npmrc` file in your project to allow pnpm to install the Cypress binary even if the Cypress npm module has been cached by pnpm.
+The example below follows [pnpm recommendations](https://pnpm.io/continuous-integration#github-actions) for installing pnpm and caching the [pnpm store](https://pnpm.io/cli/store). Follow the [Cypress pnpm configuration instructions](https://on.cypress.io/install#pnpm-Configuration) and apply them to your project, to enable pnpm to install the Cypress binary.
 
 ```yaml
 name: example-basic-pnpm

--- a/examples/basic-pnpm/.npmrc
+++ b/examples/basic-pnpm/.npmrc
@@ -1,2 +1,0 @@
-# https://pnpm.io/settings#sideeffectscache
-side-effects-cache=false

--- a/examples/basic-pnpm/pnpm-workspace.yaml
+++ b/examples/basic-pnpm/pnpm-workspace.yaml
@@ -1,2 +1,4 @@
 onlyBuiltDependencies:
   - cypress
+
+sideEffectsCache: false

--- a/examples/start-and-pnpm-workspaces/.npmrc
+++ b/examples/start-and-pnpm-workspaces/.npmrc
@@ -1,2 +1,0 @@
-# https://pnpm.io/settings#sideeffectscache
-side-effects-cache=false

--- a/examples/start-and-pnpm-workspaces/pnpm-workspace.yaml
+++ b/examples/start-and-pnpm-workspaces/pnpm-workspace.yaml
@@ -1,4 +1,7 @@
 packages:
   - packages/*
+
 onlyBuiltDependencies:
   - cypress
+
+sideEffectsCache: false


### PR DESCRIPTION
## Issue

1. In order to disable the pnpm side effects cache, to prevent pnpm from skipping Cypress binary installation if the Cypress npm module is already cached, the [Cypress documentation > pnpm Configuration](https://docs.cypress.io/app/get-started/install-cypress#pnpm-Configuration) now recommends using:

    ```shell
    pnpm config set side-effects-cache false --location project
    ```

    This uses ini-syntax and is compatible with pnpm 9.x and earlier 10.x versions. Later versions, such as `pnpm@10.9.0` also accept this syntax and convert it into json-syntax using [sideEffectsCache](https://pnpm.io/settings#sideeffectscache).

2. When the above command is executed on a empty `pnpm@10.9.0` project it writes now to the file `pnpm-workspace.yaml` instead of to `.npmrc`.

3. The pnpm bookmark https://pnpm.io/npmrc#side-effects-cache no longer exists. It has been moved to https://pnpm.io/settings#sideeffectscache as part of https://pnpm.io/settings#build-settings.

## Change

In the [README.md > pnpm](https://github.com/cypress-io/github-action/blob/master/README.md#pnpm) document section, link to https://on.cypress.io/install#pnpm-Configuration so that pnpm configuration instructions are not repeated and can be maintained in one place, on the Cypress documentation site for general use.

In
- [examples/basic-pnpm](https://github.com/cypress-io/github-action/tree/master/examples/basic-pnpm)
- [examples/start-and-pnpm-workspaces](https://github.com/cypress-io/github-action/tree/master/examples/start-and-pnpm-workspaces)

delete `.npmrc` and apply

```shell
pnpm config set side-effects-cache false --location project
```

to update the corresponding `pnpm-workspace.yaml` file with `sideEffectsCache: false`