### PR TITLE
feat(deps): remove node.js 18

### DIFF
--- a/.github/workflows/example-node-versions.yml
+++ b/.github/workflows/example-node-versions.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [18, 20, 22, 23]
+        node: [20, 22, 23]
     name: Cypress E2E on Node v${{ matrix.node }}
     steps:
       - name: Setup Node

--- a/README.md
+++ b/README.md
@@ -54,7 +54,6 @@ The following examples demonstrate the actions' functions.
 - [Start server](#start-server) before running the tests
 - [Start multiple servers](#start-multiple-servers) before running the tests
 - [Wait for server](#wait-on) to respond before running the tests
-- [`wait-on` with Node.js 18+](#wait-on-with-nodejs-18) workarounds
 - Use [custom install command](#custom-install-command)
 - Use [command prefix](#command-prefix)
 - Use [own custom test command](#custom-test-command)
@@ -529,7 +528,7 @@ jobs:
     # let's make sure our "app" works on several versions of Node
     strategy:
       matrix:
-        node: [18, 20, 22, 23]
+        node: [20, 22, 23]
     name: E2E on Node v${{ matrix.node }}
     steps:
       - name: Setup Node
@@ -555,7 +554,7 @@ The recording will have tags as labels on the run.
 
 ![Tags](images/tags.png)
 
-You can pass multiple tags using commas like `tag: node-18,nightly,staging`.
+You can pass multiple tags using commas like `tag: node-22,nightly,staging`.
 
 ### Auto cancel after failures
 
@@ -915,14 +914,6 @@ You can even use your own command (usually by using `npm`, `yarn`, `npx`) to wai
 See [example-wait-on.yml](.github/workflows/example-wait-on.yml) workflow file.
 
 If this action times out waiting for the server to respond, please see [Debugging](#debugging) section in this README file.
-
-#### `wait-on` with Node.js 18+
-
-Under Node.js version 18 and later, `wait-on` may fail to recognize that a `localhost` server is running. This affects development web servers which do not listen on both IPv4 and IPv6 network stacks.
-
-- Check your server documentation to see if it can be started using `0.0.0.0` (all addresses) and use this if available. If this option is not available or does not resolve the issue then carry on to the next steps:
-- If the action log shows that `wait-on` is failing to connect to `127.0.0.1`, replace `localhost` by `[::1]` (the IPv6 loopback address)
-- If the action log shows that `wait-on` is failing to connect to `::1`, replace `localhost` by `127.0.0.1` (the IPv4 loopback address)
 
 ### Custom install command
 
@@ -1302,7 +1293,7 @@ jobs:
     # let's make sure our "app" works on several versions of Node
     strategy:
       matrix:
-        node: [18, 20, 22, 23]
+        node: [20, 22, 23]
     name: E2E on Node v${{ matrix.node }}
     steps:
       - name: Setup Node
@@ -1336,7 +1327,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        node: [18, 20, 22, 23]
+        node: [20, 22, 23]
     name: E2E on Node v${{ matrix.node }}
     steps:
       - uses: actions/setup-node@v4
@@ -1758,7 +1749,7 @@ jobs:
 
 Node.js is required to run this action. The recommended version `v6` supports:
 
-- **Node.js** 18.x, 20.x, 22.x and 23.x
+- **Node.js** 20.x, 22.x and 23.x
 
 and is generally aligned with [Node.js's release schedule](https://github.com/nodejs/Release).
 


### PR DESCRIPTION
## Situation

Node.js 18.x transitioned into [End-of-life](https://github.com/nodejs/release#release-schedule) status on Apr 30, 2025.

## Change

This PR removes Node.js `18`:

- from the matrix of tested nodes under [.github/workflows/example-node-versions.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-node-versions.yml)
- from the [README > Examples](https://github.com/cypress-io/github-action/blob/master/README.md#examples) section
- from the [README > Node.js > Support](https://github.com/cypress-io/github-action/blob/master/README.md#examples) section

The section [README > `wait-on` with Node.js 18+](https://github.com/cypress-io/github-action/blob/master/README.md#wait-on-with-nodejs-18) is removed. This section describes workarounds which some environments needed to implement after the introduction of [dns changes in Node.js `17.x`](https://nodejs.org/docs/latest-v17.x/api/dns.html#dnslookuphostname-options-callback) where the `verbatim` option defaulted to `true` in `dns.lookup()` - meaning that IPv4 addresses were not automatically placed first. There are no longer significant numbers of users reporting that they are encountering these issues, so leaving this section in place is more likely to confuse than to assist.

## Comments

- Although there is no change to the action itself, this PR triggers a minor version release in order to republish the [README](https://github.com/cypress-io/github-action/blob/master/README.md) to the npm registry for reference.
