### PR TITLE
ci: exclude yarn pnp sources from eslint checks

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -14,6 +14,7 @@ export default [
       'examples/nextjs/.next/',
       'examples/nextjs/src/app/',
       'examples/wait-on-vite/dist/',
+      'examples/**/.pnp.*',
     ],
   },
   {


### PR DESCRIPTION
## Issue

ESlint reports warnings from an externally sourced Yarn Plug'n'Play module:

```text
github-action/examples/yarn-modern-pnp/.pnp.cjs
  8519:4   warning  Unused eslint-disable directive (no problems were reported from 'operator-linebreak')
  8570:10  warning  Unused eslint-disable directive (no problems were reported from 'no-undef')
```

## Change

Add externally sourced Yarn Plug'n'Play modules to global ignore list of [eslint.config.mjs](https://github.com/cypress-io/github-action/blob/master/eslint.config.mjs)

```json
examples/**/.pnp.*
```

## Verification

Ubuntu `22.04.2` LTS, Node.js `22.14.0` LTS

```shell
git clean -xfd
npm ci
corepack enable yarn
cd examples/yarn-modern-pnp
yarn
cd ../..
npx eslint
```

and confirm no ESLint warnings or errors are shown.