### PR TITLE
test: harmonize example custom-ci-build-id to use module API only

### DIFF
--- a/.github/workflows/example-custom-ci-build-id.yml
+++ b/.github/workflows/example-custom-ci-build-id.yml
@@ -13,13 +13,7 @@ name: example-custom-ci-build-id
 # In that case it is important to make sure this build id
 # is generated _again_ on workflow re-run. This example
 # shows how to create a unique ID then pass it to
-# multiple testing jobs running in parallel
-# based on the recipe written in
-# https://medium.com/attest-r-and-d/adding-a-unique-github-build-identifier-7aa2e83cadca
-# The use of set-output is however deprecated by GitHub since the above blog
-# was written in 2019 so this is replaced by GitHub Environment files, see
-# https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#environment-files
-#
+# multiple testing jobs running in parallel.
 
 on:
   push:
@@ -60,14 +54,14 @@ jobs:
     outputs:
       uuid: ${{ steps.uuid.outputs.value }}
     steps:
-      - name: Generate unique ID 💎
+      - name: Generate unique ID
         id: uuid
         # take the current commit + timestamp together
         # the typical value would be something like
         # "sha-5d3fe...35d3-time-1620841214"
         run: echo "value=sha-$GITHUB_SHA-time-$(date +"%s")" >> $GITHUB_OUTPUT
 
-      - name: Print unique ID 🖨`
+      - name: Print unique ID
         run: echo "generated id ${{ steps.uuid.outputs.value }}"
 
   # let's run a small subset of the tests
@@ -76,13 +70,13 @@ jobs:
     needs: [prepare]
     runs-on: ubuntu-24.04
     steps:
-      - name: Checkout 🛎
+      - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Print custom build id 🖨
+      - name: Print custom build id
         run: echo "Custom build id is ${{ needs.prepare.outputs.uuid }}"
 
-      - name: Smoke tests using custom build id 🧪
+      - name: Smoke tests using custom build id
         uses: ./
         with:
           # run just some specs in this group
@@ -104,22 +98,21 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # run 3 copies of the current job in parallel
-        containers: [1, 2, 3]
+        # run 2 copies of the current job in parallel
+        containers: [1, 2]
     steps:
-      - name: Checkout 🛎
+      - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Print custom build id 🖨
+      - name: Print custom build id
         run: echo "Custom build id is ${{ needs.prepare.outputs.uuid }}"
 
-      - name: All tests using custom build id 🧪
+      - name: All tests using custom build id
         uses: ./
         with:
-          # we can pass the build id using CLI argument
-          # since we are using a custom command
-          command: |
-            npx cypress run --record --parallel \
-              --ci-build-id ${{ needs.prepare.outputs.uuid }} \
-              --group "2 - all tests"
+          record: true
+          parallel: true
+          group: '2 - all tests'
+          ci-build-id: ${{ needs.prepare.outputs.uuid }}
+          publish-summary: false # view consolidated test summary on Cypress Cloud
           working-directory: examples/recording


### PR DESCRIPTION
## Situation

The workflow [.github/workflows/example-custom-ci-build-id.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-custom-ci-build-id.yml) contains hybrid use of the action, with both Module API and CLI commands beings used.

The job `smoke-tests` uses regular action parameters

```yml
          record: true
          parallel: true
          group: '1 - smoke tests'
          ci-build-id: ${{ needs.prepare.outputs.uuid }}
          spec: 'cypress/e2e/spec-a.cy.js'
          working-directory: examples/recording
```

The follow-on job `all-tests` uses the action with a CLI command

```yml
          command: |
            npx cypress run --record --parallel \
              --ci-build-id ${{ needs.prepare.outputs.uuid }} \
              --group "2 - all tests"
          working-directory: examples/recording
```

## Assessment

The `command` parameter uses a CLI command to run the action, which by-passes the Module API.

Best practice is however to use non-`command` parameters.

Each of the CLI options can be used with action parameters, so there is no necessity to use the `command` parameter.

## Change

- Convert the `all-tests` job to use action parameters other than `command`. Suppress the [job summary](https://github.com/cypress-io/github-action/blob/master/README.md#suppress-job-summary) with `publish-summary: false` because there are 4 tests load-balanced over 3 containers and the job summary does not consolidate parallel results. Instead, consolidated results can be viewed in Cypress Cloud https://cloud.cypress.io/projects/3tb7jn/runs

```yml
          record: true
          parallel: true
          group: '2 - all tests'
          ci-build-id: ${{ needs.prepare.outputs.uuid }}
          publish-summary: false
          working-directory: examples/recording
```

- Remove the reference to the outdated blog article from the year 2019.

- Remove the icons for consistency with other workflows.

- Reduce `all-tests` job to 2 parallel containers, as even with 3 containers, load-balancing sometimes uses only 2 containers. The [.github/workflows/example-recording.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-recording.yml) workflow, which uses the same [examples/recording](https://github.com/cypress-io/github-action/tree/master/examples/recording) project, also uses only 2 containers.
