### PR TITLE
test: add chrome for testing example

### DIFF
--- a/.github/workflows/example-chrome-for-testing.yml
+++ b/.github/workflows/example-chrome-for-testing.yml
@@ -1,0 +1,28 @@
+name: example-chrome-for-testing
+on:
+  push:
+    branches:
+      - 'master'
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  tests:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install Chrome for Testing
+        # https://github.com/browser-actions/setup-chrome
+        uses: browser-actions/setup-chrome@v1
+        with:
+          chrome-version: 137
+      - name: Cypress info
+        uses: ./
+        with:
+          # just for full picture after installing Cypress
+          # print information about detected browsers, etc
+          # see https://on.cypress.io/command-line#cypress-info
+          build: npm run info
+          working-directory: examples/browser
+          browser: chrome-for-testing

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ The following examples demonstrate the actions' functions.
 - Select [action version](#action-version)
 - Run tests in a given [browser](#browser)
   - using [Chrome](#chrome)
+  - using [Chrome for Testing](#chrome-for-testing)
   - using [Firefox](#firefox)
   - using [Edge](#edge)
   - using [headed mode](#headed)
@@ -177,6 +178,29 @@ jobs:
 ```
 
 [![Chrome example](https://github.com/cypress-io/github-action/actions/workflows/example-chrome.yml/badge.svg)](.github/workflows/example-chrome.yml)
+
+### Chrome for Testing
+
+To install [Google Chrome for Testing](https://developer.chrome.com/blog/chrome-for-testing/), specify a partial or full numerical Chrome for Testing version using [browser-actions/setup-chrome](https://github.com/browser-actions/setup-chrome). Refer to [Chrome for Testing availability](https://googlechromelabs.github.io/chrome-for-testing/) for current versions or [JSON API endpoints](https://github.com/GoogleChromeLabs/chrome-for-testing#json-api-endpoints) for all available versions.
+
+```yml
+name: Chrome for Testing
+on: push
+jobs:
+  chrome:
+    runs-on: ubuntu-24.04
+    name: E2E on Chrome for Testing
+    steps:
+      - uses: actions/checkout@v4
+      - uses: browser-actions/setup-chrome@v1
+        with:
+          chrome-version: 137
+      - uses: cypress-io/github-action@v6
+        with:
+          browser: chrome-for-testing
+```
+
+[![Chrome for Testing example](https://github.com/cypress-io/github-action/actions/workflows/example-chrome-for-testing.yml/badge.svg)](.github/workflows/example-chrome-for-testing.yml)
 
 ### Firefox
 


### PR DESCRIPTION
## Situation

Cypress introduced support for [Google Chrome for Testing](https://developer.chrome.com/blog/chrome-for-testing/) in [cypress@13.17.0](https://docs.cypress.io/app/references/changelog#13-17-0).

[Google restricted the use](https://groups.google.com/a/chromium.org/g/chromium-extensions/c/aEHdhDZ-V0E/m/UWP4-k32AgAJ) of the `--load-extension` flag in Chrome version 137 (May 2025) and above and continues to allow its use in Chrome for Testing. See also [cypress@14.4.0 changelog](https://docs.cypress.io/app/references/changelog#14-4-0).

This repo does not currently describe using Chrome for Testing.

GitHub runner images such as [ubuntu-24.04](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md#browsers-and-drivers) do not include Chrome for Testing. https://github.com/browser-actions/setup-chrome does however provides a JavaScript action to install Chrome for Testing in GitHub runners.

## Change

- Add a workflow `.github/workflows/example-chrome.yml`

- Add a [README](https://github.com/cypress-io/github-action/blob/master/README.md) section "Chrome for Testing"

