### PR TITLE
test: add example-build-artifacts workflow

### DIFF
--- a/.github/workflows/example-build-artifacts.yml
+++ b/.github/workflows/example-build-artifacts.yml
@@ -1,0 +1,58 @@
+name: example-build-artifacts
+# This workflow shows how to split build and test steps with artifacts.
+# In the build job, dependencies are installed, the app is built and the build results
+# are stored as an artifact using actions/upload-artifact.
+# No tests are run in the build job.
+# The test jobs use the results from the build job:
+# - dependencies and the Cypress binary are installed using dependency caching
+# - build results are restored using actions/download-artifact
+on:
+  push:
+    branches:
+      - 'master'
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build app
+        uses: ./ # refers to local instance of cypress-io/github-action@v6
+        with:
+          runTests: false # only build app, don't test yet
+          build: npm run build
+          working-directory: examples/nextjs
+      - name: Store build artifacts
+        uses: actions/upload-artifact@v4 # https://github.com/actions/upload-artifact
+        with:
+          name: app
+          path: examples/nextjs/build
+          if-no-files-found: error
+          retention-days: 1
+
+  test:
+    needs: build
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-24.04, windows-2025, macos-15]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Restore build artifacts
+        uses: actions/download-artifact@v4 # https://github.com/actions/download-artifact
+        with:
+          name: app
+          path: examples/nextjs/build
+
+      - name: Cypress tests
+        uses: ./
+        with:
+          start: npm start # start server using the build artifacts
+          working-directory: examples/nextjs

--- a/.github/workflows/example-build-artifacts.yml
+++ b/.github/workflows/example-build-artifacts.yml
@@ -55,4 +55,5 @@ jobs:
         uses: ./
         with:
           start: npm start # start server using the build artifacts
+          wait-on: http://localhost:3000
           working-directory: examples/nextjs

--- a/README.md
+++ b/README.md
@@ -1393,6 +1393,8 @@ If your test job(s) first need a build step, you can split the jobs into a separ
 
 In the build job, use [upload-artifact](https://github.com/actions/upload-artifact) to store the build results, then in subsequent jobs use [download-artifact](https://github.com/actions/download-artifact) to restore them.
 
+Your tests jobs may use a [GitHub Actions matrix strategy](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/running-variations-of-jobs-in-a-workflow), such as when recording to [Cypress Cloud](https://on.cypress.io/cloud-introduction) with [parallel jobs](#parallel).
+
 ```yml
 name: Split build and test
 on: push

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ The following examples demonstrate the actions' functions.
 - Use [custom cache key](#custom-cache-key)
 - Run tests on multiple [Node versions](#node-versions)
 - Split [install and tests](#split-install-and-tests) into separate jobs
+- Split [install and tests](#split-install-and-test-with-artifacts) with artifacts
 - Use [custom install commands](#custom-install)
 - Install [only Cypress](#install-cypress-only) to avoid installing all dependencies
 - Use [timeouts](#timeouts) to avoid hanging CI jobs
@@ -1385,6 +1386,52 @@ jobs:
 ```
 
 See [cypress-gh-action-monorepo](https://github.com/bahmutov/cypress-gh-action-monorepo) for a working example.
+
+### Split install and test with artifacts
+
+If your test job(s) first need a build step, you can split the jobs into a separate build job followed by test jobs. You pass the build results to any subsequent jobs using [GitHub Actions artifacts](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/storing-and-sharing-data-from-a-workflow).
+
+In the build job, use [upload-artifact](https://github.com/actions/upload-artifact) to store the build results, then in subsequent jobs use [download-artifact](https://github.com/actions/download-artifact) to restore them.
+
+```yml
+name: Split build and test
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build app
+        uses: cypress-io/github-action@v6
+        with:
+          runTests: false # only build app, don't test yet
+          build: npm run build
+      - name: Store build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: app
+          path: build
+          if-no-files-found: error
+          retention-days: 1
+
+  test:
+    needs: build
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Restore build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: app
+          path: build
+
+      - name: Cypress tests
+        uses: cypress-io/github-action@v6
+        with:
+          start: npm start # start server using the build artifacts
+```
+
+[![Split with build artifacts](https://github.com/cypress-io/github-action/actions/workflows/example-build-artifacts.yml/badge.svg)](.github/workflows/example-build-artifacts.yml)
 
 ### Custom install
 

--- a/examples/nextjs/next.config.mjs
+++ b/examples/nextjs/next.config.mjs
@@ -1,4 +1,6 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  distDir: 'build',
+};
 
 export default nextConfig;


### PR DESCRIPTION
- contributes to closure of issue https://github.com/cypress-io/github-action/issues/1455

## Situation

The repo contains no example of splitting jobs between install and test, using stored build artifacts between the jobs.

## Change

- The existing [examples/nextjs](https://github.com/cypress-io/github-action/tree/master/examples/nextjs) example project, which is currently only used in the [.github/workflows/example-wait-on.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-wait-on.yml) workflow, is used in a new workflow `.github/workflows/example-build-artifacts.yml` to show how an install job can pass on build artifacts to a test job.

- The app is tested in 3 different E2E jobs, using Ubuntu, Windows and macOS.