### PR TITLE
docs: remove legacy v9 references

### DIFF
--- a/.github/workflows/example-custom-ci-build-id.yml
+++ b/.github/workflows/example-custom-ci-build-id.yml
@@ -25,7 +25,7 @@ on:
 env:
   # Set up the Cypress Cloud project ID and record key as environment variables
   # If the Actions secret EXAMPLE_PROJECT_ID is not defined then
-  # the projectId is taken from cypress.json (v9) or cypress.config.js (v10 and later).
+  # the projectId is taken from cypress.config.js.
   # If the Actions secret EXAMPLE_RECORDING_KEY is not defined then recording jobs are skipped.
   CYPRESS_PROJECT_ID: ${{ secrets.EXAMPLE_PROJECT_ID }}
   CYPRESS_RECORD_KEY: ${{ secrets.EXAMPLE_RECORDING_KEY }}

--- a/.github/workflows/example-recording.yml
+++ b/.github/workflows/example-recording.yml
@@ -13,7 +13,7 @@ on:
 env:
   # Set up the Cypress Cloud project ID and record key as environment variables
   # If the Actions secret EXAMPLE_PROJECT_ID is not defined then
-  # the projectId is taken from cypress.json (v9) or cypress.config.js (v10 and later).
+  # the projectId is taken from cypress.config.js.
   # If the Actions secret EXAMPLE_RECORDING_KEY is not defined then recording jobs are skipped.
   CYPRESS_PROJECT_ID: ${{ secrets.EXAMPLE_PROJECT_ID }}
   CYPRESS_RECORD_KEY: ${{ secrets.EXAMPLE_RECORDING_KEY }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,7 +79,7 @@ The repository is set up with a `git` / `Husky` pre-commit hook which ensures th
 
 ### Adding a new example
 
-1. If you are creating a new example, add this as a new project in the `examples` directory. An example project is a regular npm package with its own `package.json` and Cypress dev dependency. (Note: Legacy `examples/v9` are archived in the [v5](https://github.com/cypress-io/github-action/tree/v5/) branch and are no longer supported or maintained.)
+1. If you are creating a new example, add this as a new project in the `examples` directory. An example project is a regular npm package with its own `package.json` and Cypress dev dependency.
 1. Add a corresponding `.github/workflows` YAML file that uses this action and runs using your new `examples/X` through the `working-directory` parameter. The example should demonstrate any new feature.
 1. Add a workflow status badge to the [README.md](README.md) file (see [Adding a workflow status badge](https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/adding-a-workflow-status-badge)), like the following:
 

--- a/docs/MAINTENANCE.md
+++ b/docs/MAINTENANCE.md
@@ -8,8 +8,6 @@ The [examples](../examples) directory contains examples of the use of Cypress (C
 
 The examples make use of [npm](https://www.npmjs.com/), [pnpm](https://pnpm.io/), [Yarn 1 (Classic)](https://classic.yarnpkg.com/) and [Yarn Modern](https://yarnpkg.com/) to define and install the packages being used. For [Yarn Modern](https://yarnpkg.com/) the recommended [Corepack](https://yarnpkg.com/corepack) is used as a Yarn version manager.
 
-_The previous [examples/v9](https://github.com/cypress-io/github-action/tree/v5/examples/v9) are archived in the [v5](https://github.com/cypress-io/github-action/tree/v5/) branch. This directory contains examples which were set up to use Cypress `9.7.0`, the last version using Legacy Configuration, covering Cypress 9 and below. These `v9` examples are no longer maintained._
-
 ## Requirements
 
 - A local system running [Ubuntu](https://ubuntu.com/), <!-- markdown-link-check-disable -->[Microsoft Windows](https://www.microsoft.com/windows/)<!-- markdown-link-check-enable --> or [Apple macOS](https://www.apple.com/macos/).


### PR DESCRIPTION
## Situation

- [Cypress 10.0.0](https://docs.cypress.io/app/references/changelog#10-0-0) was released on June 1, 2022, 3 years ago

- The [Cypress documentation website](https://docs.cypress.io/) no longer contains any configuration information for legacy Cypress version < 10

- Several documents / comments in this repo still refer to Cypress v9, although it is no longer supported.

## Change

Remove references to Cypress v9