### PR TITLE
docs: remove outdated external monorepo example from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1483,7 +1483,6 @@ jobs:
 | --------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
 | [cypress-io/cypress-example-kitchensink](https://github.com/cypress-io/cypress-example-kitchensink) | Runs every API command in Cypress using various CI platforms including GitHub Actions |
 | [cypress-io/cypress-realworld-app](https://github.com/cypress-io/cypress-realworld-app)             | A real-world example payment application. Uses GitHub Actions and CircleCI.           |
-| [cypress-gh-action-monorepo](https://github.com/bahmutov/cypress-gh-action-monorepo)                | Splits install and running tests commands, runs Cypress from sub-folder               |
 
 ## Migration
 


### PR DESCRIPTION
## Situation

The example repo

- https://github.com/bahmutov/cypress-gh-action-monorepo

listed in the README table [More examples](https://github.com/cypress-io/github-action/blob/master/README.md#more-examples) is running `cypress-io/github-action@v5`, which is an outdated and unsupported action version that fails caching.

The latest `v5` version was [v5.8.4](https://github.com/cypress-io/github-action/releases/tag/v5.8.4) released in Aug 2023. This is the version that the example repo is running.

> Download action repository 'cypress-io/github-action@v5' (SHA:248bde77443c376edc45906ede03a1aba9da0462)

Errors are:

> Run cypress-io/github-action@v5
> Warning: Failed to restore: Cache service responded with 422
> Warning: Failed to restore: Cache service responded with 422
> /usr/local/bin/yarn --frozen-lockfile

The repo is being updated solely by Renovate and the last manual updates by the owner / maintainer were done in December 2022.

The lowest supported action version is currently [v6.7.9](https://github.com/cypress-io/github-action/releases/tag/v6.7.9) released in Jan 2025.

## Change

Remove the repo https://github.com/bahmutov/cypress-gh-action-monorepo from the README [More examples](https://github.com/cypress-io/github-action/blob/master/README.md#more-examples) list.

Although the repo is running the latest version of Cypress, it is not running a supported version of the action and so it is not a good example to be promoting.