### PR TITLE
chore(deps): update eslint-plugin-cypress to 5.1.0

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,6 +1,6 @@
 import globals from 'globals'
 import pluginJs from '@eslint/js'
-import pluginCypress from 'eslint-plugin-cypress/flat'
+import pluginCypress from 'eslint-plugin-cypress'
 import stylistic from '@stylistic/eslint-plugin'
 
 export default [

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@types/node": "22.13.10",
         "@vercel/ncc": "0.38.1",
         "eslint": "9.29.0",
-        "eslint-plugin-cypress": "4.3.0",
+        "eslint-plugin-cypress": "5.1.0",
         "globals": "16.0.0",
         "husky": "9.1.7",
         "markdown-link-check": "3.13.7",
@@ -1973,22 +1973,22 @@
       }
     },
     "node_modules/eslint-plugin-cypress": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-cypress/-/eslint-plugin-cypress-4.3.0.tgz",
-      "integrity": "sha512-CgS/S940MJlT8jtnWGKI0LvZQBGb/BB0QCpgBOxFMM/Z6znD+PZUwBhCTwHKN2GEr5AOny3xB92an0QfzBGooQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-cypress/-/eslint-plugin-cypress-5.1.0.tgz",
+      "integrity": "sha512-tdLXm4aq9vX2hTtKJTUFD3gdNseMKqsf8+P6hI4TtOPdz1LU4xvTpQBd1++qPAsPZP2lyYh71B5mvzu2lBr4Ow==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "globals": "^15.15.0"
+        "globals": "^16.2.0"
       },
       "peerDependencies": {
         "eslint": ">=9"
       }
     },
     "node_modules/eslint-plugin-cypress/node_modules/globals": {
-      "version": "15.15.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-15.15.0.tgz",
-      "integrity": "sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==",
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-16.2.0.tgz",
+      "integrity": "sha512-O+7l9tPdHCU320IigZZPj5zmRCFG9xHmx9cU8FqU2Rp+JN714seHV+2S9+JslCpY4gJwU2vOGox0wzgae/MCEg==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@types/node": "22.13.10",
     "@vercel/ncc": "0.38.1",
     "eslint": "9.29.0",
-    "eslint-plugin-cypress": "4.3.0",
+    "eslint-plugin-cypress": "5.1.0",
     "globals": "16.0.0",
     "husky": "9.1.7",
     "markdown-link-check": "3.13.7",


### PR DESCRIPTION
- supersedes Renovate PR https://github.com/cypress-io/github-action/pull/1478

## Situation

Release [eslint-plugin-cypress@5.1.0](https://github.com/cypress-io/eslint-plugin-cypress/releases/tag/v5.1.0) is now the latest available release.

## Change

- Update from [eslint-plugin-cypress@4.3.0](https://github.com/cypress-io/eslint-plugin-cypress/releases/tag/v4.3.0) to [eslint-plugin-cypress@5.1.0](https://github.com/cypress-io/eslint-plugin-cypress/releases/tag/v5.1.0)
- Update [eslint.config.mjs](https://github.com/cypress-io/github-action/blob/master/eslint.config.mjs) from using the deprecated configuration `eslint-plugin-cypress/flat` to using the non-deprecated default configuration `eslint-plugin-cypress`.

## Verification

On Ubuntu `24.04.2` LTS, Node.js `22.16.0` LTS

```shell
git clean -xfd
npm ci
npm run lint
```

and confirm that no linting errors are reported.