### PR TITLE
test(deps): update setup-chrome to v2

### DIFF
--- a/.github/workflows/example-chrome-for-testing.yml
+++ b/.github/workflows/example-chrome-for-testing.yml
@@ -14,9 +14,9 @@ jobs:
         uses: actions/checkout@v4
       - name: Install Chrome for Testing
         # https://github.com/browser-actions/setup-chrome
-        uses: browser-actions/setup-chrome@v1
+        uses: browser-actions/setup-chrome@v2
         with:
-          chrome-version: 137
+          chrome-version: 140
       - name: Cypress info
         uses: ./ # if copying, replace with cypress-io/github-action@v6
         with:

--- a/README.md
+++ b/README.md
@@ -198,9 +198,9 @@ jobs:
     name: E2E on Chrome for Testing
     steps:
       - uses: actions/checkout@v4
-      - uses: browser-actions/setup-chrome@v1
+      - uses: browser-actions/setup-chrome@v2
         with:
-          chrome-version: 137
+          chrome-version: 140
       - uses: cypress-io/github-action@v6
         with:
           browser: chrome-for-testing


### PR DESCRIPTION
- supersedes https://github.com/cypress-io/github-action/pull/1530, since this would only update the workflow, not the documentation

## Situation

- [README > Chrome for Testing](https://github.com/cypress-io/github-action/blob/master/README.md#chrome-for-testing)
- [.github/workflows/example-chrome-for-testing.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-chrome-for-testing.yml)

show outdated versions:

```yaml
      - uses: browser-actions/setup-chrome@v1
        with:
          chrome-version: 137
```

- The current action version is [browser-actions/setup-chrome@v2.1.0](https://github.com/browser-actions/setup-chrome/releases/tag/v2.1.0), with major version `v2`
- The current [Chrome for Testing](https://googlechromelabs.github.io/chrome-for-testing/) version is `140.0.7339.82`, with major version `140`
- Cypress officially supports the latest 3 major versions of Chrome, which would be currently `140`, `139` & `138`

## Change

In

- [README > Chrome for Testing](https://github.com/cypress-io/github-action/blob/master/README.md#chrome-for-testing)
- [.github/workflows/example-chrome-for-testing.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-chrome-for-testing.yml)

update to:

```yaml
      - uses: browser-actions/setup-chrome@v2
        with:
          chrome-version: 140
```
