### PR TITLE
docs: remove external artifact examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -1484,8 +1484,6 @@ jobs:
 | [cypress-io/cypress-example-kitchensink](https://github.com/cypress-io/cypress-example-kitchensink) | Runs every API command in Cypress using various CI platforms including GitHub Actions |
 | [cypress-io/cypress-realworld-app](https://github.com/cypress-io/cypress-realworld-app)             | A real-world example payment application. Uses GitHub Actions and CircleCI.           |
 | [cypress-gh-action-monorepo](https://github.com/bahmutov/cypress-gh-action-monorepo)                | Splits install and running tests commands, runs Cypress from sub-folder               |
-| [cypress-examples](https://github.com/bahmutov/cypress-examples)                                    | Shows separate install job from parallel test jobs                                    |
-| [cypress-gh-action-split-jobs](https://github.com/bahmutov/cypress-gh-action-split-jobs)            | Shows a separate install job with the build step, and another job that runs the tests |
 
 ## Migration
 


### PR DESCRIPTION
- closes https://github.com/cypress-io/github-action/issues/1455

## Situation

- PR https://github.com/cypress-io/github-action/pull/1456 added the example workflow [.github/workflows/example-build-artifacts.yml](https://github.com/cypress-io/github-action/blob/example-build-artifacts/.github/workflows/example-build-artifacts.yml) removing the need for similar external examples.
- The README table [More examples](https://github.com/cypress-io/github-action/blob/master/README.md#more-examples) currently contains two related external example links that are now redundant:

  - https://github.com/bahmutov/cypress-examples
  - https://github.com/bahmutov/cypress-gh-action-split-jobs

## Change

Remove the links

  - https://github.com/bahmutov/cypress-examples
  - https://github.com/bahmutov/cypress-gh-action-split-jobs

from the README table [More examples](https://github.com/cypress-io/github-action/blob/master/README.md#more-examples).
