### PR TITLE
test(deps): update brace-expansion - Part 2

### DIFF
--- a/examples/config/package-lock.json
+++ b/examples/config/package-lock.json
@@ -466,9 +466,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/examples/nextjs/package-lock.json
+++ b/examples/nextjs/package-lock.json
@@ -1095,9 +1095,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/examples/start/package-lock.json
+++ b/examples/start/package-lock.json
@@ -466,9 +466,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## Situation

`npm audit` reports a low severity vulnerability [CVE-2025-5889](https://github.com/advisories/GHSA-v6h2-p8h4-qcjw) in a transient dependency:

- [brace-expansion](https://www.npmjs.com/package/brace-expansion)

used in action examples. This issue was previously not identified by Dependabot and so PR https://github.com/cypress-io/github-action/pull/1486 did not cover these instances.

Remaining lockfiles with vulnerable versions are:

- [examples/config/package-lock.json](https://github.com/cypress-io/github-action/blob/master/examples/config/package-lock.json)
- [examples/nextjs/package-lock.json](https://github.com/cypress-io/github-action/blob/master/examples/nextjs/package-lock.json)
- [examples/start/package-lock.json](https://github.com/cypress-io/github-action/blob/master/examples/start/package-lock.json)

## Change

Update affected lock files to use:

- [brace-expansion@1.1.12](https://github.com/juliangruber/brace-expansion/releases/tag/v1.1.12)
- [brace-expansion@2.0.2](https://github.com/juliangruber/brace-expansion/releases/tag/v2.0.2)