### PR TITLE
test(deps): update upload- & download-artifact to node24 versions

### DIFF
--- a/.github/workflows/example-build-artifacts.yml
+++ b/.github/workflows/example-build-artifacts.yml
@@ -33,7 +33,7 @@ jobs:
           build: npm run build
           working-directory: examples/nextjs
       - name: Store build artifacts
-        uses: actions/upload-artifact@v4 # https://github.com/actions/upload-artifact
+        uses: actions/upload-artifact@v6 # https://github.com/actions/upload-artifact
         with:
           name: app
           path: examples/nextjs/build
@@ -52,7 +52,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Restore build artifacts
-        uses: actions/download-artifact@v4 # https://github.com/actions/download-artifact
+        uses: actions/download-artifact@v7 # https://github.com/actions/download-artifact
         with:
           name: app
           path: examples/nextjs/build

--- a/.github/workflows/example-chrome.yml
+++ b/.github/workflows/example-chrome.yml
@@ -36,7 +36,7 @@ jobs:
           # As of Cypress v8.0 the `cypress run` command
           # executes tests in `headless` mode by default
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: screenshots-headless-chrome
           path: examples/browser/cypress/screenshots
@@ -54,7 +54,7 @@ jobs:
           headed: true
           summary-title: 'Chrome headed'
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: screenshots-headed-chrome
           path: examples/browser/cypress/screenshots

--- a/.github/workflows/example-firefox.yml
+++ b/.github/workflows/example-firefox.yml
@@ -23,7 +23,7 @@ jobs:
           browser: firefox
 
       # report screenshot size and store the screenshots as test artifacts
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: screenshots-in-firefox
           path: examples/browser/cypress/screenshots

--- a/README.md
+++ b/README.md
@@ -636,14 +636,14 @@ jobs:
       - uses: actions/checkout@v6
       - uses: cypress-io/github-action@v6
       # after the test run completes store videos and any screenshots
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         # add the line below to store screenshots only on failures
         # if: failure()
         with:
           name: cypress-screenshots
           path: cypress/screenshots
           if-no-files-found: ignore # 'warn' or 'error' are also available, defaults to `warn`
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: cypress-videos
           path: cypress/videos
@@ -1441,7 +1441,7 @@ jobs:
           runTests: false # only build app, don't test yet
           build: npm run build
       - name: Store build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: app
           path: build
@@ -1454,7 +1454,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Restore build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: app
           path: build


### PR DESCRIPTION
- closes https://github.com/cypress-io/github-action/issues/1566
- supersedes Renovate PR https://github.com/cypress-io/github-action/pull/1573

## Situation

Documentation and examples currently use:

- [actions/upload-artifact@v4](https://github.com/actions/upload-artifact/tree/v4)
- [actions/download-artifact@v4](https://github.com/actions/download-artifact/tree/v4)

and these are based on `runs.using: node20`.

GitHub has deprecated the use of `node20` and will force runners to use `node24` beginning on Mar 4, 2026 - see [Deprecation of Node 20 on GitHub Actions runners](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/).

## Change

In the [README](https://github.com/cypress-io/github-action/blob/master/README.md) document and in workflows:

- [.github/workflows/example-build-artifacts.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-build-artifacts.yml)
- [.github/workflows/example-chrome.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-chrome.yml)
- [.github/workflows/example-firefox.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-firefox.yml)

update:

| From                                                                                 | To                                                                                   |
| ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------ |
| [actions/upload-artifact@v4](https://github.com/actions/upload-artifact/tree/v4)     | [actions/upload-artifact@v6](https://github.com/actions/upload-artifact/tree/v6)     |
| [actions/download-artifact@v4](https://github.com/actions/download-artifact/tree/v4) | [actions/download-artifact@v7](https://github.com/actions/download-artifact/tree/v7) |
