### PR TITLE
chore(deps): update on-headers to 1.1.0

### DIFF
--- a/examples/config/package-lock.json
+++ b/examples/config/package-lock.json
@@ -1963,10 +1963,11 @@
       }
     },
     "node_modules/on-headers": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
-      "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.1.0.tgz",
+      "integrity": "sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }

--- a/examples/config/package.json
+++ b/examples/config/package.json
@@ -13,5 +13,10 @@
   "devDependencies": {
     "cypress": "15.0.0",
     "serve": "14.2.4"
+  },
+  "overrides": {
+    "compression": {
+      "on-headers": "1.1.0"
+    }
   }
 }

--- a/examples/start-and-pnpm-workspaces/package.json
+++ b/examples/start-and-pnpm-workspaces/package.json
@@ -2,5 +2,10 @@
   "name": "start-and-pnpm-workspaces",
   "version": "1.0.0",
   "description": "example using pnpm with workspaces",
-  "private": true
+  "private": true,
+  "pnpm": {
+    "overrides": {
+      "on-headers": "1.1.0"
+    }
+  }
 }

--- a/examples/start-and-pnpm-workspaces/pnpm-lock.yaml
+++ b/examples/start-and-pnpm-workspaces/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  on-headers: 1.1.0
+
 importers:
 
   .: {}
@@ -625,8 +628,8 @@ packages:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
     engines: {node: '>= 0.4'}
 
-  on-headers@1.0.2:
-    resolution: {integrity: sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==}
+  on-headers@1.1.0:
+    resolution: {integrity: sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==}
     engines: {node: '>= 0.8'}
 
   once@1.4.0:
@@ -1140,7 +1143,7 @@ snapshots:
       bytes: 3.0.0
       compressible: 2.0.18
       debug: 2.6.9
-      on-headers: 1.0.2
+      on-headers: 1.1.0
       safe-buffer: 5.1.2
       vary: 1.1.2
     transitivePeerDependencies:
@@ -1539,7 +1542,7 @@ snapshots:
 
   object-inspect@1.13.4: {}
 
-  on-headers@1.0.2: {}
+  on-headers@1.1.0: {}
 
   once@1.4.0:
     dependencies:

--- a/examples/start-and-yarn-workspaces/package.json
+++ b/examples/start-and-yarn-workspaces/package.json
@@ -3,5 +3,8 @@
   "workspaces": [
     "workspace-1",
     "workspace-2"
-  ]
+  ],
+  "resolutions": {
+    "on-headers": "~1.1.0"
+  }
 }

--- a/examples/start-and-yarn-workspaces/yarn.lock
+++ b/examples/start-and-yarn-workspaces/yarn.lock
@@ -1096,10 +1096,10 @@ object-inspect@^1.13.3:
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.13.4.tgz#8375265e21bc20d0fa582c22e1b13485d6e00213"
   integrity sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==
 
-on-headers@~1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/on-headers/-/on-headers-1.0.2.tgz#772b0ae6aaa525c399e489adfad90c403eb3c28f"
-  integrity sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==
+on-headers@1.1.0, on-headers@~1.0.2:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/on-headers/-/on-headers-1.1.0.tgz#59da4f91c45f5f989c6e4bcedc5a3b0aed70ff65"
+  integrity sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==
 
 once@^1.3.1, once@^1.4.0:
   version "1.4.0"

--- a/examples/start/package-lock.json
+++ b/examples/start/package-lock.json
@@ -1963,10 +1963,11 @@
       }
     },
     "node_modules/on-headers": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
-      "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.1.0.tgz",
+      "integrity": "sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }

--- a/examples/start/package.json
+++ b/examples/start/package.json
@@ -13,5 +13,10 @@
   "devDependencies": {
     "cypress": "15.0.0",
     "serve": "14.2.4"
+  },
+  "overrides": {
+    "compression": {
+      "on-headers": "1.1.0"
+    }
   }
 }


### PR DESCRIPTION
- Closes https://github.com/cypress-io/github-action/issues/1508

## Situation

The following example directories report low severity vulnerabilities [CVE-2025-7339](https://github.com/advisories/GHSA-76c9-3jph-rj3q) due to their transitive dependency usage of [on-headers](https://www.npmjs.com/package/on-headers) `< 1.1.0`:

Check with `npm audit`:

-  [examples/config](https://github.com/cypress-io/github-action/tree/master/examples/config)
-  [examples/start](https://github.com/cypress-io/github-action/tree/master/examples/start)

Check with `pnpm audit`:

- [examples/start-and-pnpm-workspaces/packages](https://github.com/cypress-io/github-action/tree/master/examples/start-and-pnpm-workspaces/packages)

`yarn audit` shows no issue, however Dependabot reports the vulnerability:

- [examples/start-and-yarn-workspaces/packages](https://github.com/cypress-io/github-action/tree/master/examples/start-and-yarn-workspaces/packages)

Maintainers of the repo [vercel/serve](https://github.com/vercel/serve) are not responding to a related issue / PR that would resolve the vulnerability. These have been open for more than one month.

## Change

Pin to [on-headers@1.1.0](https://github.com/jshttp/on-headers/releases/tag/v1.1.0) using the appropriate option according to the package manager being used:

- npm `package.json` option [overrides](https://docs.npmjs.com/cli/v11/configuring-npm/package-json#overrides)
- [pnpm.overrides](https://pnpm.io/package_json#pnpmoverrides)
- Yarn Classic v1 [resolutions](https://classic.yarnpkg.com/lang/en/docs/selective-version-resolutions/)

