### PR TITLE
chore(deps): update prettier to 3.6.0

### DIFF
--- a/examples/component-tests/README.md
+++ b/examples/component-tests/README.md
@@ -8,7 +8,6 @@ This example was built as follows:
    ```
    The linting `npm` modules and linting script have been removed, since this is out-of-scope for the example.
 1. The Cypress documentation instructions from [Component Testing > Getting Started](https://on.cypress.io/guides/component-testing/getting-started) were followed to set up component testing, including copying
-
    - `<Stepper />` component: [react/my-awesome-app/src/components/Stepper.jsx](https://github.com/cypress-io/component-testing-quickstart-apps/blob/main/react/my-awesome-app/src/components/Stepper.jsx)
 
    from the [Cypress Component Testing Quickstart Apps](https://github.com/cypress-io/component-testing-quickstart-apps) repo to this repo's `examples/component-tests/src/components/` sub-directory.

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "globals": "16.0.0",
         "husky": "9.1.7",
         "markdown-link-check": "3.13.7",
-        "prettier": "3.5.3"
+        "prettier": "3.6.0"
       }
     },
     "node_modules/@actions/cache": {
@@ -3325,9 +3325,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
-      "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.0.tgz",
+      "integrity": "sha512-ujSB9uXHJKzM/2GBuE0hBOUgC77CN3Bnpqa+g80bkv3T3A93wL/xlzDATHhnhkzifz/UE2SNOvmbTz5hSkDlHw==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "globals": "16.0.0",
     "husky": "9.1.7",
     "markdown-link-check": "3.13.7",
-    "prettier": "3.5.3"
+    "prettier": "3.6.0"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
- supersedes https://github.com/cypress-io/github-action/pull/1489

## Situation

Renovate PR https://github.com/cypress-io/github-action/pull/1489 attempts to update to [prettier@3.6.0](https://prettier.io/blog/2025/06/23/3.6.0) and fails because of a blank line in [examples/component-tests/README.md](https://github.com/cypress-io/github-action/blob/master/examples/component-tests/README.md) 

## Change

Update from [prettier@3.5.3](https://github.com/prettier/prettier/blob/HEAD/CHANGELOG.md#353) to [prettier@3.6.0](https://prettier.io/blog/2025/06/23/3.6.0)

Blank line removal in [examples/component-tests/README.md](https://github.com/cypress-io/github-action/blob/master/examples/component-tests/README.md)

## Verification

On Ubuntu `24.04.2` LTS, Node.js `22.16.0` LTS

```shell
git clean -xfd
npm ci
npm run format:all:check
```

and check that Prettier shows
> All matched files use Prettier code style!