### PR TITLE
docs: correct moved pnpm configuration link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1163,7 +1163,7 @@ jobs:
 
 The package manager `pnpm` is not pre-installed in [GitHub Actions runner images](https://github.com/actions/runner-images) (unlike `npm` and `yarn`) and so it must be installed in a separate workflow step (see below). If the action finds a `pnpm-lock.yaml` file, it uses the [pnpm](https://pnpm.io/cli/install) command `pnpm install --frozen-lockfile` by default to install dependencies.
 
-The example below follows [pnpm recommendations](https://pnpm.io/continuous-integration#github-actions) for installing pnpm and caching the [pnpm store](https://pnpm.io/cli/store). Follow the [Cypress pnpm configuration instructions](https://on.cypress.io/install#pnpm-Configuration) and apply them to your project, to enable pnpm to install the Cypress binary.
+The example below follows [pnpm recommendations](https://pnpm.io/continuous-integration#github-actions) for installing pnpm and caching the [pnpm store](https://pnpm.io/cli/store). Follow the [Cypress pnpm configuration instructions](https://docs.cypress.io/app/get-started/install-cypress#pnpm-configuration) and apply them to your project, to enable pnpm to install the Cypress binary.
 
 ```yaml
 name: example-basic-pnpm


### PR DESCRIPTION
## Situation

Cypress 15 changed the case of the bookmark:

- https://docs.cypress.io/app/get-started/install-cypress#pnpm-Configuration to
- https://docs.cypress.io/app/get-started/install-cypress#pnpm-configuration

The corresponding link in the [README > pnpm](https://github.com/cypress-io/github-action/blob/master/README.md#pnpm) section no longer links to the correct section on the page https://docs.cypress.io/app/get-started/install-cypress

## Change

In the [README > pnpm](https://github.com/cypress-io/github-action/blob/master/README.md#pnpm) section change:

- from https://on.cypress.io/install#pnpm-Configuration

- to https://docs.cypress.io/app/get-started/install-cypress#pnpm-configuration