### PR TITLE
test(deps): update cypress/browsers to v24.11.0 in example-docker

### DIFF
--- a/.github/workflows/example-docker.yml
+++ b/.github/workflows/example-docker.yml
@@ -16,7 +16,7 @@ jobs:
     # Cypress Docker image documentation on https://github.com/cypress-io/cypress-docker-images
     # Available cypress/browsers tags listed on https://hub.docker.com/r/cypress/browsers/tags
     container:
-      image: cypress/browsers:22.21.0
+      image: cypress/browsers:24.11.0
       options: --user 1001
     steps:
       - name: Checkout


### PR DESCRIPTION
## Situation

The example workflow [.github/workflows/example-docker.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-docker.yml) demonstrates using the Cypress Docker image `cypress/browsers:22.21.0` to test.

Node.js 22 has transitioned into Maintenance LTS status and Node.js 24 has moved into Active LTS status - see [Node.js Release schedule](https://github.com/nodejs/release#release-schedule)

[Node.js 24.11.0](https://nodejs.org/en/blog/release/v24.11.0) is the Active LTS version at this time.

## Change

Update the example workflow [.github/workflows/example-docker.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-docker.yml) from Cypress Docker image `cypress/browsers:22.21.0` to `cypress/browsers:24.11.0`.
