### PR TITLE
docs: quote npm package name in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ See [Releases](https://github.com/cypress-io/github-action/releases) for full de
 | v6.9.0  | Add parameter validation for `command`                                                                       |
 | v6.8.0  | Examples remove Node.js 18. End of support for Node.js 18.                                                   |
 | v6.7.10 | Examples updated to Cypress 14                                                                               |
-| v6.7.9  | Migrate to @actions/cache@4.0.0 for continued access to GitHub Actions caching services                      |
+| v6.7.9  | Migrate to `@actions/cache@4.0.0` for continued access to GitHub Actions caching services                    |
 | v6.7.0  | Examples remove Node.js 21. End of support for Node.js 21.                                                   |
 | v6.6.0  | Add parameter `summary-title`                                                                                |
 | v6.5.0  | Examples remove Node.js 16. End of support for Node.js 16.                                                   |


### PR DESCRIPTION
## Situation

The workflow [workflows/check-markdown.yml](https://github.com/cypress-io/github-action/actions/workflows/check-markdown.yml) reports a false positive bad link:

```text
FILE: CHANGELOG.md
  [✓] https://github.com/cypress-io/github-action
  [✓] https://github.com/cypress-io/github-action/releases
  [✖] mailto:cache@4.0.0
  [✓] https://github.com/cypress-io/github-action/tree/v5
  [✓] https://on.cypress.io/module-api

  ERROR: 1 dead links found!

  5 links checked.
  [✖] mailto:cache@4.0.0 → Status: 400
```

## Change

In the [CHANGELOG.md](https://github.com/cypress-io/github-action/blob/master/CHANGELOG.md) add code backticks to `@actions/cache@4.0.0` to avoid the npm package name being interpreted as an e-mail address by [markdown-link-check](https://www.npmjs.com/package/markdown-link-check).

## Verify

```shell
npm run check:markdown-links
```

and confirm that no dead links are reported.