### PR TITLE
docs: update http://on.cypress.io/ to https

### DIFF
--- a/README.md
+++ b/README.md
@@ -1638,7 +1638,7 @@ To collect more verbose GitHub Action logs you can set a GitHub secret or variab
 
 ### Logs from the test runner
 
-To see all [Cypress debug logs](http://on.cypress.io/troubleshooting#Print-DEBUG-logs), add the environment variable `DEBUG` to the workflow using the value `cypress:*`:
+To see all [Cypress debug logs](https://on.cypress.io/troubleshooting#Print-DEBUG-logs), add the environment variable `DEBUG` to the workflow using the value `cypress:*`:
 
 ```yml
 - name: Cypress tests with debug logs


### PR DESCRIPTION
- relates to issue https://github.com/cypress-io/github-action/issues/1591

## Situation

The [README > Logs from the test runner](https://github.com/cypress-io/github-action/blob/master/README.md#logs-from-the-test-runner) contains an outdated `http` URL to http://on.cypress.io/troubleshooting#Print-DEBUG-logs

http://on.cypress.io has an HTTP `307 - Internal Redirect` to https://on.cypress.io, so that HTTPS would be the preferred protocol.

## Change

Use https://on.cypress.io/troubleshooting#Print-DEBUG-logs in the [README > Logs from the test runner](https://github.com/cypress-io/github-action/blob/master/README.md#logs-from-the-test-runner) document section.