### PR TITLE
test(deps): update actions/cache to v5

### DIFF
--- a/.github/workflows/example-install-only.yml
+++ b/.github/workflows/example-install-only.yml
@@ -21,7 +21,7 @@ jobs:
       # (which is important when using ^ version in package.json)
       # see https://github.com/actions/cache
       - name: Cache npm and Cypress 📦
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cache/Cypress

--- a/README.md
+++ b/README.md
@@ -1477,7 +1477,7 @@ If the project has many dependencies, but you want to install just Cypress you c
 
 ```yml
 - uses: actions/checkout@v6
-- uses: actions/cache@v4
+- uses: actions/cache@v5
   with:
     path: |
       ~/.cache/Cypress


### PR DESCRIPTION
- closes https://github.com/cypress-io/github-action/issues/1571

## Situation

Documentation and examples currently use the GitHub JavaScript [actions/cache@v4](https://github.com/actions/cache/tree/v4) which runs.using `node20`, and which is deprecated with a schedule to be bypassed in March 2026 (see [Deprecation of Node 20 on GitHub Actions runners](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)).

[actions/cache@v5.0.0](https://github.com/actions/cache/releases/tag/v5.0.0) was released on Dec 11, 2025 and this is set up for runs.using `node24`.

## Change

In the [README > Install Cypress only](https://github.com/cypress-io/github-action/blob/master/README.md#install-cypress-only) section, and the corresponding [example-install-only.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-install-only.yml) workflow, update:

| From                                                         | To                                                           |
| ------------------------------------------------------------ | ------------------------------------------------------------ |
| [actions/cache@v4](https://github.com/actions/cache/tree/v4) | [actions/cache@v5](https://github.com/actions/cache/tree/v5) |

## Verify

1. Run [example-install-only.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-install-only.yml) - Note
    > Cache not found for input keys: my-cache-Linux-`<hash>`
2. Re-run - Note
    > Cache restored successfully
    > Cache restored from key: my-cache-Linux-`<hash>`