### PR TITLE
chore: add Renovate rebuild action workflow

### DIFF
--- a/.github/workflows/rebuild-dist.yml
+++ b/.github/workflows/rebuild-dist.yml
@@ -37,5 +37,5 @@ jobs:
 
       - uses: stefanzweifel/git-auto-commit-action@v7 # https://github.com/stefanzweifel/git-auto-commit-action
         with:
-          commit_message: "chore: rebuild action after dependency update"
+          commit_message: 'chore: rebuild action after dependency update'
           file_pattern: 'dist/*'


### PR DESCRIPTION
- closes https://github.com/cypress-io/github-action/issues/1252

## Situation

When Renovate attempts to update `dependencies` from [package.json](https://github.com/cypress-io/github-action/blob/master/package.json) it regularly fails the CI workflow [.github/workflows/check-dist.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/check-dist.yml) because it does not run the [.husky/pre-commit](https://github.com/cypress-io/github-action/blob/master/.husky/pre-commit) script.

The commands in this script are however essential to rebuild the action, including propagating changes to the [dist](https://github.com/cypress-io/github-action/tree/master/dist) directory:

```shell
npm ci
npm run format
npm run build
```

## Change

Add a new workflow `rebuild-dist.yml` that runs after Renovate PRs, rebuilds the action and commits any changes to the Renovate PR branch.

The workflow uses the action https://github.com/stefanzweifel/git-auto-commit-action.

## Verification

This could be verified by a Cypress.io team member with write privileges to the repo.

The [Dependency Dashboard](https://github.com/cypress-io/github-action/issues/108) could be used to recreate a blocked PR such as

- https://github.com/cypress-io/github-action/pull/1552

Otherwise, just wait for the next Renovate PR creation / update.
