### PR TITLE
docs: remove additional 'use: ./' syntax duplicated explanations

### DIFF
--- a/.github/workflows/example-docker.yml
+++ b/.github/workflows/example-docker.yml
@@ -21,8 +21,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      # replace with the following for regular use:
-      # uses: cypress-io/github-action@v6
       - name: Cypress tests
         uses: ./ # if copying, replace with cypress-io/github-action@v6
         with:

--- a/.github/workflows/example-recording.yml
+++ b/.github/workflows/example-recording.yml
@@ -53,8 +53,6 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Cypress tests
-        # normally you would write
-        # uses: cypress-io/github-action@v6
         uses: ./
         # let's give this action an ID so we can refer
         # to its output values later
@@ -84,8 +82,6 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Cypress tests
-        # normally you would write
-        # uses: cypress-io/github-action@v6
         uses: ./
         with:
           working-directory: examples/recording

--- a/.github/workflows/example-start-and-pnpm-workspaces.yml
+++ b/.github/workflows/example-start-and-pnpm-workspaces.yml
@@ -37,13 +37,7 @@ jobs:
         # the root of the pnpm workspace examples/start-and-pnpm-workspaces
         # to be installed
         # AND it automatically caches the Cypress binary.
-        #
-        # If you copy this workflow to another repository replace the following with
-        # uses: cypress-io/github-action@v6
-        # The notation ./ is a special usage only used here.
-        # It causes the version of the action code from whatever branch it is launched in to be used.
-        # Do not try to use the ./ notation this outside of this repository!
-        uses: ./ # approximately equivalent to using cypress-io/github-action@v6
+        uses: ./
         with:
           working-directory: examples/start-and-pnpm-workspaces
           runTests: false


### PR DESCRIPTION
## Situation

PR https://github.com/cypress-io/github-action/pull/1534 changed comments to harmonize the explanation of the `use: ./` syntax. Some previous text, that should have been removed, was however overlooked.

## Change

Remove remnant and duplicated old explanations for the `use: ./` syntax in workflow examples.