### PR TITLE
feat(deps): remove node.js 23

### DIFF
--- a/.github/workflows/example-node-versions.yml
+++ b/.github/workflows/example-node-versions.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [20, 22, 23, 24]
+        node: [20, 22, 24]
     name: Cypress E2E on Node v${{ matrix.node }}
     steps:
       - name: Setup Node

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ See [Releases](https://github.com/cypress-io/github-action/releases) for full de
 
 | Version | Changes                                                                                                      |
 | ------- | ------------------------------------------------------------------------------------------------------------ |
+| v6.10.0 | Examples remove Node.js 23. End of support for Node.js 23.                                                   |
 | v6.9.0  | Add parameter validation for `command`                                                                       |
 | v6.8.0  | Examples remove Node.js 18. End of support for Node.js 18.                                                   |
 | v6.7.10 | Examples updated to Cypress 14                                                                               |

--- a/README.md
+++ b/README.md
@@ -529,7 +529,7 @@ jobs:
     # let's make sure our "app" works on several versions of Node
     strategy:
       matrix:
-        node: [20, 22, 23, 24]
+        node: [20, 22, 24]
     name: E2E on Node v${{ matrix.node }}
     steps:
       - name: Setup Node
@@ -1310,7 +1310,7 @@ jobs:
     # let's make sure our "app" works on several versions of Node
     strategy:
       matrix:
-        node: [20, 22, 23, 24]
+        node: [20, 22, 24]
     name: E2E on Node v${{ matrix.node }}
     steps:
       - name: Setup Node
@@ -1344,7 +1344,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        node: [20, 22, 23, 24]
+        node: [20, 22, 24]
     name: E2E on Node v${{ matrix.node }}
     steps:
       - uses: actions/setup-node@v4
@@ -1812,7 +1812,7 @@ jobs:
 
 Node.js is required to run this action. The recommended version `v6` supports:
 
-- **Node.js** 20.x, 22.x, 23.x and 24.x
+- **Node.js** 20.x, 22.x and 24.x
 
 and is generally aligned with [Node.js's release schedule](https://github.com/nodejs/Release).
 


### PR DESCRIPTION
## Situation

Node.js `23.x` transitioned into [End-of-life](https://github.com/nodejs/release#release-schedule) status on June 1, 2025.

## Change

This PR removes Node.js `23`:

- from the matrix of tested nodes under [.github/workflows/example-node-versions.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-node-versions.yml)
- from the [README > Examples](https://github.com/cypress-io/github-action/blob/master/README.md#examples) section
- from the [README > Node.js > Support](https://github.com/cypress-io/github-action/blob/master/README.md#examples) section

and adds the change to the [CHANGELOG](https://github.com/cypress-io/github-action/blob/master/CHANGELOG.md).

## Comments

- Although there is no change to the action itself, this PR triggers a minor version release in order to republish the [README](https://github.com/cypress-io/github-action/blob/master/README.md) to the npm registry for reference. It also provides a release milestone for reference in the [CHANGELOG](https://github.com/cypress-io/github-action/blob/master/CHANGELOG.md).