### PR TITLE
ci(deps): update cycjimmy/semantic-release-action to v5

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,7 +41,7 @@ jobs:
       - run: npm ci
       # https://github.com/cycjimmy/semantic-release-action
       - name: Semantic Release
-        uses: cycjimmy/semantic-release-action@v4
+        uses: cycjimmy/semantic-release-action@v5
         id: semantic
         with:
           # https://github.com/semantic-release/semantic-release


### PR DESCRIPTION
- closes https://github.com/cypress-io/github-action/issues/1563

## Situation

The CI workflow [.github/workflows/main.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/main.yml) in the `release` job uses [cycjimmy/semantic-release-action@v4](https://github.com/cycjimmy/semantic-release-action/tree/v4) which runs.using `node20`.

The `node20` option for GitHub Actions is tied to Node.js 20 that is planned for [End-of-life](https://github.com/nodejs/release#release-schedule) on Apr 30, 2026.

## Change

Update CI [.github/workflows/main.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/main.yml) from [cycjimmy/semantic-release-action@v4](https://github.com/cycjimmy/semantic-release-action/tree/v4) to [cycjimmy/semantic-release-action@v5](https://github.com/cycjimmy/semantic-release-action/tree/v5) which runs using `node24`.
