### PR TITLE
fix(ci): update semantic-version to 24.2.3

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,7 +45,7 @@ jobs:
         id: semantic
         with:
           # https://github.com/semantic-release/semantic-release
-          semantic_version: 24.1.0
+          semantic_version: 24.2.3
           branches: master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- this may allow issue https://github.com/cypress-io/github-action/issues/1464 to be closed

## Situation

Publication of release `6.9.1` was only partially successful.

The logs show
> An error occurred while running semantic-release: Error: Could not resolve to an Issue with the number of 1416.

There was a related issue resolved in [@semantic-release/github@11.0.1](https://github.com/semantic-release/github/releases/tag/v11.0.1).

## Change

Update the [main](https://github.com/cypress-io/github-action/blob/master/.github/workflows/main.yml) workflow to use `semantic_version: 24.2.3` (`latest`)