### PR TITLE
chore(deps): update cypress to 15.6.0

### DIFF
--- a/.github/workflows/example-install-only.yml
+++ b/.github/workflows/example-install-only.yml
@@ -29,7 +29,7 @@ jobs:
           key: my-cache-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
 
       - name: Install Cypress 📥
-        run: npm install cypress@15.5.0 --save-dev
+        run: npm install cypress@15.6.0 --save-dev
 
       - name: Cypress tests 🧪
         uses: ./ # if copying, replace with cypress-io/github-action@v6

--- a/examples/basic-pnpm/package.json
+++ b/examples/basic-pnpm/package.json
@@ -8,6 +8,6 @@
   },
   "private": true,
   "devDependencies": {
-    "cypress": "15.5.0"
+    "cypress": "15.6.0"
   }
 }

--- a/examples/basic-pnpm/pnpm-lock.yaml
+++ b/examples/basic-pnpm/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     devDependencies:
       cypress:
-        specifier: 15.5.0
-        version: 15.5.0
+        specifier: 15.6.0
+        version: 15.6.0
 
 packages:
 
@@ -173,8 +173,8 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
-  cypress@15.5.0:
-    resolution: {integrity: sha512-7jXBsh5hTfjxr9QQONC2IbdTj0nxSyU8x4eiarMZBzXzCj3pedKviUx8JnLcE4vL8e0TsOzp70WSLRORjEssRA==}
+  cypress@15.6.0:
+    resolution: {integrity: sha512-Vqo66GG1vpxZ7H1oDX9umfmzA3nF7Wy80QAc3VjwPREO5zTY4d1xfQFNPpOWleQl9vpdmR2z1liliOcYlRX6rQ==}
     engines: {node: ^20.1.0 || ^22.0.0 || >=24.0.0}
     hasBin: true
 
@@ -830,7 +830,7 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
-  cypress@15.5.0:
+  cypress@15.6.0:
     dependencies:
       '@cypress/request': 3.0.9
       '@cypress/xvfb': 1.2.4(supports-color@8.1.1)

--- a/examples/basic/package-lock.json
+++ b/examples/basic/package-lock.json
@@ -8,7 +8,7 @@
       "name": "example-basic",
       "version": "1.0.0",
       "devDependencies": {
-        "cypress": "15.5.0"
+        "cypress": "15.6.0"
       }
     },
     "node_modules/@cypress/request": {
@@ -547,9 +547,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "15.5.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-15.5.0.tgz",
-      "integrity": "sha512-7jXBsh5hTfjxr9QQONC2IbdTj0nxSyU8x4eiarMZBzXzCj3pedKviUx8JnLcE4vL8e0TsOzp70WSLRORjEssRA==",
+      "version": "15.6.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-15.6.0.tgz",
+      "integrity": "sha512-Vqo66GG1vpxZ7H1oDX9umfmzA3nF7Wy80QAc3VjwPREO5zTY4d1xfQFNPpOWleQl9vpdmR2z1liliOcYlRX6rQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",

--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -8,6 +8,6 @@
   },
   "private": true,
   "devDependencies": {
-    "cypress": "15.5.0"
+    "cypress": "15.6.0"
   }
 }

--- a/examples/browser/package-lock.json
+++ b/examples/browser/package-lock.json
@@ -8,7 +8,7 @@
       "name": "example-browser",
       "version": "1.1.0",
       "devDependencies": {
-        "cypress": "15.5.0",
+        "cypress": "15.6.0",
         "image-size": "^1.0.2"
       }
     },
@@ -548,9 +548,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "15.5.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-15.5.0.tgz",
-      "integrity": "sha512-7jXBsh5hTfjxr9QQONC2IbdTj0nxSyU8x4eiarMZBzXzCj3pedKviUx8JnLcE4vL8e0TsOzp70WSLRORjEssRA==",
+      "version": "15.6.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-15.6.0.tgz",
+      "integrity": "sha512-Vqo66GG1vpxZ7H1oDX9umfmzA3nF7Wy80QAc3VjwPREO5zTY4d1xfQFNPpOWleQl9vpdmR2z1liliOcYlRX6rQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",

--- a/examples/browser/package.json
+++ b/examples/browser/package.json
@@ -13,7 +13,7 @@
   },
   "private": true,
   "devDependencies": {
-    "cypress": "15.5.0",
+    "cypress": "15.6.0",
     "image-size": "^1.0.2"
   }
 }

--- a/examples/component-tests/package-lock.json
+++ b/examples/component-tests/package-lock.json
@@ -15,7 +15,7 @@
         "@types/react": "^19.1.10",
         "@types/react-dom": "^19.1.7",
         "@vitejs/plugin-react": "^5.0.0",
-        "cypress": "15.5.0",
+        "cypress": "15.6.0",
         "vite": "^7.1.5"
       }
     },
@@ -1837,9 +1837,9 @@
       "license": "MIT"
     },
     "node_modules/cypress": {
-      "version": "15.5.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-15.5.0.tgz",
-      "integrity": "sha512-7jXBsh5hTfjxr9QQONC2IbdTj0nxSyU8x4eiarMZBzXzCj3pedKviUx8JnLcE4vL8e0TsOzp70WSLRORjEssRA==",
+      "version": "15.6.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-15.6.0.tgz",
+      "integrity": "sha512-Vqo66GG1vpxZ7H1oDX9umfmzA3nF7Wy80QAc3VjwPREO5zTY4d1xfQFNPpOWleQl9vpdmR2z1liliOcYlRX6rQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",

--- a/examples/component-tests/package.json
+++ b/examples/component-tests/package.json
@@ -17,7 +17,7 @@
     "@types/react": "^19.1.10",
     "@types/react-dom": "^19.1.7",
     "@vitejs/plugin-react": "^5.0.0",
-    "cypress": "15.5.0",
+    "cypress": "15.6.0",
     "vite": "^7.1.5"
   }
 }

--- a/examples/config/package-lock.json
+++ b/examples/config/package-lock.json
@@ -8,7 +8,7 @@
       "name": "example-config",
       "version": "1.0.0",
       "devDependencies": {
-        "cypress": "15.5.0",
+        "cypress": "15.6.0",
         "serve": "14.2.5"
       }
     },
@@ -903,9 +903,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "15.5.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-15.5.0.tgz",
-      "integrity": "sha512-7jXBsh5hTfjxr9QQONC2IbdTj0nxSyU8x4eiarMZBzXzCj3pedKviUx8JnLcE4vL8e0TsOzp70WSLRORjEssRA==",
+      "version": "15.6.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-15.6.0.tgz",
+      "integrity": "sha512-Vqo66GG1vpxZ7H1oDX9umfmzA3nF7Wy80QAc3VjwPREO5zTY4d1xfQFNPpOWleQl9vpdmR2z1liliOcYlRX6rQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",

--- a/examples/config/package.json
+++ b/examples/config/package.json
@@ -11,7 +11,7 @@
   },
   "private": true,
   "devDependencies": {
-    "cypress": "15.5.0",
+    "cypress": "15.6.0",
     "serve": "14.2.5"
   }
 }

--- a/examples/custom-command/package-lock.json
+++ b/examples/custom-command/package-lock.json
@@ -8,7 +8,7 @@
       "name": "example-custom-command",
       "version": "1.0.0",
       "devDependencies": {
-        "cypress": "15.5.0",
+        "cypress": "15.6.0",
         "lodash": "4.17.21"
       }
     },
@@ -548,9 +548,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "15.5.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-15.5.0.tgz",
-      "integrity": "sha512-7jXBsh5hTfjxr9QQONC2IbdTj0nxSyU8x4eiarMZBzXzCj3pedKviUx8JnLcE4vL8e0TsOzp70WSLRORjEssRA==",
+      "version": "15.6.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-15.6.0.tgz",
+      "integrity": "sha512-Vqo66GG1vpxZ7H1oDX9umfmzA3nF7Wy80QAc3VjwPREO5zTY4d1xfQFNPpOWleQl9vpdmR2z1liliOcYlRX6rQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",

--- a/examples/custom-command/package.json
+++ b/examples/custom-command/package.json
@@ -9,7 +9,7 @@
   },
   "private": true,
   "devDependencies": {
-    "cypress": "15.5.0",
+    "cypress": "15.6.0",
     "lodash": "4.17.21"
   }
 }

--- a/examples/env/package-lock.json
+++ b/examples/env/package-lock.json
@@ -8,7 +8,7 @@
       "name": "example-env",
       "version": "1.0.0",
       "devDependencies": {
-        "cypress": "15.5.0"
+        "cypress": "15.6.0"
       }
     },
     "node_modules/@cypress/request": {
@@ -547,9 +547,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "15.5.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-15.5.0.tgz",
-      "integrity": "sha512-7jXBsh5hTfjxr9QQONC2IbdTj0nxSyU8x4eiarMZBzXzCj3pedKviUx8JnLcE4vL8e0TsOzp70WSLRORjEssRA==",
+      "version": "15.6.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-15.6.0.tgz",
+      "integrity": "sha512-Vqo66GG1vpxZ7H1oDX9umfmzA3nF7Wy80QAc3VjwPREO5zTY4d1xfQFNPpOWleQl9vpdmR2z1liliOcYlRX6rQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",

--- a/examples/env/package.json
+++ b/examples/env/package.json
@@ -8,6 +8,6 @@
   },
   "private": true,
   "devDependencies": {
-    "cypress": "15.5.0"
+    "cypress": "15.6.0"
   }
 }

--- a/examples/install-command/package.json
+++ b/examples/install-command/package.json
@@ -7,7 +7,7 @@
   },
   "private": true,
   "devDependencies": {
-    "cypress": "15.5.0"
+    "cypress": "15.6.0"
   },
   "dependencies": {
     "arg": "5.0.0",

--- a/examples/install-command/yarn.lock
+++ b/examples/install-command/yarn.lock
@@ -296,10 +296,10 @@ cross-spawn@^7.0.0:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
-cypress@15.5.0:
-  version "15.5.0"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-15.5.0.tgz#039c8549f623957a14e57adee46dbfabaabac741"
-  integrity sha512-7jXBsh5hTfjxr9QQONC2IbdTj0nxSyU8x4eiarMZBzXzCj3pedKviUx8JnLcE4vL8e0TsOzp70WSLRORjEssRA==
+cypress@15.6.0:
+  version "15.6.0"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-15.6.0.tgz#bde57b8ae9fbe6473a3324bb1d583437c299230d"
+  integrity sha512-Vqo66GG1vpxZ7H1oDX9umfmzA3nF7Wy80QAc3VjwPREO5zTY4d1xfQFNPpOWleQl9vpdmR2z1liliOcYlRX6rQ==
   dependencies:
     "@cypress/request" "^3.0.9"
     "@cypress/xvfb" "^1.2.4"

--- a/examples/install-only/package-lock.json
+++ b/examples/install-only/package-lock.json
@@ -12,7 +12,7 @@
         "debug": "4.3.6"
       },
       "devDependencies": {
-        "cypress": "15.5.0"
+        "cypress": "15.6.0"
       }
     },
     "node_modules/@cypress/request": {
@@ -556,9 +556,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "15.5.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-15.5.0.tgz",
-      "integrity": "sha512-7jXBsh5hTfjxr9QQONC2IbdTj0nxSyU8x4eiarMZBzXzCj3pedKviUx8JnLcE4vL8e0TsOzp70WSLRORjEssRA==",
+      "version": "15.6.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-15.6.0.tgz",
+      "integrity": "sha512-Vqo66GG1vpxZ7H1oDX9umfmzA3nF7Wy80QAc3VjwPREO5zTY4d1xfQFNPpOWleQl9vpdmR2z1liliOcYlRX6rQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",

--- a/examples/install-only/package.json
+++ b/examples/install-only/package.json
@@ -11,6 +11,6 @@
     "debug": "4.3.6"
   },
   "devDependencies": {
-    "cypress": "15.5.0"
+    "cypress": "15.6.0"
   }
 }

--- a/examples/nextjs/package-lock.json
+++ b/examples/nextjs/package-lock.json
@@ -13,7 +13,7 @@
         "react-dom": "^19.1.1"
       },
       "devDependencies": {
-        "cypress": "15.5.0",
+        "cypress": "15.6.0",
         "postcss": "^8.5.6",
         "tailwindcss": "^3.4.17"
       }
@@ -1558,9 +1558,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "15.5.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-15.5.0.tgz",
-      "integrity": "sha512-7jXBsh5hTfjxr9QQONC2IbdTj0nxSyU8x4eiarMZBzXzCj3pedKviUx8JnLcE4vL8e0TsOzp70WSLRORjEssRA==",
+      "version": "15.6.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-15.6.0.tgz",
+      "integrity": "sha512-Vqo66GG1vpxZ7H1oDX9umfmzA3nF7Wy80QAc3VjwPREO5zTY4d1xfQFNPpOWleQl9vpdmR2z1liliOcYlRX6rQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",

--- a/examples/nextjs/package.json
+++ b/examples/nextjs/package.json
@@ -15,7 +15,7 @@
     "react-dom": "^19.1.1"
   },
   "devDependencies": {
-    "cypress": "15.5.0",
+    "cypress": "15.6.0",
     "postcss": "^8.5.6",
     "tailwindcss": "^3.4.17"
   }

--- a/examples/node-versions/package-lock.json
+++ b/examples/node-versions/package-lock.json
@@ -8,7 +8,7 @@
       "name": "example-node-versions",
       "version": "1.0.0",
       "devDependencies": {
-        "cypress": "15.5.0"
+        "cypress": "15.6.0"
       }
     },
     "node_modules/@cypress/request": {
@@ -547,9 +547,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "15.5.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-15.5.0.tgz",
-      "integrity": "sha512-7jXBsh5hTfjxr9QQONC2IbdTj0nxSyU8x4eiarMZBzXzCj3pedKviUx8JnLcE4vL8e0TsOzp70WSLRORjEssRA==",
+      "version": "15.6.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-15.6.0.tgz",
+      "integrity": "sha512-Vqo66GG1vpxZ7H1oDX9umfmzA3nF7Wy80QAc3VjwPREO5zTY4d1xfQFNPpOWleQl9vpdmR2z1liliOcYlRX6rQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",

--- a/examples/node-versions/package.json
+++ b/examples/node-versions/package.json
@@ -8,6 +8,6 @@
   },
   "private": true,
   "devDependencies": {
-    "cypress": "15.5.0"
+    "cypress": "15.6.0"
   }
 }

--- a/examples/quiet/package-lock.json
+++ b/examples/quiet/package-lock.json
@@ -8,7 +8,7 @@
       "name": "example-quiet",
       "version": "1.0.0",
       "devDependencies": {
-        "cypress": "15.5.0",
+        "cypress": "15.6.0",
         "image-size": "0.8.3"
       }
     },
@@ -548,9 +548,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "15.5.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-15.5.0.tgz",
-      "integrity": "sha512-7jXBsh5hTfjxr9QQONC2IbdTj0nxSyU8x4eiarMZBzXzCj3pedKviUx8JnLcE4vL8e0TsOzp70WSLRORjEssRA==",
+      "version": "15.6.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-15.6.0.tgz",
+      "integrity": "sha512-Vqo66GG1vpxZ7H1oDX9umfmzA3nF7Wy80QAc3VjwPREO5zTY4d1xfQFNPpOWleQl9vpdmR2z1liliOcYlRX6rQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",

--- a/examples/quiet/package.json
+++ b/examples/quiet/package.json
@@ -9,7 +9,7 @@
   },
   "private": true,
   "devDependencies": {
-    "cypress": "15.5.0",
+    "cypress": "15.6.0",
     "image-size": "0.8.3"
   }
 }

--- a/examples/recording/package-lock.json
+++ b/examples/recording/package-lock.json
@@ -8,7 +8,7 @@
       "name": "example-recording",
       "version": "1.0.0",
       "devDependencies": {
-        "cypress": "15.5.0"
+        "cypress": "15.6.0"
       }
     },
     "node_modules/@cypress/request": {
@@ -547,9 +547,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "15.5.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-15.5.0.tgz",
-      "integrity": "sha512-7jXBsh5hTfjxr9QQONC2IbdTj0nxSyU8x4eiarMZBzXzCj3pedKviUx8JnLcE4vL8e0TsOzp70WSLRORjEssRA==",
+      "version": "15.6.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-15.6.0.tgz",
+      "integrity": "sha512-Vqo66GG1vpxZ7H1oDX9umfmzA3nF7Wy80QAc3VjwPREO5zTY4d1xfQFNPpOWleQl9vpdmR2z1liliOcYlRX6rQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",

--- a/examples/recording/package.json
+++ b/examples/recording/package.json
@@ -9,6 +9,6 @@
   },
   "private": true,
   "devDependencies": {
-    "cypress": "15.5.0"
+    "cypress": "15.6.0"
   }
 }

--- a/examples/start-and-pnpm-workspaces/packages/workspace-1/package.json
+++ b/examples/start-and-pnpm-workspaces/packages/workspace-1/package.json
@@ -10,7 +10,7 @@
   },
   "private": true,
   "devDependencies": {
-    "cypress": "15.5.0",
+    "cypress": "15.6.0",
     "serve": "14.2.5"
   }
 }

--- a/examples/start-and-pnpm-workspaces/packages/workspace-2/package.json
+++ b/examples/start-and-pnpm-workspaces/packages/workspace-2/package.json
@@ -10,7 +10,7 @@
   },
   "private": true,
   "devDependencies": {
-    "cypress": "15.5.0",
+    "cypress": "15.6.0",
     "serve": "14.2.5"
   }
 }

--- a/examples/start-and-pnpm-workspaces/pnpm-lock.yaml
+++ b/examples/start-and-pnpm-workspaces/pnpm-lock.yaml
@@ -11,8 +11,8 @@ importers:
   packages/workspace-1:
     devDependencies:
       cypress:
-        specifier: 15.5.0
-        version: 15.5.0
+        specifier: 15.6.0
+        version: 15.6.0
       serve:
         specifier: 14.2.5
         version: 14.2.5
@@ -20,8 +20,8 @@ importers:
   packages/workspace-2:
     devDependencies:
       cypress:
-        specifier: 15.5.0
-        version: 15.5.0
+        specifier: 15.6.0
+        version: 15.6.0
       serve:
         specifier: 14.2.5
         version: 14.2.5
@@ -35,8 +35,8 @@ packages:
   '@cypress/xvfb@1.2.4':
     resolution: {integrity: sha512-skbBzPggOVYCbnGgV+0dmBdW/s77ZkAOXIC1knS8NagwDjBrNC1LuXtQJeiN6l+m7lzmHtaoUw/ctJKdqkG57Q==}
 
-  '@types/node@24.9.1':
-    resolution: {integrity: sha512-QoiaXANRkSXK6p0Duvt56W208du4P9Uye9hWLWgGMDTEoKPhuenzNcC4vGUmrNkiOKTlIrBoyNQYNpSwfEZXSg==}
+  '@types/node@24.10.0':
+    resolution: {integrity: sha512-qzQZRBqkFsYyaSWXuEHc2WR9c0a0CXwiE5FWUvn7ZM+vdy1uZLfCunD38UzhuB7YN/J11ndbDBcTmOdxJo9Q7A==}
 
   '@types/sinonjs__fake-timers@8.1.1':
     resolution: {integrity: sha512-0kSuKjAS0TrGLJ0M/+8MaFkGsQhZpB6pxOmvS3K8FYI72K//YmdfoW9X2qPsAKh1mkwxGD5zib9s1FIFed6E8g==}
@@ -260,8 +260,8 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
-  cypress@15.5.0:
-    resolution: {integrity: sha512-7jXBsh5hTfjxr9QQONC2IbdTj0nxSyU8x4eiarMZBzXzCj3pedKviUx8JnLcE4vL8e0TsOzp70WSLRORjEssRA==}
+  cypress@15.6.0:
+    resolution: {integrity: sha512-Vqo66GG1vpxZ7H1oDX9umfmzA3nF7Wy80QAc3VjwPREO5zTY4d1xfQFNPpOWleQl9vpdmR2z1liliOcYlRX6rQ==}
     engines: {node: ^20.1.0 || ^22.0.0 || >=24.0.0}
     hasBin: true
 
@@ -269,8 +269,8 @@ packages:
     resolution: {integrity: sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==}
     engines: {node: '>=0.10'}
 
-  dayjs@1.11.18:
-    resolution: {integrity: sha512-zFBQ7WFRvVRhKcWoUh+ZA1g2HVgUbsZm9sbddh8EC5iv93sui8DVVz1Npvz+r6meo9VKfa8NyLWBsQK1VvIKPA==}
+  dayjs@1.11.19:
+    resolution: {integrity: sha512-t5EcLVS6QPBNqM2z8fakk/NKel+Xzshgt8FFKAn+qwlD1pzZWxh0nVCrvFK7ZDb6XucZeF9z8C7CBWTRIVApAw==}
 
   debug@2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
@@ -935,7 +935,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@types/node@24.9.1':
+  '@types/node@24.10.0':
     dependencies:
       undici-types: 7.16.0
     optional: true
@@ -948,7 +948,7 @@ snapshots:
 
   '@types/yauzl@2.10.3':
     dependencies:
-      '@types/node': 24.9.1
+      '@types/node': 24.10.0
     optional: true
 
   '@zeit/schemas@2.36.0': {}
@@ -1145,7 +1145,7 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
-  cypress@15.5.0:
+  cypress@15.6.0:
     dependencies:
       '@cypress/request': 3.0.9
       '@cypress/xvfb': 1.2.4(supports-color@8.1.1)
@@ -1163,7 +1163,7 @@ snapshots:
       cli-table3: 0.6.1
       commander: 6.2.1
       common-tags: 1.8.2
-      dayjs: 1.11.18
+      dayjs: 1.11.19
       debug: 4.4.3(supports-color@8.1.1)
       enquirer: 2.4.1
       eventemitter2: 6.4.7
@@ -1195,7 +1195,7 @@ snapshots:
     dependencies:
       assert-plus: 1.0.0
 
-  dayjs@1.11.18: {}
+  dayjs@1.11.19: {}
 
   debug@2.6.9:
     dependencies:

--- a/examples/start-and-yarn-workspaces/workspace-1/package.json
+++ b/examples/start-and-yarn-workspaces/workspace-1/package.json
@@ -10,7 +10,7 @@
   },
   "private": true,
   "devDependencies": {
-    "cypress": "15.5.0",
+    "cypress": "15.6.0",
     "serve": "14.2.5"
   }
 }

--- a/examples/start-and-yarn-workspaces/workspace-2/package.json
+++ b/examples/start-and-yarn-workspaces/workspace-2/package.json
@@ -10,7 +10,7 @@
   },
   "private": true,
   "devDependencies": {
-    "cypress": "15.5.0",
+    "cypress": "15.6.0",
     "serve": "14.2.5"
   }
 }

--- a/examples/start-and-yarn-workspaces/yarn.lock
+++ b/examples/start-and-yarn-workspaces/yarn.lock
@@ -431,10 +431,10 @@ cross-spawn@^7.0.0, cross-spawn@^7.0.3:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
-cypress@15.5.0:
-  version "15.5.0"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-15.5.0.tgz#039c8549f623957a14e57adee46dbfabaabac741"
-  integrity sha512-7jXBsh5hTfjxr9QQONC2IbdTj0nxSyU8x4eiarMZBzXzCj3pedKviUx8JnLcE4vL8e0TsOzp70WSLRORjEssRA==
+cypress@15.6.0:
+  version "15.6.0"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-15.6.0.tgz#bde57b8ae9fbe6473a3324bb1d583437c299230d"
+  integrity sha512-Vqo66GG1vpxZ7H1oDX9umfmzA3nF7Wy80QAc3VjwPREO5zTY4d1xfQFNPpOWleQl9vpdmR2z1liliOcYlRX6rQ==
   dependencies:
     "@cypress/request" "^3.0.9"
     "@cypress/xvfb" "^1.2.4"

--- a/examples/start/package-lock.json
+++ b/examples/start/package-lock.json
@@ -8,7 +8,7 @@
       "name": "example-start",
       "version": "1.0.0",
       "devDependencies": {
-        "cypress": "15.5.0",
+        "cypress": "15.6.0",
         "serve": "14.2.5"
       }
     },
@@ -903,9 +903,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "15.5.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-15.5.0.tgz",
-      "integrity": "sha512-7jXBsh5hTfjxr9QQONC2IbdTj0nxSyU8x4eiarMZBzXzCj3pedKviUx8JnLcE4vL8e0TsOzp70WSLRORjEssRA==",
+      "version": "15.6.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-15.6.0.tgz",
+      "integrity": "sha512-Vqo66GG1vpxZ7H1oDX9umfmzA3nF7Wy80QAc3VjwPREO5zTY4d1xfQFNPpOWleQl9vpdmR2z1liliOcYlRX6rQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",

--- a/examples/start/package.json
+++ b/examples/start/package.json
@@ -11,7 +11,7 @@
   },
   "private": true,
   "devDependencies": {
-    "cypress": "15.5.0",
+    "cypress": "15.6.0",
     "serve": "14.2.5"
   }
 }

--- a/examples/wait-on-vite/package-lock.json
+++ b/examples/wait-on-vite/package-lock.json
@@ -8,7 +8,7 @@
       "name": "example-wait-on-vite",
       "version": "2.0.0",
       "devDependencies": {
-        "cypress": "15.5.0",
+        "cypress": "15.6.0",
         "vite": "^7.1.5"
       }
     },
@@ -1306,9 +1306,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "15.5.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-15.5.0.tgz",
-      "integrity": "sha512-7jXBsh5hTfjxr9QQONC2IbdTj0nxSyU8x4eiarMZBzXzCj3pedKviUx8JnLcE4vL8e0TsOzp70WSLRORjEssRA==",
+      "version": "15.6.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-15.6.0.tgz",
+      "integrity": "sha512-Vqo66GG1vpxZ7H1oDX9umfmzA3nF7Wy80QAc3VjwPREO5zTY4d1xfQFNPpOWleQl9vpdmR2z1liliOcYlRX6rQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",

--- a/examples/wait-on-vite/package.json
+++ b/examples/wait-on-vite/package.json
@@ -10,7 +10,7 @@
   },
   "private": true,
   "devDependencies": {
-    "cypress": "15.5.0",
+    "cypress": "15.6.0",
     "vite": "^7.1.5"
   }
 }

--- a/examples/wait-on/package-lock.json
+++ b/examples/wait-on/package-lock.json
@@ -12,7 +12,7 @@
         "debug": "4.3.6"
       },
       "devDependencies": {
-        "cypress": "15.5.0"
+        "cypress": "15.6.0"
       }
     },
     "node_modules/@cypress/request": {
@@ -556,9 +556,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "15.5.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-15.5.0.tgz",
-      "integrity": "sha512-7jXBsh5hTfjxr9QQONC2IbdTj0nxSyU8x4eiarMZBzXzCj3pedKviUx8JnLcE4vL8e0TsOzp70WSLRORjEssRA==",
+      "version": "15.6.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-15.6.0.tgz",
+      "integrity": "sha512-Vqo66GG1vpxZ7H1oDX9umfmzA3nF7Wy80QAc3VjwPREO5zTY4d1xfQFNPpOWleQl9vpdmR2z1liliOcYlRX6rQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",

--- a/examples/wait-on/package.json
+++ b/examples/wait-on/package.json
@@ -20,6 +20,6 @@
     "debug": "4.3.6"
   },
   "devDependencies": {
-    "cypress": "15.5.0"
+    "cypress": "15.6.0"
   }
 }

--- a/examples/webpack/package-lock.json
+++ b/examples/webpack/package-lock.json
@@ -8,7 +8,7 @@
       "name": "example-webpack",
       "version": "1.0.0",
       "devDependencies": {
-        "cypress": "15.5.0",
+        "cypress": "15.6.0",
         "webpack": "^5.99.6",
         "webpack-cli": "^5.1.4",
         "webpack-dev-server": "^5.2.1"
@@ -1611,9 +1611,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "15.5.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-15.5.0.tgz",
-      "integrity": "sha512-7jXBsh5hTfjxr9QQONC2IbdTj0nxSyU8x4eiarMZBzXzCj3pedKviUx8JnLcE4vL8e0TsOzp70WSLRORjEssRA==",
+      "version": "15.6.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-15.6.0.tgz",
+      "integrity": "sha512-Vqo66GG1vpxZ7H1oDX9umfmzA3nF7Wy80QAc3VjwPREO5zTY4d1xfQFNPpOWleQl9vpdmR2z1liliOcYlRX6rQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",

--- a/examples/webpack/package.json
+++ b/examples/webpack/package.json
@@ -8,7 +8,7 @@
   },
   "private": true,
   "devDependencies": {
-    "cypress": "15.5.0",
+    "cypress": "15.6.0",
     "webpack": "^5.99.6",
     "webpack-cli": "^5.1.4",
     "webpack-dev-server": "^5.2.1"

--- a/examples/yarn-classic/package.json
+++ b/examples/yarn-classic/package.json
@@ -7,6 +7,6 @@
   },
   "private": true,
   "devDependencies": {
-    "cypress": "15.5.0"
+    "cypress": "15.6.0"
   }
 }

--- a/examples/yarn-classic/yarn.lock
+++ b/examples/yarn-classic/yarn.lock
@@ -293,10 +293,10 @@ cross-spawn@^7.0.0:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
-cypress@15.5.0:
-  version "15.5.0"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-15.5.0.tgz#039c8549f623957a14e57adee46dbfabaabac741"
-  integrity sha512-7jXBsh5hTfjxr9QQONC2IbdTj0nxSyU8x4eiarMZBzXzCj3pedKviUx8JnLcE4vL8e0TsOzp70WSLRORjEssRA==
+cypress@15.6.0:
+  version "15.6.0"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-15.6.0.tgz#bde57b8ae9fbe6473a3324bb1d583437c299230d"
+  integrity sha512-Vqo66GG1vpxZ7H1oDX9umfmzA3nF7Wy80QAc3VjwPREO5zTY4d1xfQFNPpOWleQl9vpdmR2z1liliOcYlRX6rQ==
   dependencies:
     "@cypress/request" "^3.0.9"
     "@cypress/xvfb" "^1.2.4"

--- a/examples/yarn-modern-pnp/package.json
+++ b/examples/yarn-modern-pnp/package.json
@@ -8,6 +8,6 @@
   "private": true,
   "packageManager": "yarn@4.10.3",
   "devDependencies": {
-    "cypress": "15.5.0"
+    "cypress": "15.6.0"
   }
 }

--- a/examples/yarn-modern-pnp/yarn.lock
+++ b/examples/yarn-modern-pnp/yarn.lock
@@ -386,9 +386,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cypress@npm:15.5.0":
-  version: 15.5.0
-  resolution: "cypress@npm:15.5.0"
+"cypress@npm:15.6.0":
+  version: 15.6.0
+  resolution: "cypress@npm:15.6.0"
   dependencies:
     "@cypress/request": "npm:^3.0.9"
     "@cypress/xvfb": "npm:^1.2.4"
@@ -435,7 +435,7 @@ __metadata:
     yauzl: "npm:^2.10.0"
   bin:
     cypress: bin/cypress
-  checksum: 10c0/0a7aabc9920a808f5257f111b9b4bb6602e9b7146dd945a49e16a0811c201d5f5837f9ae439756556b686e020155483542505bf8499b72307236047b85a1130b
+  checksum: 10c0/55534a2ee8e86bb9c7adaf42aaa4160cbafb3f52f78f5d288cba48230e431565ef1654d0c626238e2122a6fb08765db7447725516e6c28c05b05b7c51f5e4624
   languageName: node
   linkType: hard
 
@@ -583,7 +583,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "example-yarn-modern-pnp@workspace:."
   dependencies:
-    cypress: "npm:15.5.0"
+    cypress: "npm:15.6.0"
   languageName: unknown
   linkType: soft
 

--- a/examples/yarn-modern/package.json
+++ b/examples/yarn-modern/package.json
@@ -8,6 +8,6 @@
   "private": true,
   "packageManager": "yarn@4.10.3",
   "devDependencies": {
-    "cypress": "15.5.0"
+    "cypress": "15.6.0"
   }
 }

--- a/examples/yarn-modern/yarn.lock
+++ b/examples/yarn-modern/yarn.lock
@@ -386,9 +386,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cypress@npm:15.5.0":
-  version: 15.5.0
-  resolution: "cypress@npm:15.5.0"
+"cypress@npm:15.6.0":
+  version: 15.6.0
+  resolution: "cypress@npm:15.6.0"
   dependencies:
     "@cypress/request": "npm:^3.0.9"
     "@cypress/xvfb": "npm:^1.2.4"
@@ -435,7 +435,7 @@ __metadata:
     yauzl: "npm:^2.10.0"
   bin:
     cypress: bin/cypress
-  checksum: 10c0/0a7aabc9920a808f5257f111b9b4bb6602e9b7146dd945a49e16a0811c201d5f5837f9ae439756556b686e020155483542505bf8499b72307236047b85a1130b
+  checksum: 10c0/55534a2ee8e86bb9c7adaf42aaa4160cbafb3f52f78f5d288cba48230e431565ef1654d0c626238e2122a6fb08765db7447725516e6c28c05b05b7c51f5e4624
   languageName: node
   linkType: hard
 
@@ -583,7 +583,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "example-yarn-modern@workspace:."
   dependencies:
-    cypress: "npm:15.5.0"
+    cypress: "npm:15.6.0"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
This PR updates the [examples](https://github.com/cypress-io/github-action/tree/master/examples) to [cypress@15.6.0](https://docs.cypress.io/app/references/changelog#15-6-0) released Nov 4, 2025.