### PR TITLE
tests(deps): add node.js 24 (current) support

### DIFF
--- a/.github/workflows/example-node-versions.yml
+++ b/.github/workflows/example-node-versions.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [20, 22, 23]
+        node: [20, 22, 23, 24]
     name: Cypress E2E on Node v${{ matrix.node }}
     steps:
       - name: Setup Node

--- a/README.md
+++ b/README.md
@@ -529,7 +529,7 @@ jobs:
     # let's make sure our "app" works on several versions of Node
     strategy:
       matrix:
-        node: [20, 22, 23]
+        node: [20, 22, 23, 24]
     name: E2E on Node v${{ matrix.node }}
     steps:
       - name: Setup Node
@@ -1310,7 +1310,7 @@ jobs:
     # let's make sure our "app" works on several versions of Node
     strategy:
       matrix:
-        node: [20, 22, 23]
+        node: [20, 22, 23, 24]
     name: E2E on Node v${{ matrix.node }}
     steps:
       - name: Setup Node
@@ -1344,7 +1344,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        node: [20, 22, 23]
+        node: [20, 22, 23, 24]
     name: E2E on Node v${{ matrix.node }}
     steps:
       - uses: actions/setup-node@v4
@@ -1812,7 +1812,7 @@ jobs:
 
 Node.js is required to run this action. The recommended version `v6` supports:
 
-- **Node.js** 20.x, 22.x and 23.x
+- **Node.js** 20.x, 22.x, 23.x and 24.x
 
 and is generally aligned with [Node.js's release schedule](https://github.com/nodejs/Release).
 


### PR DESCRIPTION
## Situation

[Node.js 24.0.0](https://nodejs.org/en/blog/release/v24.0.0) was released on May 6, 2025.

## Change

This PR adds Node.js `24`:

- to the matrix of tested nodes under [.github/workflows/example-node-versions.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-node-versions.yml)
- to the [README > Example](https://github.com/cypress-io/github-action/blob/master/README.md#examples) section
- to the [README > Node.js > Support](https://github.com/cypress-io/github-action/blob/master/README.md#examples) section

## Comments

- Since there is no change to the action itself, and the additional support of Node.js `24.x` is an extension, there is no version change of the action

- According to [Node.js release schedule](https://github.com/nodejs/release#release-schedule) plans, Node.js `24.x` changes from "Current" status to "LTS" status on Oct 28, 2025.
