### PR TITLE
test: use native pnpm install for pnpm workspace example

### DIFF
--- a/.github/workflows/example-start-and-pnpm-workspaces.yml
+++ b/.github/workflows/example-start-and-pnpm-workspaces.yml
@@ -18,7 +18,6 @@ jobs:
   single-ws:
     # This job installs pnpm,
     # installs all dependencies,
-    # caches the Cypress binary cache,
     # then runs Cypress tests in the single workspace
     # of the subfolder "packages/workspace-1".
     runs-on: ubuntu-24.04
@@ -32,15 +31,9 @@ jobs:
         run: npm install -g pnpm@10
 
       - name: Install dependencies
-        # with Cypress GitHub Action.
-        # Calling the Cypress GitHub Action causes all dependencies from
-        # the root of the pnpm workspace examples/start-and-pnpm-workspaces
-        # to be installed
-        # AND it automatically caches the Cypress binary.
-        uses: ./
-        with:
-          working-directory: examples/start-and-pnpm-workspaces
-          runTests: false
+        # All dependencies including workspaces are installed
+        run: pnpm install --frozen-lockfile
+        working-directory: examples/start-and-pnpm-workspaces
 
       - name: Cypress test Single
         # Run Cypress in examples/start-and-pnpm-workspaces/packages/workspace-1 only
@@ -49,7 +42,7 @@ jobs:
           # Do not attempt to install dependencies in the workspace using the action.
           # There is no pnpm-lock.yaml file in a workspace for
           # Cypress GitHub Action to use.
-          # We already installed dependencies when we called the action previously.
+          # We already installed dependencies previously.
           install: false
           working-directory: examples/start-and-pnpm-workspaces/packages/workspace-1
           build: pnpm run build
@@ -59,7 +52,6 @@ jobs:
   multiple-ws:
     # This job installs pnpm,
     # installs all dependencies,
-    # caches the Cypress binary cache,
     # then runs Cypress tests in each of the workspaces.
     runs-on: ubuntu-24.04
     strategy:
@@ -77,10 +69,8 @@ jobs:
         run: npm install -g pnpm@10
 
       - name: Install dependencies
-        uses: ./
-        with:
-          working-directory: examples/start-and-pnpm-workspaces
-          runTests: false
+        run: pnpm install --frozen-lockfile
+        working-directory: examples/start-and-pnpm-workspaces
 
       - name: Cypress test Multiple
         # Run Cypress in

--- a/README.md
+++ b/README.md
@@ -1200,22 +1200,20 @@ jobs:
 
 ### pnpm workspaces
 
-If you are using [pnpm workspaces](https://pnpm.io/workspaces) you need to install dependencies and run Cypress tests in a workspace in separate steps. The snippet below shows this principle.
+The action does not directly support using [pnpm workspaces](https://pnpm.io/workspaces) (see feature request [#1144](https://github.com/cypress-io/github-action/issues/1144)). As a workaround, you can install dependencies and run Cypress tests in a workspace in separate steps. The snippet below shows this principle.
 
 ```yml
       ...
       - name: Install dependencies
-        uses: cypress-io/github-action@v6
-        with:
-          working-directory: examples/start-and-pnpm-workspaces
-          runTests: false
+        run: pnpm install --frozen-lockfile
+        working-directory: examples/start-and-pnpm-workspaces
 
       - name: Cypress test
         uses: cypress-io/github-action@v6
         with:
           install: false
           working-directory: examples/start-and-pnpm-workspaces/packages/workspace-1
-        ...
+      ...
 ```
 
 [![pnpm workspaces example](https://github.com/cypress-io/github-action/actions/workflows/example-start-and-pnpm-workspaces.yml/badge.svg)](.github/workflows/example-start-and-pnpm-workspaces.yml)


### PR DESCRIPTION
- closes https://github.com/cypress-io/github-action/issues/1594
- closes https://github.com/cypress-io/github-action/issues/1590

## Situation

- The [example-start-and-pnpm-workspaces](https://github.com/cypress-io/github-action/actions/workflows/example-start-and-pnpm-workspaces.yml) may fail under certain re-run conditions if the Cypress binary cache has been evicted (see https://github.com/cypress-io/github-action/issues/1594 for full details). The failure message is:

    ```text
    /usr/local/bin/npx cypress verify
    The cypress npm package is installed, but the Cypress binary is missing.
    ```

- The action does not cache the pnpm store, and instead caches the `.npm` cache. It also uses uses `npx` commands (see feature request https://github.com/cypress-io/github-action/issues/1366).

- The action is not aware of pnpm workspaces (see feature request https://github.com/cypress-io/github-action/issues/1144) and so cannot reliably install and cache dependencies on its own.

- Additionally, issue https://github.com/cypress-io/github-action/issues/1590 reported problems using the example in a monorepo. It should be clear that the example is a workaround only and does not represent full support of pnpm workspaces.

## Change

Replace dependency installation in [example-start-and-pnpm-workspaces](https://github.com/cypress-io/github-action/actions/workflows/example-start-and-pnpm-workspaces.yml), currently using the action, to instead use a direct call to:

```shell
pnpm install --frozen-lockfile
```

Update the [README > pnpm workspaces](https://github.com/cypress-io/github-action/blob/master/README.md#pnpm-workspaces) documentation section accordingly.

## Verification

Run and re-run the workflow [example-start-and-pnpm-workspaces](https://github.com/cypress-io/github-action/actions/workflows/example-start-and-pnpm-workspaces.yml)

Examine the logs for the PR and note that there are no caches used, so they can no longer get out of sync.

