### PR TITLE
docs: harmonize examples 'use: ./' syntax explanation

### DIFF
--- a/.github/workflows/example-basic-pnpm.yml
+++ b/.github/workflows/example-basic-pnpm.yml
@@ -32,10 +32,7 @@ jobs:
           cache-dependency-path: examples/basic-pnpm/pnpm-lock.yaml
 
       - name: Cypress tests
-        # if you copy this workflow to another repository
-        # take the next line as replacement for ./
-        # uses: cypress-io/github-action@v6
-        uses: ./
+        uses: ./ # if copying, replace with cypress-io/github-action@v6
         with:
           working-directory: examples/basic-pnpm
           # print information about detected browsers, etc

--- a/.github/workflows/example-basic.yml
+++ b/.github/workflows/example-basic.yml
@@ -19,9 +19,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Cypress tests
-        # normally you would write
-        # uses: cypress-io/github-action@v6
-        uses: ./
+        uses: ./ # if copying, replace with cypress-io/github-action@v6
         # the parameters below are only necessary
         # because we are running these examples in a monorepo
         with:

--- a/.github/workflows/example-build-artifacts.yml
+++ b/.github/workflows/example-build-artifacts.yml
@@ -6,6 +6,12 @@ name: example-build-artifacts
 # The test jobs use the results from the build job:
 # - dependencies and the Cypress binary are installed using dependency caching
 # - build results are restored using actions/download-artifact
+#
+# In the example jobs, the action is called with
+# uses: ./
+# which runs the action code from the current branch.
+# If you copy this workflow to another repo, replace the above line with
+# uses: cypress-io/github-action@v6
 on:
   push:
     branches:
@@ -21,7 +27,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Build app
-        uses: ./ # refers to local instance of cypress-io/github-action@v6
+        uses: ./
         with:
           runTests: false # only build app, don't test yet
           build: npm run build

--- a/.github/workflows/example-build-artifacts.yml
+++ b/.github/workflows/example-build-artifacts.yml
@@ -10,7 +10,7 @@ name: example-build-artifacts
 # In the example jobs, the action is called with
 # uses: ./
 # which runs the action code from the current branch.
-# If you copy this workflow to another repo, replace the above line with
+# If you copy this workflow to another repo, replace the line with
 # uses: cypress-io/github-action@v6
 on:
   push:

--- a/.github/workflows/example-chrome-for-testing.yml
+++ b/.github/workflows/example-chrome-for-testing.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           chrome-version: 137
       - name: Cypress info
-        uses: ./
+        uses: ./ # if copying, replace with cypress-io/github-action@v6
         with:
           # just for full picture after installing Cypress
           # print information about detected browsers, etc

--- a/.github/workflows/example-chrome.yml
+++ b/.github/workflows/example-chrome.yml
@@ -2,7 +2,7 @@ name: example-chrome
 # In the example jobs, the action is called with
 # uses: ./
 # which runs the action code from the current branch.
-# If you copy this workflow to another repo, replace the above line with
+# If you copy this workflow to another repo, replace the line with
 # uses: cypress-io/github-action@v6
 on:
   push:

--- a/.github/workflows/example-chrome.yml
+++ b/.github/workflows/example-chrome.yml
@@ -1,4 +1,9 @@
 name: example-chrome
+# In the example jobs, the action is called with
+# uses: ./
+# which runs the action code from the current branch.
+# If you copy this workflow to another repo, replace the above line with
+# uses: cypress-io/github-action@v6
 on:
   push:
     branches:

--- a/.github/workflows/example-component-test.yml
+++ b/.github/workflows/example-component-test.yml
@@ -13,9 +13,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Cypress run
-        # normally you would write
-        # uses: cypress-io/github-action@v6
-        uses: ./
+        uses: ./ # if copying, replace with cypress-io/github-action@v6
         with:
           working-directory: examples/component-tests
           component: true

--- a/.github/workflows/example-config.yml
+++ b/.github/workflows/example-config.yml
@@ -2,7 +2,7 @@ name: example-config
 # In the example jobs, the action is called with
 # uses: ./
 # which runs the action code from the current branch.
-# If you copy this workflow to another repo, replace the above line with
+# If you copy this workflow to another repo, replace the line with
 # uses: cypress-io/github-action@v6
 on:
   push:

--- a/.github/workflows/example-config.yml
+++ b/.github/workflows/example-config.yml
@@ -1,4 +1,9 @@
 name: example-config
+# In the example jobs, the action is called with
+# uses: ./
+# which runs the action code from the current branch.
+# If you copy this workflow to another repo, replace the above line with
+# uses: cypress-io/github-action@v6
 on:
   push:
     branches:

--- a/.github/workflows/example-cron.yml
+++ b/.github/workflows/example-cron.yml
@@ -13,6 +13,6 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Cypress nightly tests 🌃
-        uses: ./
+        uses: ./ # if copying, replace with cypress-io/github-action@v6
         with:
           working-directory: examples/basic

--- a/.github/workflows/example-custom-ci-build-id.yml
+++ b/.github/workflows/example-custom-ci-build-id.yml
@@ -18,7 +18,7 @@ name: example-custom-ci-build-id
 # In the example jobs, the action is called with
 # uses: ./
 # which runs the action code from the current branch.
-# If you copy this workflow to another repo, replace the above line with
+# If you copy this workflow to another repo, replace the line with
 # uses: cypress-io/github-action@v6
 on:
   push:

--- a/.github/workflows/example-custom-ci-build-id.yml
+++ b/.github/workflows/example-custom-ci-build-id.yml
@@ -14,7 +14,12 @@ name: example-custom-ci-build-id
 # is generated _again_ on workflow re-run. This example
 # shows how to create a unique ID then pass it to
 # multiple testing jobs running in parallel.
-
+#
+# In the example jobs, the action is called with
+# uses: ./
+# which runs the action code from the current branch.
+# If you copy this workflow to another repo, replace the above line with
+# uses: cypress-io/github-action@v6
 on:
   push:
     branches:

--- a/.github/workflows/example-custom-command.yml
+++ b/.github/workflows/example-custom-command.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Custom tests
-        uses: ./
+        uses: ./ # if copying, replace with cypress-io/github-action@v6
         with:
           command: npm run custom-test
           working-directory: examples/custom-command

--- a/.github/workflows/example-debug.yml
+++ b/.github/workflows/example-debug.yml
@@ -1,15 +1,13 @@
 name: example-debug
-
 # This workflow demonstrates how to use the DEBUG environment variable to get debug output.
 # See also https://github.com/cypress-io/github-action/blob/master/README.md#debugging and
 # https://on.cypress.io/troubleshooting#Print-DEBUG-logs
-
+#
 # In the example jobs, the action is called with
 # uses: ./
 # which runs the action code from the current branch.
 # If you copy this workflow to another repo, replace the above line with
 # uses: cypress-io/github-action@v6
-
 on:
   push:
     branches:

--- a/.github/workflows/example-debug.yml
+++ b/.github/workflows/example-debug.yml
@@ -6,7 +6,7 @@ name: example-debug
 # In the example jobs, the action is called with
 # uses: ./
 # which runs the action code from the current branch.
-# If you copy this workflow to another repo, replace the above line with
+# If you copy this workflow to another repo, replace the line with
 # uses: cypress-io/github-action@v6
 on:
   push:

--- a/.github/workflows/example-docker.yml
+++ b/.github/workflows/example-docker.yml
@@ -24,7 +24,7 @@ jobs:
       # replace with the following for regular use:
       # uses: cypress-io/github-action@v6
       - name: Cypress tests
-        uses: ./
+        uses: ./ # if copying, replace with cypress-io/github-action@v6
         with:
           working-directory: examples/basic
           browser: ${{ matrix.browser }}

--- a/.github/workflows/example-edge.yml
+++ b/.github/workflows/example-edge.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Cypress info
-        uses: ./
+        uses: ./ # if copying, replace with cypress-io/github-action@v6
         with:
           # just for full picture after installing Cypress
           # print information about detected browsers, etc

--- a/.github/workflows/example-env.yml
+++ b/.github/workflows/example-env.yml
@@ -2,7 +2,7 @@ name: example-env
 # In the example jobs, the action is called with
 # uses: ./
 # which runs the action code from the current branch.
-# If you copy this workflow to another repo, replace the above line with
+# If you copy this workflow to another repo, replace the line with
 # uses: cypress-io/github-action@v6
 on:
   push:

--- a/.github/workflows/example-env.yml
+++ b/.github/workflows/example-env.yml
@@ -1,4 +1,9 @@
 name: example-env
+# In the example jobs, the action is called with
+# uses: ./
+# which runs the action code from the current branch.
+# If you copy this workflow to another repo, replace the above line with
+# uses: cypress-io/github-action@v6
 on:
   push:
     branches:

--- a/.github/workflows/example-firefox.yml
+++ b/.github/workflows/example-firefox.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Firefox
-        uses: ./
+        uses: ./ # if copying, replace with cypress-io/github-action@v6
         timeout-minutes: 3
         with:
           # let's show browser and system info

--- a/.github/workflows/example-install-command.yml
+++ b/.github/workflows/example-install-command.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Custom Yarn command
-        uses: ./
+        uses: ./ # if copying, replace with cypress-io/github-action@v6
         with:
           working-directory: examples/install-command
           # https://classic.yarnpkg.com/en/docs/cli/install

--- a/.github/workflows/example-install-only.yml
+++ b/.github/workflows/example-install-only.yml
@@ -32,7 +32,7 @@ jobs:
         run: npm install cypress@15.0.0 --save-dev
 
       - name: Cypress tests 🧪
-        uses: ./
+        uses: ./ # if copying, replace with cypress-io/github-action@v6
         with:
           working-directory: examples/install-only
           install: false

--- a/.github/workflows/example-node-versions.yml
+++ b/.github/workflows/example-node-versions.yml
@@ -26,6 +26,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - uses: ./
+      - uses: ./ # if copying, replace with cypress-io/github-action@v6
         with:
           working-directory: examples/node-versions

--- a/.github/workflows/example-node-versions.yml
+++ b/.github/workflows/example-node-versions.yml
@@ -26,6 +26,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - uses: ./ # if copying, replace with cypress-io/github-action@v6
+      - name: Cypress tests
+        uses: ./ # if copying, replace with cypress-io/github-action@v6
         with:
           working-directory: examples/node-versions

--- a/.github/workflows/example-quiet.yml
+++ b/.github/workflows/example-quiet.yml
@@ -15,7 +15,7 @@ jobs:
       # Install npm dependencies, cache them correctly
       # and run all Cypress tests with `quiet` parameter
       - name: Cypress run
-        uses: ./
+        uses: ./ # if copying, replace with cypress-io/github-action@v6
         with:
           working-directory: examples/quiet
           quiet: true

--- a/.github/workflows/example-recording.yml
+++ b/.github/workflows/example-recording.yml
@@ -6,7 +6,7 @@ name: example-recording
 # In the example jobs, the action is called with
 # uses: ./
 # which runs the action code from the current branch.
-# If you copy this workflow to another repo, replace the above line with
+# If you copy this workflow to another repo, replace the line with
 # uses: cypress-io/github-action@v6
 on:
   push:

--- a/.github/workflows/example-recording.yml
+++ b/.github/workflows/example-recording.yml
@@ -3,6 +3,11 @@ name: example-recording
 # To set up this workflow to work with your own Cypress Cloud project
 # refer to the README in the example directory examples/recording.
 #
+# In the example jobs, the action is called with
+# uses: ./
+# which runs the action code from the current branch.
+# If you copy this workflow to another repo, replace the above line with
+# uses: cypress-io/github-action@v6
 on:
   push:
     branches:

--- a/.github/workflows/example-start-and-pnpm-workspaces.yml
+++ b/.github/workflows/example-start-and-pnpm-workspaces.yml
@@ -1,4 +1,9 @@
 name: example-start-and-pnpm-workspaces
+# In the example jobs, the action is called with
+# uses: ./
+# which runs the action code from the current branch.
+# If you copy this workflow to another repo, replace the above line with
+# uses: cypress-io/github-action@v6
 on:
   push:
     branches:
@@ -45,7 +50,7 @@ jobs:
 
       - name: Cypress test Single
         # Run Cypress in examples/start-and-pnpm-workspaces/packages/workspace-1 only
-        uses: ./ # equivalent to using cypress-io/github-action@v6
+        uses: ./
         with:
           # Do not attempt to install dependencies in the workspace using the action.
           # There is no pnpm-lock.yaml file in a workspace for
@@ -78,7 +83,7 @@ jobs:
         run: npm install -g pnpm@10
 
       - name: Install dependencies
-        uses: ./ # approximately equivalent to using cypress-io/github-action@v6
+        uses: ./
         with:
           working-directory: examples/start-and-pnpm-workspaces
           runTests: false
@@ -87,7 +92,7 @@ jobs:
         # Run Cypress in
         # examples/start-and-pnpm-workspaces/packages/workspace-1 and
         # examples/start-and-pnpm-workspaces/packages/workspace-2
-        uses: ./ # equivalent to using cypress-io/github-action@v6
+        uses: ./
         with:
           install: false
           working-directory: ${{ matrix.cypress.working_directory }}

--- a/.github/workflows/example-start-and-pnpm-workspaces.yml
+++ b/.github/workflows/example-start-and-pnpm-workspaces.yml
@@ -2,7 +2,7 @@ name: example-start-and-pnpm-workspaces
 # In the example jobs, the action is called with
 # uses: ./
 # which runs the action code from the current branch.
-# If you copy this workflow to another repo, replace the above line with
+# If you copy this workflow to another repo, replace the line with
 # uses: cypress-io/github-action@v6
 on:
   push:

--- a/.github/workflows/example-start-and-yarn-workspaces.yml
+++ b/.github/workflows/example-start-and-yarn-workspaces.yml
@@ -1,4 +1,9 @@
 name: example-start-and-yarn-workspaces
+# In the example jobs, the action is called with
+# uses: ./
+# which runs the action code from the current branch.
+# If you copy this workflow to another repo, replace the above line with
+# uses: cypress-io/github-action@v6
 on:
   push:
     branches:

--- a/.github/workflows/example-start-and-yarn-workspaces.yml
+++ b/.github/workflows/example-start-and-yarn-workspaces.yml
@@ -2,7 +2,7 @@ name: example-start-and-yarn-workspaces
 # In the example jobs, the action is called with
 # uses: ./
 # which runs the action code from the current branch.
-# If you copy this workflow to another repo, replace the above line with
+# If you copy this workflow to another repo, replace the line with
 # uses: cypress-io/github-action@v6
 on:
   push:

--- a/.github/workflows/example-start.yml
+++ b/.github/workflows/example-start.yml
@@ -2,7 +2,7 @@ name: example-start
 # In the example jobs, the action is called with
 # uses: ./
 # which runs the action code from the current branch.
-# If you copy this workflow to another repo, replace the above line with
+# If you copy this workflow to another repo, replace the line with
 # uses: cypress-io/github-action@v6
 on:
   push:

--- a/.github/workflows/example-start.yml
+++ b/.github/workflows/example-start.yml
@@ -1,4 +1,9 @@
 name: example-start
+# In the example jobs, the action is called with
+# uses: ./
+# which runs the action code from the current branch.
+# If you copy this workflow to another repo, replace the above line with
+# uses: cypress-io/github-action@v6
 on:
   push:
     branches:

--- a/.github/workflows/example-wait-on.yml
+++ b/.github/workflows/example-wait-on.yml
@@ -2,7 +2,7 @@ name: example-wait-on
 # In the example jobs, the action is called with
 # uses: ./
 # which runs the action code from the current branch.
-# If you copy this workflow to another repo, replace the above line with
+# If you copy this workflow to another repo, replace the line with
 # uses: cypress-io/github-action@v6
 on:
   push:

--- a/.github/workflows/example-wait-on.yml
+++ b/.github/workflows/example-wait-on.yml
@@ -1,4 +1,9 @@
 name: example-wait-on
+# In the example jobs, the action is called with
+# uses: ./
+# which runs the action code from the current branch.
+# If you copy this workflow to another repo, replace the above line with
+# uses: cypress-io/github-action@v6
 on:
   push:
     branches:

--- a/.github/workflows/example-webpack.yml
+++ b/.github/workflows/example-webpack.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Cypress tests
-        uses: ./
+        uses: ./ # if copying, replace with cypress-io/github-action@v6
         with:
           working-directory: examples/webpack
           start: npm start

--- a/.github/workflows/example-yarn-classic.yml
+++ b/.github/workflows/example-yarn-classic.yml
@@ -14,6 +14,6 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Test with Yarn Classic
-        uses: ./
+        uses: ./ # if copying, replace with cypress-io/github-action@v6
         with:
           working-directory: examples/yarn-classic

--- a/.github/workflows/example-yarn-modern-pnp.yml
+++ b/.github/workflows/example-yarn-modern-pnp.yml
@@ -27,7 +27,7 @@ jobs:
           npm install -g corepack
           corepack enable yarn
       - name: Custom Yarn command
-        uses: ./
+        uses: ./ # if copying, replace with cypress-io/github-action@v6
         with:
           working-directory: examples/yarn-modern-pnp
           # https://yarnpkg.com/cli/install

--- a/.github/workflows/example-yarn-modern.yml
+++ b/.github/workflows/example-yarn-modern.yml
@@ -27,7 +27,7 @@ jobs:
           npm install -g corepack
           corepack enable yarn
       - name: Custom Yarn command
-        uses: ./
+        uses: ./ # if copying, replace with cypress-io/github-action@v6
         with:
           working-directory: examples/yarn-modern
           # https://yarnpkg.com/cli/install

--- a/README.md
+++ b/README.md
@@ -157,6 +157,12 @@ Alternatively, to mitigate unforeseen breaks, bind to a specific [tag](https://g
 
 The changes associated with each tag are shown under GitHub's [releases](https://github.com/cypress-io/github-action/releases) list. Refer also to the [CHANGELOG](./CHANGELOG.md) for an overview of major changes.
 
+The workflows in the [examples](./examples/) directory use the latest commit from the repo's current branch. This allows all tests to run in CI before release. If you copy any of the examples to your own repo, you should replace `./` and specify instead the action and version as described above.
+
+```yml
+- uses: ./ # replace with cypress-io/github-action@v6
+```
+
 ### Browser
 
 Specify the browser name or path with the `browser` parameter. The default browser, if none is specified, is the built-in [Electron browser](https://on.cypress.io/guides/guides/launching-browsers#Electron-Browser).
@@ -660,7 +666,7 @@ jobs:
       # Install npm dependencies, cache them correctly
       # and run all Cypress tests with `quiet` parameter
       - name: Cypress run
-        uses: ./
+        uses: cypress-io/github-action@v6
         with:
           working-directory: examples/quiet
           quiet: true


### PR DESCRIPTION
## Situation

Example workflows, such as [.github/workflows/example-basic.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-basic.yml) include the syntax `uses: ./` to run the action from the root of the repo's current branch. This is not explained in the [README](https://github.com/cypress-io/github-action/blob/master/README.md) and the comments in the different example workflows in the [.github/workflows](https://github.com/cypress-io/github-action/blob/master/.github/workflows) are inconsistently worded. Some workflows don't contain any related remark.

## Change

- Add an explanation to the [README](https://github.com/cypress-io/github-action/blob/master/README.md) about `uses: ./`
- Add a comment to the workflows:
```yml
uses: ./ # if copying, replace with cypress-io/github-action@v6
```

For workflows with multiple calls to the action, add a comment at the top of the workflow to avoid replicating the comment on multiple lines:

```yml
# In the example jobs, the action is called with
# uses: ./
# which runs the action code from the current branch.
# If you copy this workflow to another repo, replace the above line with
# uses: cypress-io/github-action@v6
````
