### PR TITLE
test(deps): add Node.js 25 (current) support

### DIFF
--- a/.github/workflows/example-node-versions.yml
+++ b/.github/workflows/example-node-versions.yml
@@ -13,7 +13,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [20, 22, 24]
+        node:
+          - 20
+          - 22
+          - 24
+          - 25
     name: Cypress E2E on Node v${{ matrix.node }}
     steps:
       - name: Setup Node

--- a/README.md
+++ b/README.md
@@ -563,7 +563,7 @@ jobs:
     # let's make sure our "app" works on several versions of Node
     strategy:
       matrix:
-        node: [20, 22, 24]
+        node: [20, 22, 24, 25]
     name: E2E on Node v${{ matrix.node }}
     steps:
       - name: Setup Node
@@ -1344,7 +1344,7 @@ jobs:
     # let's make sure our "app" works on several versions of Node
     strategy:
       matrix:
-        node: [20, 22, 24]
+        node: [20, 22, 24, 25]
     name: E2E on Node v${{ matrix.node }}
     steps:
       - name: Setup Node
@@ -1378,7 +1378,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        node: [20, 22, 24]
+        node: [20, 22, 24, 25]
     name: E2E on Node v${{ matrix.node }}
     steps:
       - uses: actions/setup-node@v4
@@ -1845,7 +1845,7 @@ jobs:
 
 Node.js is required to run this action. The recommended version `v6` supports:
 
-- **Node.js** 20.x, 22.x and 24.x
+- **Node.js** 20.x, 22.x, 24.x and 25.x
 
 and is generally aligned with [Node.js's release schedule](https://github.com/nodejs/Release).
 


### PR DESCRIPTION
## Situation

[Node.js v25.0.0 (Current)](https://nodejs.org/en/blog/release/v25.0.0) was released on Oct 15, 2025.

## Change

This PR adds Node.js `25`:

- to the matrix of tested nodes under [.github/workflows/example-node-versions.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-node-versions.yml)
- to the [README](https://github.com/cypress-io/github-action/blob/master/README.md) sections that describe testing across multiple node versions in a `matrix`
- to the [README > Node.js > Support](https://github.com/cypress-io/github-action/blob/master/README.md#examples) section

## Comments

- Since there is no change to the action itself, and the additional support of Node.js `25.x` is an extension, there is no version change of the action

- According to [Node.js release schedule](https://github.com/nodejs/release) plans, Node.js `25.x` reaches end-of-life on Jun 1, 2026

- Node.js `25.0.0` is the first supported release without [Corepack](https://github.com/nodejs/corepack) being bundled. The following workflows are the only ones that use Corepack, and they are already written so they do not rely on Corepack being bundled with Node.js:
  - [.github/workflows/example-yarn-modern.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-yarn-modern.yml)
  - [.github/workflows/example-yarn-modern-pnp.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-yarn-modern-pnp.yml)

- Cypress itself continues to run under Node.js `v20.19.4` within the action, and using the Cypress Module API, as explained in the [README > Usage](https://github.com/cypress-io/github-action/blob/master/README.md#usage) section. Issue https://github.com/cypress-io/github-action/issues/1519 is waiting for prerequisite conditions to be fulfilled before upgrading to Node.js 24 usage in general.