### PR TITLE
fix(deps): update form-data to 2.5.5 (CVE-2025-7783)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2037,14 +2037,15 @@
       "license": "ISC"
     },
     "node_modules/form-data": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.3.tgz",
-      "integrity": "sha512-XHIrMD0NpDrNM/Ckf7XJiBbLl57KEhT3+i3yY+eWm+cqYZJQTZrKo8Y8AWKnuV5GT4scfuUGt9LzNoIx3dU1nQ==",
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.5.tgz",
+      "integrity": "sha512-jqdObeR2rxZZbPSGL+3VckHMYtu+f9//KXBsVny6JSX/pa38Fy+bGjuG8eW/H6USNQWhLi8Num++cU2yOCNz4A==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
         "mime-types": "^2.1.35",
         "safe-buffer": "^5.2.1"
       },


### PR DESCRIPTION
- resolves reporting of CVE-2025-7783 in action

## Situation

`npm audit` reports https://github.com/advisories/GHSA-fjxv-7rqg-78g4 critical vulnerability CVE-2025-7783 for transient dependency [form-data@2.5.3](https://github.com/form-data/form-data/releases/tag/v2.5.3)

## Steps to reproduce

```
git clone https://github.com/cypress-io/github-action
cd github-action
npm ci
npm audit
```

## Logs

```
$ npm audit
# npm audit report

form-data  <2.5.4
Severity: critical
form-data uses unsafe random function in form-data for choosing boundary - https://github.com/advisories/GHSA-fjxv-7rqg-78g4
fix available via `npm audit fix`
node_modules/form-data

1 critical severity vulnerability

To address all issues, run:
  npm audit fix

$ npm ls form-data
@cypress/github-action@0.0.0-development
└─┬ @actions/cache@4.0.2
  └─┬ @azure/ms-rest-js@2.7.0
    └── form-data@2.5.3
```

## Change

Use `npm audit fix` to update from [form-data@2.5.3](https://github.com/form-data/form-data/releases/tag/v2.5.3) to the non-vulnerable transient dependency [form-data@2.5.5](https://github.com/form-data/form-data/releases/tag/v2.5.5) (current `2.x` latest).

## Comment

- Updating the dependency does not cause any change to the compiled code, so it looks like there was no corresponding vulnerability compiled into the action in the first place. Nevertheless, the PR remediates the vulnerability report in the action and I suggest therefore to merge it.

- This PR does not address vulnerabilities in the examples coming from [cypress@14.5.2](https://github.com/cypress-io/cypress/releases/tag/v14.5.2). This will be handled separately and may depend on an update from Cypress, and Cypress' dependencies. See https://github.com/cypress-io/cypress/issues/32066
