### PR TITLE
test(deps): update node-forge to 1.3.2

### DIFF
--- a/examples/webpack/package-lock.json
+++ b/examples/webpack/package-lock.json
@@ -3616,9 +3616,9 @@
       "license": "MIT"
     },
     "node_modules/node-forge": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
-      "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.2.tgz",
+      "integrity": "sha512-6xKiQ+cph9KImrRh0VsjH2d8/GXA4FIMlgU4B757iI1ApvcyA9VlouP0yZJha01V+huImO+kKMU7ih+2+E14fw==",
       "dev": true,
       "license": "(BSD-3-Clause OR GPL-2.0)",
       "engines": {


### PR DESCRIPTION
## Situation

Dependabot and `npm audit` report vulnerabilities CVE-2025-12816 & CVE-2025-66030 in the npm package [node-forge](https://github.com/digitalbazaar/forge) `<1.3.2` in [examples/webpack](https://github.com/cypress-io/github-action/tree/master/examples/webpack).

## Change

In [examples/webpack](https://github.com/cypress-io/github-action/tree/master/examples/webpack) run `npm audit fix` to update to [node-forge@1.3.2](https://github.com/digitalbazaar/forge/tree/v1.3.2)