### PR TITLE
chore(deps): update validator to 13.15.20

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3393,9 +3393,9 @@
       }
     },
     "node_modules/validator": {
-      "version": "13.15.15",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.15.tgz",
-      "integrity": "sha512-BgWVbCI72aIQy937xbawcs+hrVaN/CZ2UwutgaJ36hGqRrLNM+f5LUT/YPRbo8IV/ASeFzXszezV+y2+rq3l8A==",
+      "version": "13.15.20",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.20.tgz",
+      "integrity": "sha512-KxPOq3V2LmfQPP4eqf3Mq/zrT0Dqp2Vmx2Bn285LwVahLc+CsxOM0crBHczm8ijlcjZ0Q5Xd6LW3z3odTPnlrw==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
## Situation

`npm audit` and Dependabot report a medium severity vulnerability CVE-2025-56200 in [validator@13.15.15](https://github.com/validatorjs/validator.js/releases/tag/13.15.15) which is a transient dependency of [markdown-link-check@3.14.1](https://github.com/tcort/markdown-link-check/releases/tag/v3.14.1) (the latest version available).

## Change

Use `npm audit` to bump the transient dependency from [validator@13.15.15](https://github.com/validatorjs/validator.js/releases/tag/13.15.15) to [validator@13.15.20](https://github.com/validatorjs/validator.js/releases/tag/13.15.20)

## Verification

```shell
npm ci
npm audit
```

verify output to be:

```text
found 0 vulnerabilities
```
