### PR TITLE
feat: validate other parameters against command parameter when used

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -93982,10 +93982,57 @@ const runTestsUsingCommandLine = async () => {
 
   return exec.exec(quote(npxPath), cmd, opts)
 }
+/**
+ * Validate input parameters for consistency when command parameter is used
+ * Output GitHub actions annotation warning if ignored parameters are used
+ */
+const commandIgnoredBooleanInputs = [
+  // parameter name, default value
+  [`component`, false],
+  [`headed`, false],
+  [`parallel`, false],
+  [`quiet`, false],
+  [`record`, false],
+  [`publish-summary`, true]
+]
+const commandIgnoredStringInputs = [
+  `auto-cancel-after-failures`,
+  `browser`,
+  `ci-build-id`,
+  `config`,
+  `config-file`,
+  `group`,
+  `project`,
+  `spec`,
+  `tag`,
+  `command-prefix`,
+  `summary-title`
+]
+let ignoredInputParameters = []
+const validateCustomCommand = () => {
+  commandIgnoredBooleanInputs.forEach((input) => {
+    const inputParameter = input[0]
+    const inputDefault = input[1]
+    if (getInputBool(inputParameter) !== inputDefault) {
+      ignoredInputParameters.push(inputParameter)
+    }
+  })
+  commandIgnoredStringInputs.forEach((input) => {
+    if (core.getInput(input)) {
+      ignoredInputParameters.push(input)
+    }
+  })
+  if (ignoredInputParameters.length > 0) {
+    core.warning(
+      `command parameter is used and the following other parameters are ignored: ${ignoredInputParameters.sort().join(', ')}.`
+    )
+  }
+}
 
 /**
  * Run Cypress tests by collecting input parameters
  * and using Cypress module API to run tests.
+ * If command parameter is specified, then run using @actions/exec instead.
  * @see https://on.cypress.io/module-api
  */
 const runTests = async () => {
@@ -94014,6 +94061,7 @@ const runTests = async () => {
 
   if (customCommand) {
     console.log('Using custom test command: %s', customCommand)
+    validateCustomCommand() // catch ignored parameters and output warning
     return execCommand(customCommand, true, 'run tests')
   }
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -93988,25 +93988,26 @@ const runTestsUsingCommandLine = async () => {
  */
 const commandIgnoredBooleanInputs = [
   // parameter name, default value
-  [`component`, false],
-  [`headed`, false],
-  [`parallel`, false],
-  [`quiet`, false],
-  [`record`, false],
-  [`publish-summary`, true]
+  ['component', false],
+  ['headed', false],
+  ['parallel', false],
+  ['quiet', false],
+  ['record', false],
+  ['publish-summary', true]
 ]
 const commandIgnoredStringInputs = [
-  `auto-cancel-after-failures`,
-  `browser`,
-  `ci-build-id`,
-  `config`,
-  `config-file`,
-  `group`,
-  `project`,
-  `spec`,
-  `tag`,
-  `command-prefix`,
-  `summary-title`
+  'auto-cancel-after-failures',
+  'browser',
+  'ci-build-id',
+  'config',
+  'config-file',
+  'env',
+  'group',
+  'project',
+  'spec',
+  'tag',
+  'command-prefix',
+  'summary-title'
 ]
 let ignoredInputParameters = []
 const validateCustomCommand = () => {

--- a/index.js
+++ b/index.js
@@ -719,10 +719,57 @@ const runTestsUsingCommandLine = async () => {
 
   return exec.exec(quote(npxPath), cmd, opts)
 }
+/**
+ * Validate input parameters for consistency when command parameter is used
+ * Output GitHub actions annotation warning if ignored parameters are used
+ */
+const commandIgnoredBooleanInputs = [
+  // parameter name, default value
+  [`component`, false],
+  [`headed`, false],
+  [`parallel`, false],
+  [`quiet`, false],
+  [`record`, false],
+  [`publish-summary`, true]
+]
+const commandIgnoredStringInputs = [
+  `auto-cancel-after-failures`,
+  `browser`,
+  `ci-build-id`,
+  `config`,
+  `config-file`,
+  `group`,
+  `project`,
+  `spec`,
+  `tag`,
+  `command-prefix`,
+  `summary-title`
+]
+let ignoredInputParameters = []
+const validateCustomCommand = () => {
+  commandIgnoredBooleanInputs.forEach((input) => {
+    const inputParameter = input[0]
+    const inputDefault = input[1]
+    if (getInputBool(inputParameter) !== inputDefault) {
+      ignoredInputParameters.push(inputParameter)
+    }
+  })
+  commandIgnoredStringInputs.forEach((input) => {
+    if (core.getInput(input)) {
+      ignoredInputParameters.push(input)
+    }
+  })
+  if (ignoredInputParameters.length > 0) {
+    core.warning(
+      `command parameter is used and the following other parameters are ignored: ${ignoredInputParameters.sort().join(', ')}.`
+    )
+  }
+}
 
 /**
  * Run Cypress tests by collecting input parameters
  * and using Cypress module API to run tests.
+ * If command parameter is specified, then run using @actions/exec instead.
  * @see https://on.cypress.io/module-api
  */
 const runTests = async () => {
@@ -751,6 +798,7 @@ const runTests = async () => {
 
   if (customCommand) {
     console.log('Using custom test command: %s', customCommand)
+    validateCustomCommand() // catch ignored parameters and output warning
     return execCommand(customCommand, true, 'run tests')
   }
 

--- a/index.js
+++ b/index.js
@@ -725,25 +725,26 @@ const runTestsUsingCommandLine = async () => {
  */
 const commandIgnoredBooleanInputs = [
   // parameter name, default value
-  [`component`, false],
-  [`headed`, false],
-  [`parallel`, false],
-  [`quiet`, false],
-  [`record`, false],
-  [`publish-summary`, true]
+  ['component', false],
+  ['headed', false],
+  ['parallel', false],
+  ['quiet', false],
+  ['record', false],
+  ['publish-summary', true]
 ]
 const commandIgnoredStringInputs = [
-  `auto-cancel-after-failures`,
-  `browser`,
-  `ci-build-id`,
-  `config`,
-  `config-file`,
-  `group`,
-  `project`,
-  `spec`,
-  `tag`,
-  `command-prefix`,
-  `summary-title`
+  'auto-cancel-after-failures',
+  'browser',
+  'ci-build-id',
+  'config',
+  'config-file',
+  'env',
+  'group',
+  'project',
+  'spec',
+  'tag',
+  'command-prefix',
+  'summary-title'
 ]
 let ignoredInputParameters = []
 const validateCustomCommand = () => {


### PR DESCRIPTION
- closes https://github.com/cypress-io/github-action/issues/1439
- contributes to resolution of issue #1440 

## Situation

When the input parameter `command` is used (see [README > Custom test command](https://github.com/cypress-io/github-action/blob/master/README.md#custom-test-command)) then multiple other command parameters are ignored without error or warning.

If related string parameters are set then they will be ignored.
Boolean input parameters are ignored if they are set different from their default settings.

## Change

Validate input parameters used together with the `command` parameter and emit a GitHub Actions annotations warning if any ignored parameters are being used.

## Example warning

This example contains all possible ignored parameters:

![image](https://github.com/user-attachments/assets/64e91ad8-3843-4935-a8c5-3b4a1ca03ec5)

