### PR TITLE
chore(deps): update actions/checkout to v5

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Setup Node
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/check-markdown.yml
+++ b/.github/workflows/check-markdown.yml
@@ -12,7 +12,7 @@ jobs:
     name: Check Markdown files
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Install dependencies
         run: npm ci
       - name: Check Markdown links

--- a/.github/workflows/example-basic-pnpm.yml
+++ b/.github/workflows/example-basic-pnpm.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
         # See https://github.com/pnpm/action-setup
       - name: Install pnpm

--- a/.github/workflows/example-basic.yml
+++ b/.github/workflows/example-basic.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Cypress tests
         uses: ./ # if copying, replace with cypress-io/github-action@v6

--- a/.github/workflows/example-build-artifacts.yml
+++ b/.github/workflows/example-build-artifacts.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Build app
         uses: ./
@@ -49,7 +49,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Restore build artifacts
         uses: actions/download-artifact@v4 # https://github.com/actions/download-artifact

--- a/.github/workflows/example-chrome-for-testing.yml
+++ b/.github/workflows/example-chrome-for-testing.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Install Chrome for Testing
         # https://github.com/browser-actions/setup-chrome
         uses: browser-actions/setup-chrome@v2

--- a/.github/workflows/example-chrome.yml
+++ b/.github/workflows/example-chrome.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Chrome headless
         uses: ./

--- a/.github/workflows/example-component-test.yml
+++ b/.github/workflows/example-component-test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Cypress run
         uses: ./ # if copying, replace with cypress-io/github-action@v6
         with:

--- a/.github/workflows/example-config.yml
+++ b/.github/workflows/example-config.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Cypress tests
         uses: ./
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Cypress tests
         uses: ./
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Cypress tests
         uses: ./
@@ -68,7 +68,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Cypress tests
         uses: ./

--- a/.github/workflows/example-cron.yml
+++ b/.github/workflows/example-cron.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Cypress nightly tests 🌃
         uses: ./ # if copying, replace with cypress-io/github-action@v6

--- a/.github/workflows/example-custom-ci-build-id.yml
+++ b/.github/workflows/example-custom-ci-build-id.yml
@@ -76,7 +76,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Print custom build id
         run: echo "Custom build id is ${{ needs.prepare.outputs.uuid }}"
@@ -107,7 +107,7 @@ jobs:
         containers: [1, 2]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Print custom build id
         run: echo "Custom build id is ${{ needs.prepare.outputs.uuid }}"

--- a/.github/workflows/example-custom-command.yml
+++ b/.github/workflows/example-custom-command.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Custom tests
         uses: ./ # if copying, replace with cypress-io/github-action@v6

--- a/.github/workflows/example-debug.yml
+++ b/.github/workflows/example-debug.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Cypress action debug logs
         uses: ./
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Cypress debug logs
         uses: ./
@@ -53,7 +53,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Cypress npm install
         # Install only the Cypress npm module

--- a/.github/workflows/example-docker.yml
+++ b/.github/workflows/example-docker.yml
@@ -20,7 +20,7 @@ jobs:
       options: --user 1001
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Cypress tests
         uses: ./ # if copying, replace with cypress-io/github-action@v6
         with:

--- a/.github/workflows/example-edge.yml
+++ b/.github/workflows/example-edge.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Cypress info
         uses: ./ # if copying, replace with cypress-io/github-action@v6

--- a/.github/workflows/example-env.yml
+++ b/.github/workflows/example-env.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       # in the tests below, only the environment
       # variable 'environmentName' will be set
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Cypress run with env
         uses: ./
@@ -57,7 +57,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Cypress run with env
         uses: ./
@@ -79,7 +79,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Cypress run with env
         uses: ./

--- a/.github/workflows/example-firefox.yml
+++ b/.github/workflows/example-firefox.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Firefox
         uses: ./ # if copying, replace with cypress-io/github-action@v6

--- a/.github/workflows/example-install-command.yml
+++ b/.github/workflows/example-install-command.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Custom Yarn command
         uses: ./ # if copying, replace with cypress-io/github-action@v6

--- a/.github/workflows/example-install-only.yml
+++ b/.github/workflows/example-install-only.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout 🛎
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       # cache npm modules and Cypress binary folder
       # we can use "package-lock.json" as the key file

--- a/.github/workflows/example-node-versions.yml
+++ b/.github/workflows/example-node-versions.yml
@@ -28,7 +28,7 @@ jobs:
       - run: npm -v
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Cypress tests
         uses: ./ # if copying, replace with cypress-io/github-action@v6

--- a/.github/workflows/example-quiet.yml
+++ b/.github/workflows/example-quiet.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       # Install npm dependencies, cache them correctly
       # and run all Cypress tests with `quiet` parameter
       - name: Cypress run

--- a/.github/workflows/example-recording.yml
+++ b/.github/workflows/example-recording.yml
@@ -50,7 +50,7 @@ jobs:
     if: needs.check-record-key.outputs.record-key-exists == 'true'
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Cypress tests
         uses: ./
@@ -79,7 +79,7 @@ jobs:
     if: needs.check-record-key.outputs.record-key-exists == 'true'
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Cypress tests
         uses: ./

--- a/.github/workflows/example-start-and-pnpm-workspaces.yml
+++ b/.github/workflows/example-start-and-pnpm-workspaces.yml
@@ -25,7 +25,7 @@ jobs:
     name: Single workspace
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
         # pnpm is not installed by default on GitHub runners
       - name: Install pnpm
@@ -71,7 +71,7 @@ jobs:
     name: Multiple workspaces
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install pnpm
         run: npm install -g pnpm@10

--- a/.github/workflows/example-start-and-yarn-workspaces.yml
+++ b/.github/workflows/example-start-and-yarn-workspaces.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Single
         uses: ./
@@ -44,7 +44,7 @@ jobs:
           - working_directory: examples/start-and-yarn-workspaces/workspace-2
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Cypress tests
         uses: ./

--- a/.github/workflows/example-start.yml
+++ b/.github/workflows/example-start.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Cypress tests
         uses: ./
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Cypress tests
         uses: ./
@@ -61,7 +61,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Cypress tests
         uses: ./

--- a/.github/workflows/example-wait-on.yml
+++ b/.github/workflows/example-wait-on.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Cypress tests
         uses: ./
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Cypress tests
         uses: ./
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Cypress tests
         uses: ./
@@ -58,7 +58,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Cypress tests
         uses: ./
@@ -71,7 +71,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Cypress tests
         uses: ./
@@ -85,7 +85,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Cypress tests
         uses: ./
         with:
@@ -99,7 +99,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Cypress tests
         uses: ./
         with:
@@ -114,7 +114,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Cypress tests
         uses: ./
         with:
@@ -126,7 +126,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Cypress tests
         uses: ./
         with:
@@ -140,7 +140,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Cypress tests
         uses: ./
         with:
@@ -152,7 +152,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Cypress tests
         uses: ./
         with:
@@ -165,7 +165,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Install dependencies
         run: npm ci
       - name: Run ping from CLI
@@ -175,7 +175,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Cypress tests
         uses: ./
         with:

--- a/.github/workflows/example-webpack.yml
+++ b/.github/workflows/example-webpack.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Cypress tests
         uses: ./ # if copying, replace with cypress-io/github-action@v6

--- a/.github/workflows/example-yarn-classic.yml
+++ b/.github/workflows/example-yarn-classic.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Test with Yarn Classic
         uses: ./ # if copying, replace with cypress-io/github-action@v6

--- a/.github/workflows/example-yarn-modern-pnp.yml
+++ b/.github/workflows/example-yarn-modern-pnp.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Enable Corepack # see https://yarnpkg.com/getting-started/install
         run: |
           npm install -g corepack

--- a/.github/workflows/example-yarn-modern.yml
+++ b/.github/workflows/example-yarn-modern.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Enable Corepack # see https://yarnpkg.com/getting-started/install
         run: |
           npm install -g corepack

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
     name: Build and test
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
@@ -37,7 +37,7 @@ jobs:
       (github.repository == 'cypress-io/github-action')
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - run: npm ci
       # https://github.com/cycjimmy/semantic-release-action
       - name: Semantic Release

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       # Install npm dependencies, cache them correctly
       # and run all Cypress tests
       - name: Cypress run
@@ -124,7 +124,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Cypress run
         uses: cypress-io/github-action@v6
         with:
@@ -177,7 +177,7 @@ jobs:
     runs-on: ubuntu-24.04
     name: E2E on Chrome
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: cypress-io/github-action@v6
         with:
           browser: chrome
@@ -197,7 +197,7 @@ jobs:
     runs-on: ubuntu-24.04
     name: E2E on Chrome for Testing
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: browser-actions/setup-chrome@v2
         with:
           chrome-version: 140
@@ -218,7 +218,7 @@ jobs:
     runs-on: ubuntu-24.04
     name: E2E on Firefox
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: cypress-io/github-action@v6
         with:
           browser: firefox
@@ -236,7 +236,7 @@ jobs:
     runs-on: ubuntu-24.04
     name: E2E on Edge
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: cypress-io/github-action@v6
         with:
           browser: edge
@@ -255,7 +255,7 @@ jobs:
   cypress-run:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: cypress-io/github-action@v6
         with:
           browser: chrome
@@ -278,7 +278,7 @@ jobs:
       image: cypress/browsers:latest
       options: --user 1001
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: cypress-io/github-action@v6
         with:
           browser: chrome
@@ -302,7 +302,7 @@ jobs:
       image: cypress/included:latest
       options: --user 1001
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: cypress-io/github-action@v6
         with:
           browser: chrome
@@ -326,7 +326,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Cypress run with env
         uses: cypress-io/github-action@v6
@@ -344,7 +344,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Cypress run with env
         uses: cypress-io/github-action@v6
@@ -370,7 +370,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Cypress run
         uses: cypress-io/github-action@v6
@@ -401,7 +401,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Cypress run
         uses: cypress-io/github-action@v6
         with:
@@ -433,7 +433,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Cypress run
         uses: cypress-io/github-action@v6
@@ -463,7 +463,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Cypress run
         uses: cypress-io/github-action@v6
         with:
@@ -496,7 +496,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Cypress run
         uses: cypress-io/github-action@v6
         with:
@@ -534,7 +534,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Cypress run
         uses: cypress-io/github-action@v6
@@ -573,7 +573,7 @@ jobs:
       - run: node -v
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Cypress run
         uses: cypress-io/github-action@v6
@@ -606,7 +606,7 @@ jobs:
     name: E2E
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Cypress run
         uses: cypress-io/github-action@v6
@@ -633,7 +633,7 @@ jobs:
     runs-on: ubuntu-24.04
     name: Artifacts
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: cypress-io/github-action@v6
       # after the test run completes store videos and any screenshots
       - uses: actions/upload-artifact@v4
@@ -662,7 +662,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       # Install npm dependencies, cache them correctly
       # and run all Cypress tests with `quiet` parameter
       - name: Cypress run
@@ -687,7 +687,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Cypress run
         uses: cypress-io/github-action@v6
@@ -710,7 +710,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Cypress run
         uses: cypress-io/github-action@v6
@@ -744,7 +744,7 @@ jobs:
         containers: [1, 2, 3]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       # because of "record" and "parallel" parameters
       # these containers will load balance all found tests among themselves
@@ -805,7 +805,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Cypress run
         uses: cypress-io/github-action@v6
         with:
@@ -824,7 +824,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Cypress run
         uses: cypress-io/github-action@v6
         with:
@@ -843,7 +843,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Cypress run
         uses: cypress-io/github-action@v6
         with:
@@ -869,7 +869,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Cypress run
         uses: cypress-io/github-action@v6
         with:
@@ -899,7 +899,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Cypress run
         uses: cypress-io/github-action@v6
         with:
@@ -988,7 +988,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Cypress run
         uses: cypress-io/github-action@v6
         with:
@@ -1015,7 +1015,7 @@ Correct example snippet:
 
 ```yml
 steps:
-  - uses: actions/checkout@v4
+  - uses: actions/checkout@v5
   - uses: cypress-io/github-action@v6
     with:
       command: npm run custom-test
@@ -1038,7 +1038,7 @@ jobs:
         # run 3 copies of the current job in parallel
         containers: [1, 2, 3]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: cypress-io/github-action@v6
         with:
           record: true
@@ -1073,7 +1073,7 @@ jobs:
   smoke-tests:
     needs: ['prepare']
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: cypress-io/github-action@v6
         with:
           record: true
@@ -1113,7 +1113,7 @@ jobs:
   cypress-run:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: cypress-io/github-action@v6
         with:
           start: npm start
@@ -1151,7 +1151,7 @@ jobs:
   test:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Install root dependencies
         run: npm ci
 
@@ -1179,7 +1179,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
@@ -1234,7 +1234,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Cypress run
         uses: cypress-io/github-action@v6
         with:
@@ -1257,7 +1257,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - run: corepack enable # (experimental and optional)
       - name: Set up Yarn cache
         uses: actions/setup-node@v4
@@ -1291,7 +1291,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Cypress run
         uses: cypress-io/github-action@v6
         with:
@@ -1320,7 +1320,7 @@ jobs:
     # and tests in a subfolder like "workspace-1"
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: cypress-io/github-action@v6
         with:
           working-directory: examples/start-and-yarn-workspaces/workspace-1
@@ -1352,7 +1352,7 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       # run Cypress tests and record them under the same run
       # associated with commit SHA and just give a different group name
       - name: Cypress run
@@ -1384,7 +1384,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: cypress-io/github-action@v6
 ```
 
@@ -1403,7 +1403,7 @@ jobs:
   test:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Install dependencies
         uses: cypress-io/github-action@v6
         with:
@@ -1436,7 +1436,7 @@ jobs:
   build:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Build app
         uses: cypress-io/github-action@v6
         with:
@@ -1454,7 +1454,7 @@ jobs:
     needs: build
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Restore build artifacts
         uses: actions/download-artifact@v4
         with:
@@ -1478,7 +1478,7 @@ Finally, you might not need this GH Action at all. For example, if you want to s
 If the project has many dependencies, but you want to install just Cypress you can combine this action with `actions/cache` and `npm i cypress` commands yourself.
 
 ```yml
-- uses: actions/checkout@v4
+- uses: actions/checkout@v5
 - uses: actions/cache@v4
   with:
     path: |
@@ -1505,7 +1505,7 @@ jobs:
     # to prevent a hanging process from using all your CI minutes
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: cypress-io/github-action@v6
         # you can specify individual step timeout too
         timeout-minutes: 5
@@ -1548,7 +1548,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Check out repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Cypress run # install dependencies and run Cypress E2E tests
         uses: cypress-io/github-action@v6 # replaces CLI cypress run
         with:
@@ -1735,7 +1735,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Cypress run
         uses: cypress-io/github-action@v6
         with:
@@ -1752,7 +1752,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Cypress install
         uses: cypress-io/github-action@v6
         with:
@@ -1783,7 +1783,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Cypress nightly tests 🌃
         uses: cypress-io/github-action@v6
 ```
@@ -1803,7 +1803,7 @@ jobs:
   tests:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Cypress headless tests
         uses: cypress-io/github-action@v6
         with:
@@ -1832,7 +1832,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Cypress run
         uses: cypress-io/github-action@v6
         with:


### PR DESCRIPTION
- supersedes https://github.com/cypress-io/github-action/pull/1528
- supports resolution of https://github.com/cypress-io/github-action/issues/1519

## Situation

Documentation, CI and example tests use [actions/checkout@v4](https://github.com/actions/checkout/tree/v4), based on running as a `node20` GitHub JavaScript action.

Node.js 20 moved to status Maintenance LTS and in its place Node.js 24 has become the Active LTS version (see https://github.com/nodejs/release#release-schedule).

[actions/checkout@v5](https://github.com/actions/checkout/tree/v5) provides the follow-on and latest version of the action that runs using `node24`.

## Change

In documentation, CI and example tests replace [actions/checkout@v4](https://github.com/actions/checkout/tree/v4) with [actions/checkout@v5](https://github.com/actions/checkout/tree/v5).