### PR TITLE
chore(deps): update cypress to 15.8.1

### DIFF
--- a/.github/workflows/example-install-only.yml
+++ b/.github/workflows/example-install-only.yml
@@ -29,7 +29,7 @@ jobs:
           key: my-cache-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
 
       - name: Install Cypress 📥
-        run: npm install cypress@15.8.0 --save-dev
+        run: npm install cypress@15.8.1 --save-dev
 
       - name: Cypress tests 🧪
         uses: ./ # if copying, replace with cypress-io/github-action@v6

--- a/examples/basic-pnpm/package.json
+++ b/examples/basic-pnpm/package.json
@@ -8,6 +8,6 @@
   },
   "private": true,
   "devDependencies": {
-    "cypress": "15.8.0"
+    "cypress": "15.8.1"
   }
 }

--- a/examples/basic-pnpm/pnpm-lock.yaml
+++ b/examples/basic-pnpm/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     devDependencies:
       cypress:
-        specifier: 15.8.0
-        version: 15.8.0
+        specifier: 15.8.1
+        version: 15.8.1
 
 packages:
 
@@ -173,8 +173,8 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
-  cypress@15.8.0:
-    resolution: {integrity: sha512-/k/KT8IIvcxarRSNb5AIhT1Yxx1pXsNIrL96Ht/c0pBOO/XcsjgjD4ZlG16V/08dRmvU/gT7PW8FBz5YV+ahsA==}
+  cypress@15.8.1:
+    resolution: {integrity: sha512-ogc62stTQGh1395ipKxfCE5hQuSApTzeH5e0d9U6m7wYO9HQeCpgnkYtBtd0MbkN2Fnch5Od2mX9u4hoTlrH4Q==}
     engines: {node: ^20.1.0 || ^22.0.0 || >=24.0.0}
     hasBin: true
 
@@ -581,8 +581,8 @@ packages:
     resolution: {integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==}
     engines: {node: '>=10'}
 
-  systeminformation@5.27.7:
-    resolution: {integrity: sha512-saaqOoVEEFaux4v0K8Q7caiauRwjXC4XbD2eH60dxHXbpKxQ8kH9Rf7Jh+nryKpOUSEFxtCdBlSUx0/lO6rwRg==}
+  systeminformation@5.27.14:
+    resolution: {integrity: sha512-3DoNDYSZBLxBwaJtQGWNpq0fonga/VZ47HY1+7/G3YoIPaPz93Df6egSzzTKbEMmlzUpy3eQ0nR9REuYIycXGg==}
     engines: {node: '>=8.0.0'}
     os: [darwin, linux, win32, freebsd, openbsd, netbsd, sunos, android]
     hasBin: true
@@ -825,7 +825,7 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
-  cypress@15.8.0:
+  cypress@15.8.1:
     dependencies:
       '@cypress/request': 3.0.9
       '@cypress/xvfb': 1.2.4(supports-color@8.1.1)
@@ -864,7 +864,7 @@ snapshots:
       proxy-from-env: 1.0.0
       request-progress: 3.0.0
       supports-color: 8.1.1
-      systeminformation: 5.27.7
+      systeminformation: 5.27.14
       tmp: 0.2.5
       tree-kill: 1.2.2
       untildify: 4.0.0
@@ -1280,7 +1280,7 @@ snapshots:
     dependencies:
       has-flag: 4.0.0
 
-  systeminformation@5.27.7: {}
+  systeminformation@5.27.14: {}
 
   throttleit@1.0.0: {}
 

--- a/examples/basic/package-lock.json
+++ b/examples/basic/package-lock.json
@@ -8,7 +8,7 @@
       "name": "example-basic",
       "version": "1.0.0",
       "devDependencies": {
-        "cypress": "15.8.0"
+        "cypress": "15.8.1"
       }
     },
     "node_modules/@cypress/request": {
@@ -547,9 +547,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "15.8.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-15.8.0.tgz",
-      "integrity": "sha512-/k/KT8IIvcxarRSNb5AIhT1Yxx1pXsNIrL96Ht/c0pBOO/XcsjgjD4ZlG16V/08dRmvU/gT7PW8FBz5YV+ahsA==",
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-15.8.1.tgz",
+      "integrity": "sha512-ogc62stTQGh1395ipKxfCE5hQuSApTzeH5e0d9U6m7wYO9HQeCpgnkYtBtd0MbkN2Fnch5Od2mX9u4hoTlrH4Q==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -591,7 +591,7 @@
         "proxy-from-env": "1.0.0",
         "request-progress": "^3.0.0",
         "supports-color": "^8.1.1",
-        "systeminformation": "5.27.7",
+        "systeminformation": "^5.27.14",
         "tmp": "~0.2.4",
         "tree-kill": "1.2.2",
         "untildify": "^4.0.0",
@@ -1862,9 +1862,9 @@
       }
     },
     "node_modules/systeminformation": {
-      "version": "5.27.7",
-      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.27.7.tgz",
-      "integrity": "sha512-saaqOoVEEFaux4v0K8Q7caiauRwjXC4XbD2eH60dxHXbpKxQ8kH9Rf7Jh+nryKpOUSEFxtCdBlSUx0/lO6rwRg==",
+      "version": "5.27.14",
+      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.27.14.tgz",
+      "integrity": "sha512-3DoNDYSZBLxBwaJtQGWNpq0fonga/VZ47HY1+7/G3YoIPaPz93Df6egSzzTKbEMmlzUpy3eQ0nR9REuYIycXGg==",
       "dev": true,
       "license": "MIT",
       "os": [

--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -8,6 +8,6 @@
   },
   "private": true,
   "devDependencies": {
-    "cypress": "15.8.0"
+    "cypress": "15.8.1"
   }
 }

--- a/examples/browser/package-lock.json
+++ b/examples/browser/package-lock.json
@@ -8,7 +8,7 @@
       "name": "example-browser",
       "version": "1.1.0",
       "devDependencies": {
-        "cypress": "15.8.0",
+        "cypress": "15.8.1",
         "image-size": "^1.0.2"
       }
     },
@@ -548,9 +548,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "15.8.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-15.8.0.tgz",
-      "integrity": "sha512-/k/KT8IIvcxarRSNb5AIhT1Yxx1pXsNIrL96Ht/c0pBOO/XcsjgjD4ZlG16V/08dRmvU/gT7PW8FBz5YV+ahsA==",
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-15.8.1.tgz",
+      "integrity": "sha512-ogc62stTQGh1395ipKxfCE5hQuSApTzeH5e0d9U6m7wYO9HQeCpgnkYtBtd0MbkN2Fnch5Od2mX9u4hoTlrH4Q==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -592,7 +592,7 @@
         "proxy-from-env": "1.0.0",
         "request-progress": "^3.0.0",
         "supports-color": "^8.1.1",
-        "systeminformation": "5.27.7",
+        "systeminformation": "^5.27.14",
         "tmp": "~0.2.4",
         "tree-kill": "1.2.2",
         "untildify": "^4.0.0",
@@ -1893,9 +1893,9 @@
       }
     },
     "node_modules/systeminformation": {
-      "version": "5.27.7",
-      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.27.7.tgz",
-      "integrity": "sha512-saaqOoVEEFaux4v0K8Q7caiauRwjXC4XbD2eH60dxHXbpKxQ8kH9Rf7Jh+nryKpOUSEFxtCdBlSUx0/lO6rwRg==",
+      "version": "5.27.14",
+      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.27.14.tgz",
+      "integrity": "sha512-3DoNDYSZBLxBwaJtQGWNpq0fonga/VZ47HY1+7/G3YoIPaPz93Df6egSzzTKbEMmlzUpy3eQ0nR9REuYIycXGg==",
       "dev": true,
       "license": "MIT",
       "os": [

--- a/examples/browser/package.json
+++ b/examples/browser/package.json
@@ -13,7 +13,7 @@
   },
   "private": true,
   "devDependencies": {
-    "cypress": "15.8.0",
+    "cypress": "15.8.1",
     "image-size": "^1.0.2"
   }
 }

--- a/examples/component-tests/package-lock.json
+++ b/examples/component-tests/package-lock.json
@@ -15,7 +15,7 @@
         "@types/react": "^19.1.10",
         "@types/react-dom": "^19.1.7",
         "@vitejs/plugin-react": "^5.0.0",
-        "cypress": "15.8.0",
+        "cypress": "15.8.1",
         "vite": "^7.1.5"
       }
     },
@@ -1840,9 +1840,9 @@
       "license": "MIT"
     },
     "node_modules/cypress": {
-      "version": "15.8.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-15.8.0.tgz",
-      "integrity": "sha512-/k/KT8IIvcxarRSNb5AIhT1Yxx1pXsNIrL96Ht/c0pBOO/XcsjgjD4ZlG16V/08dRmvU/gT7PW8FBz5YV+ahsA==",
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-15.8.1.tgz",
+      "integrity": "sha512-ogc62stTQGh1395ipKxfCE5hQuSApTzeH5e0d9U6m7wYO9HQeCpgnkYtBtd0MbkN2Fnch5Od2mX9u4hoTlrH4Q==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -1884,7 +1884,7 @@
         "proxy-from-env": "1.0.0",
         "request-progress": "^3.0.0",
         "supports-color": "^8.1.1",
-        "systeminformation": "5.27.7",
+        "systeminformation": "^5.27.14",
         "tmp": "~0.2.4",
         "tree-kill": "1.2.2",
         "untildify": "^4.0.0",
@@ -3528,9 +3528,9 @@
       }
     },
     "node_modules/systeminformation": {
-      "version": "5.27.7",
-      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.27.7.tgz",
-      "integrity": "sha512-saaqOoVEEFaux4v0K8Q7caiauRwjXC4XbD2eH60dxHXbpKxQ8kH9Rf7Jh+nryKpOUSEFxtCdBlSUx0/lO6rwRg==",
+      "version": "5.27.14",
+      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.27.14.tgz",
+      "integrity": "sha512-3DoNDYSZBLxBwaJtQGWNpq0fonga/VZ47HY1+7/G3YoIPaPz93Df6egSzzTKbEMmlzUpy3eQ0nR9REuYIycXGg==",
       "dev": true,
       "license": "MIT",
       "os": [

--- a/examples/component-tests/package.json
+++ b/examples/component-tests/package.json
@@ -17,7 +17,7 @@
     "@types/react": "^19.1.10",
     "@types/react-dom": "^19.1.7",
     "@vitejs/plugin-react": "^5.0.0",
-    "cypress": "15.8.0",
+    "cypress": "15.8.1",
     "vite": "^7.1.5"
   }
 }

--- a/examples/config/package-lock.json
+++ b/examples/config/package-lock.json
@@ -8,7 +8,7 @@
       "name": "example-config",
       "version": "1.0.0",
       "devDependencies": {
-        "cypress": "15.8.0",
+        "cypress": "15.8.1",
         "serve": "14.2.5"
       }
     },
@@ -903,9 +903,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "15.8.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-15.8.0.tgz",
-      "integrity": "sha512-/k/KT8IIvcxarRSNb5AIhT1Yxx1pXsNIrL96Ht/c0pBOO/XcsjgjD4ZlG16V/08dRmvU/gT7PW8FBz5YV+ahsA==",
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-15.8.1.tgz",
+      "integrity": "sha512-ogc62stTQGh1395ipKxfCE5hQuSApTzeH5e0d9U6m7wYO9HQeCpgnkYtBtd0MbkN2Fnch5Od2mX9u4hoTlrH4Q==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -947,7 +947,7 @@
         "proxy-from-env": "1.0.0",
         "request-progress": "^3.0.0",
         "supports-color": "^8.1.1",
-        "systeminformation": "5.27.7",
+        "systeminformation": "^5.27.14",
         "tmp": "~0.2.4",
         "tree-kill": "1.2.2",
         "untildify": "^4.0.0",
@@ -2498,9 +2498,9 @@
       }
     },
     "node_modules/systeminformation": {
-      "version": "5.27.7",
-      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.27.7.tgz",
-      "integrity": "sha512-saaqOoVEEFaux4v0K8Q7caiauRwjXC4XbD2eH60dxHXbpKxQ8kH9Rf7Jh+nryKpOUSEFxtCdBlSUx0/lO6rwRg==",
+      "version": "5.27.14",
+      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.27.14.tgz",
+      "integrity": "sha512-3DoNDYSZBLxBwaJtQGWNpq0fonga/VZ47HY1+7/G3YoIPaPz93Df6egSzzTKbEMmlzUpy3eQ0nR9REuYIycXGg==",
       "dev": true,
       "license": "MIT",
       "os": [

--- a/examples/config/package.json
+++ b/examples/config/package.json
@@ -11,7 +11,7 @@
   },
   "private": true,
   "devDependencies": {
-    "cypress": "15.8.0",
+    "cypress": "15.8.1",
     "serve": "14.2.5"
   }
 }

--- a/examples/custom-command/package-lock.json
+++ b/examples/custom-command/package-lock.json
@@ -8,7 +8,7 @@
       "name": "example-custom-command",
       "version": "1.0.0",
       "devDependencies": {
-        "cypress": "15.8.0",
+        "cypress": "15.8.1",
         "lodash": "4.17.21"
       }
     },
@@ -548,9 +548,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "15.8.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-15.8.0.tgz",
-      "integrity": "sha512-/k/KT8IIvcxarRSNb5AIhT1Yxx1pXsNIrL96Ht/c0pBOO/XcsjgjD4ZlG16V/08dRmvU/gT7PW8FBz5YV+ahsA==",
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-15.8.1.tgz",
+      "integrity": "sha512-ogc62stTQGh1395ipKxfCE5hQuSApTzeH5e0d9U6m7wYO9HQeCpgnkYtBtd0MbkN2Fnch5Od2mX9u4hoTlrH4Q==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -592,7 +592,7 @@
         "proxy-from-env": "1.0.0",
         "request-progress": "^3.0.0",
         "supports-color": "^8.1.1",
-        "systeminformation": "5.27.7",
+        "systeminformation": "^5.27.14",
         "tmp": "~0.2.4",
         "tree-kill": "1.2.2",
         "untildify": "^4.0.0",
@@ -1863,9 +1863,9 @@
       }
     },
     "node_modules/systeminformation": {
-      "version": "5.27.7",
-      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.27.7.tgz",
-      "integrity": "sha512-saaqOoVEEFaux4v0K8Q7caiauRwjXC4XbD2eH60dxHXbpKxQ8kH9Rf7Jh+nryKpOUSEFxtCdBlSUx0/lO6rwRg==",
+      "version": "5.27.14",
+      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.27.14.tgz",
+      "integrity": "sha512-3DoNDYSZBLxBwaJtQGWNpq0fonga/VZ47HY1+7/G3YoIPaPz93Df6egSzzTKbEMmlzUpy3eQ0nR9REuYIycXGg==",
       "dev": true,
       "license": "MIT",
       "os": [

--- a/examples/custom-command/package.json
+++ b/examples/custom-command/package.json
@@ -9,7 +9,7 @@
   },
   "private": true,
   "devDependencies": {
-    "cypress": "15.8.0",
+    "cypress": "15.8.1",
     "lodash": "4.17.21"
   }
 }

--- a/examples/env/package-lock.json
+++ b/examples/env/package-lock.json
@@ -8,7 +8,7 @@
       "name": "example-env",
       "version": "1.0.0",
       "devDependencies": {
-        "cypress": "15.8.0"
+        "cypress": "15.8.1"
       }
     },
     "node_modules/@cypress/request": {
@@ -547,9 +547,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "15.8.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-15.8.0.tgz",
-      "integrity": "sha512-/k/KT8IIvcxarRSNb5AIhT1Yxx1pXsNIrL96Ht/c0pBOO/XcsjgjD4ZlG16V/08dRmvU/gT7PW8FBz5YV+ahsA==",
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-15.8.1.tgz",
+      "integrity": "sha512-ogc62stTQGh1395ipKxfCE5hQuSApTzeH5e0d9U6m7wYO9HQeCpgnkYtBtd0MbkN2Fnch5Od2mX9u4hoTlrH4Q==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -591,7 +591,7 @@
         "proxy-from-env": "1.0.0",
         "request-progress": "^3.0.0",
         "supports-color": "^8.1.1",
-        "systeminformation": "5.27.7",
+        "systeminformation": "^5.27.14",
         "tmp": "~0.2.4",
         "tree-kill": "1.2.2",
         "untildify": "^4.0.0",
@@ -1862,9 +1862,9 @@
       }
     },
     "node_modules/systeminformation": {
-      "version": "5.27.7",
-      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.27.7.tgz",
-      "integrity": "sha512-saaqOoVEEFaux4v0K8Q7caiauRwjXC4XbD2eH60dxHXbpKxQ8kH9Rf7Jh+nryKpOUSEFxtCdBlSUx0/lO6rwRg==",
+      "version": "5.27.14",
+      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.27.14.tgz",
+      "integrity": "sha512-3DoNDYSZBLxBwaJtQGWNpq0fonga/VZ47HY1+7/G3YoIPaPz93Df6egSzzTKbEMmlzUpy3eQ0nR9REuYIycXGg==",
       "dev": true,
       "license": "MIT",
       "os": [

--- a/examples/env/package.json
+++ b/examples/env/package.json
@@ -8,6 +8,6 @@
   },
   "private": true,
   "devDependencies": {
-    "cypress": "15.8.0"
+    "cypress": "15.8.1"
   }
 }

--- a/examples/install-command/package.json
+++ b/examples/install-command/package.json
@@ -7,7 +7,7 @@
   },
   "private": true,
   "devDependencies": {
-    "cypress": "15.8.0"
+    "cypress": "15.8.1"
   },
   "dependencies": {
     "arg": "5.0.0",

--- a/examples/install-command/yarn.lock
+++ b/examples/install-command/yarn.lock
@@ -296,10 +296,10 @@ cross-spawn@^7.0.0:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
-cypress@15.8.0:
-  version "15.8.0"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-15.8.0.tgz#b6d9d0b921eeb4be3b393fb5f974c7588e4da584"
-  integrity sha512-/k/KT8IIvcxarRSNb5AIhT1Yxx1pXsNIrL96Ht/c0pBOO/XcsjgjD4ZlG16V/08dRmvU/gT7PW8FBz5YV+ahsA==
+cypress@15.8.1:
+  version "15.8.1"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-15.8.1.tgz#48fcb0859b8b656534c9bb3f3abbf37554a2bb2d"
+  integrity sha512-ogc62stTQGh1395ipKxfCE5hQuSApTzeH5e0d9U6m7wYO9HQeCpgnkYtBtd0MbkN2Fnch5Od2mX9u4hoTlrH4Q==
   dependencies:
     "@cypress/request" "^3.0.9"
     "@cypress/xvfb" "^1.2.4"
@@ -338,7 +338,7 @@ cypress@15.8.0:
     proxy-from-env "1.0.0"
     request-progress "^3.0.0"
     supports-color "^8.1.1"
-    systeminformation "5.27.7"
+    systeminformation "^5.27.14"
     tmp "~0.2.4"
     tree-kill "1.2.2"
     untildify "^4.0.0"
@@ -1076,10 +1076,10 @@ supports-color@^8.1.1:
   dependencies:
     has-flag "^4.0.0"
 
-systeminformation@5.27.7:
-  version "5.27.7"
-  resolved "https://registry.yarnpkg.com/systeminformation/-/systeminformation-5.27.7.tgz#4dc9d436419948cd5e5f076779a1298220d19a72"
-  integrity sha512-saaqOoVEEFaux4v0K8Q7caiauRwjXC4XbD2eH60dxHXbpKxQ8kH9Rf7Jh+nryKpOUSEFxtCdBlSUx0/lO6rwRg==
+systeminformation@^5.27.14:
+  version "5.27.14"
+  resolved "https://registry.yarnpkg.com/systeminformation/-/systeminformation-5.27.14.tgz#9f2b181521c151dad4972d47936ebb49a3271e9d"
+  integrity sha512-3DoNDYSZBLxBwaJtQGWNpq0fonga/VZ47HY1+7/G3YoIPaPz93Df6egSzzTKbEMmlzUpy3eQ0nR9REuYIycXGg==
 
 throttleit@^1.0.0:
   version "1.0.0"

--- a/examples/install-only/package-lock.json
+++ b/examples/install-only/package-lock.json
@@ -12,7 +12,7 @@
         "debug": "4.3.6"
       },
       "devDependencies": {
-        "cypress": "15.8.0"
+        "cypress": "15.8.1"
       }
     },
     "node_modules/@cypress/request": {
@@ -556,9 +556,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "15.8.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-15.8.0.tgz",
-      "integrity": "sha512-/k/KT8IIvcxarRSNb5AIhT1Yxx1pXsNIrL96Ht/c0pBOO/XcsjgjD4ZlG16V/08dRmvU/gT7PW8FBz5YV+ahsA==",
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-15.8.1.tgz",
+      "integrity": "sha512-ogc62stTQGh1395ipKxfCE5hQuSApTzeH5e0d9U6m7wYO9HQeCpgnkYtBtd0MbkN2Fnch5Od2mX9u4hoTlrH4Q==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -600,7 +600,7 @@
         "proxy-from-env": "1.0.0",
         "request-progress": "^3.0.0",
         "supports-color": "^8.1.1",
-        "systeminformation": "5.27.7",
+        "systeminformation": "^5.27.14",
         "tmp": "~0.2.4",
         "tree-kill": "1.2.2",
         "untildify": "^4.0.0",
@@ -1870,9 +1870,9 @@
       }
     },
     "node_modules/systeminformation": {
-      "version": "5.27.7",
-      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.27.7.tgz",
-      "integrity": "sha512-saaqOoVEEFaux4v0K8Q7caiauRwjXC4XbD2eH60dxHXbpKxQ8kH9Rf7Jh+nryKpOUSEFxtCdBlSUx0/lO6rwRg==",
+      "version": "5.27.14",
+      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.27.14.tgz",
+      "integrity": "sha512-3DoNDYSZBLxBwaJtQGWNpq0fonga/VZ47HY1+7/G3YoIPaPz93Df6egSzzTKbEMmlzUpy3eQ0nR9REuYIycXGg==",
       "dev": true,
       "license": "MIT",
       "os": [

--- a/examples/install-only/package.json
+++ b/examples/install-only/package.json
@@ -11,6 +11,6 @@
     "debug": "4.3.6"
   },
   "devDependencies": {
-    "cypress": "15.8.0"
+    "cypress": "15.8.1"
   }
 }

--- a/examples/nextjs/package-lock.json
+++ b/examples/nextjs/package-lock.json
@@ -14,7 +14,7 @@
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4.1.18",
-        "cypress": "15.8.0",
+        "cypress": "15.8.1",
         "tailwindcss": "^4"
       }
     },
@@ -1579,9 +1579,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "15.8.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-15.8.0.tgz",
-      "integrity": "sha512-/k/KT8IIvcxarRSNb5AIhT1Yxx1pXsNIrL96Ht/c0pBOO/XcsjgjD4ZlG16V/08dRmvU/gT7PW8FBz5YV+ahsA==",
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-15.8.1.tgz",
+      "integrity": "sha512-ogc62stTQGh1395ipKxfCE5hQuSApTzeH5e0d9U6m7wYO9HQeCpgnkYtBtd0MbkN2Fnch5Od2mX9u4hoTlrH4Q==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -1623,7 +1623,7 @@
         "proxy-from-env": "1.0.0",
         "request-progress": "^3.0.0",
         "supports-color": "^8.1.1",
-        "systeminformation": "5.27.7",
+        "systeminformation": "^5.27.14",
         "tmp": "~0.2.4",
         "tree-kill": "1.2.2",
         "untildify": "^4.0.0",
@@ -3504,9 +3504,9 @@
       }
     },
     "node_modules/systeminformation": {
-      "version": "5.27.7",
-      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.27.7.tgz",
-      "integrity": "sha512-saaqOoVEEFaux4v0K8Q7caiauRwjXC4XbD2eH60dxHXbpKxQ8kH9Rf7Jh+nryKpOUSEFxtCdBlSUx0/lO6rwRg==",
+      "version": "5.27.14",
+      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.27.14.tgz",
+      "integrity": "sha512-3DoNDYSZBLxBwaJtQGWNpq0fonga/VZ47HY1+7/G3YoIPaPz93Df6egSzzTKbEMmlzUpy3eQ0nR9REuYIycXGg==",
       "dev": true,
       "license": "MIT",
       "os": [

--- a/examples/nextjs/package.json
+++ b/examples/nextjs/package.json
@@ -16,7 +16,7 @@
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.1.18",
-    "cypress": "15.8.0",
+    "cypress": "15.8.1",
     "tailwindcss": "^4"
   }
 }

--- a/examples/node-versions/package-lock.json
+++ b/examples/node-versions/package-lock.json
@@ -8,7 +8,7 @@
       "name": "example-node-versions",
       "version": "1.0.0",
       "devDependencies": {
-        "cypress": "15.8.0"
+        "cypress": "15.8.1"
       }
     },
     "node_modules/@cypress/request": {
@@ -547,9 +547,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "15.8.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-15.8.0.tgz",
-      "integrity": "sha512-/k/KT8IIvcxarRSNb5AIhT1Yxx1pXsNIrL96Ht/c0pBOO/XcsjgjD4ZlG16V/08dRmvU/gT7PW8FBz5YV+ahsA==",
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-15.8.1.tgz",
+      "integrity": "sha512-ogc62stTQGh1395ipKxfCE5hQuSApTzeH5e0d9U6m7wYO9HQeCpgnkYtBtd0MbkN2Fnch5Od2mX9u4hoTlrH4Q==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -591,7 +591,7 @@
         "proxy-from-env": "1.0.0",
         "request-progress": "^3.0.0",
         "supports-color": "^8.1.1",
-        "systeminformation": "5.27.7",
+        "systeminformation": "^5.27.14",
         "tmp": "~0.2.4",
         "tree-kill": "1.2.2",
         "untildify": "^4.0.0",
@@ -1862,9 +1862,9 @@
       }
     },
     "node_modules/systeminformation": {
-      "version": "5.27.7",
-      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.27.7.tgz",
-      "integrity": "sha512-saaqOoVEEFaux4v0K8Q7caiauRwjXC4XbD2eH60dxHXbpKxQ8kH9Rf7Jh+nryKpOUSEFxtCdBlSUx0/lO6rwRg==",
+      "version": "5.27.14",
+      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.27.14.tgz",
+      "integrity": "sha512-3DoNDYSZBLxBwaJtQGWNpq0fonga/VZ47HY1+7/G3YoIPaPz93Df6egSzzTKbEMmlzUpy3eQ0nR9REuYIycXGg==",
       "dev": true,
       "license": "MIT",
       "os": [

--- a/examples/node-versions/package.json
+++ b/examples/node-versions/package.json
@@ -8,6 +8,6 @@
   },
   "private": true,
   "devDependencies": {
-    "cypress": "15.8.0"
+    "cypress": "15.8.1"
   }
 }

--- a/examples/quiet/package-lock.json
+++ b/examples/quiet/package-lock.json
@@ -8,7 +8,7 @@
       "name": "example-quiet",
       "version": "1.0.0",
       "devDependencies": {
-        "cypress": "15.8.0",
+        "cypress": "15.8.1",
         "image-size": "0.8.3"
       }
     },
@@ -548,9 +548,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "15.8.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-15.8.0.tgz",
-      "integrity": "sha512-/k/KT8IIvcxarRSNb5AIhT1Yxx1pXsNIrL96Ht/c0pBOO/XcsjgjD4ZlG16V/08dRmvU/gT7PW8FBz5YV+ahsA==",
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-15.8.1.tgz",
+      "integrity": "sha512-ogc62stTQGh1395ipKxfCE5hQuSApTzeH5e0d9U6m7wYO9HQeCpgnkYtBtd0MbkN2Fnch5Od2mX9u4hoTlrH4Q==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -592,7 +592,7 @@
         "proxy-from-env": "1.0.0",
         "request-progress": "^3.0.0",
         "supports-color": "^8.1.1",
-        "systeminformation": "5.27.7",
+        "systeminformation": "^5.27.14",
         "tmp": "~0.2.4",
         "tree-kill": "1.2.2",
         "untildify": "^4.0.0",
@@ -1893,9 +1893,9 @@
       }
     },
     "node_modules/systeminformation": {
-      "version": "5.27.7",
-      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.27.7.tgz",
-      "integrity": "sha512-saaqOoVEEFaux4v0K8Q7caiauRwjXC4XbD2eH60dxHXbpKxQ8kH9Rf7Jh+nryKpOUSEFxtCdBlSUx0/lO6rwRg==",
+      "version": "5.27.14",
+      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.27.14.tgz",
+      "integrity": "sha512-3DoNDYSZBLxBwaJtQGWNpq0fonga/VZ47HY1+7/G3YoIPaPz93Df6egSzzTKbEMmlzUpy3eQ0nR9REuYIycXGg==",
       "dev": true,
       "license": "MIT",
       "os": [

--- a/examples/quiet/package.json
+++ b/examples/quiet/package.json
@@ -9,7 +9,7 @@
   },
   "private": true,
   "devDependencies": {
-    "cypress": "15.8.0",
+    "cypress": "15.8.1",
     "image-size": "0.8.3"
   }
 }

--- a/examples/recording/package-lock.json
+++ b/examples/recording/package-lock.json
@@ -8,7 +8,7 @@
       "name": "example-recording",
       "version": "1.0.0",
       "devDependencies": {
-        "cypress": "15.8.0"
+        "cypress": "15.8.1"
       }
     },
     "node_modules/@cypress/request": {
@@ -547,9 +547,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "15.8.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-15.8.0.tgz",
-      "integrity": "sha512-/k/KT8IIvcxarRSNb5AIhT1Yxx1pXsNIrL96Ht/c0pBOO/XcsjgjD4ZlG16V/08dRmvU/gT7PW8FBz5YV+ahsA==",
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-15.8.1.tgz",
+      "integrity": "sha512-ogc62stTQGh1395ipKxfCE5hQuSApTzeH5e0d9U6m7wYO9HQeCpgnkYtBtd0MbkN2Fnch5Od2mX9u4hoTlrH4Q==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -591,7 +591,7 @@
         "proxy-from-env": "1.0.0",
         "request-progress": "^3.0.0",
         "supports-color": "^8.1.1",
-        "systeminformation": "5.27.7",
+        "systeminformation": "^5.27.14",
         "tmp": "~0.2.4",
         "tree-kill": "1.2.2",
         "untildify": "^4.0.0",
@@ -1862,9 +1862,9 @@
       }
     },
     "node_modules/systeminformation": {
-      "version": "5.27.7",
-      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.27.7.tgz",
-      "integrity": "sha512-saaqOoVEEFaux4v0K8Q7caiauRwjXC4XbD2eH60dxHXbpKxQ8kH9Rf7Jh+nryKpOUSEFxtCdBlSUx0/lO6rwRg==",
+      "version": "5.27.14",
+      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.27.14.tgz",
+      "integrity": "sha512-3DoNDYSZBLxBwaJtQGWNpq0fonga/VZ47HY1+7/G3YoIPaPz93Df6egSzzTKbEMmlzUpy3eQ0nR9REuYIycXGg==",
       "dev": true,
       "license": "MIT",
       "os": [

--- a/examples/recording/package.json
+++ b/examples/recording/package.json
@@ -9,6 +9,6 @@
   },
   "private": true,
   "devDependencies": {
-    "cypress": "15.8.0"
+    "cypress": "15.8.1"
   }
 }

--- a/examples/start-and-pnpm-workspaces/packages/workspace-1/package.json
+++ b/examples/start-and-pnpm-workspaces/packages/workspace-1/package.json
@@ -10,7 +10,7 @@
   },
   "private": true,
   "devDependencies": {
-    "cypress": "15.8.0",
+    "cypress": "15.8.1",
     "serve": "14.2.5"
   }
 }

--- a/examples/start-and-pnpm-workspaces/packages/workspace-2/package.json
+++ b/examples/start-and-pnpm-workspaces/packages/workspace-2/package.json
@@ -10,7 +10,7 @@
   },
   "private": true,
   "devDependencies": {
-    "cypress": "15.8.0",
+    "cypress": "15.8.1",
     "serve": "14.2.5"
   }
 }

--- a/examples/start-and-pnpm-workspaces/pnpm-lock.yaml
+++ b/examples/start-and-pnpm-workspaces/pnpm-lock.yaml
@@ -11,8 +11,8 @@ importers:
   packages/workspace-1:
     devDependencies:
       cypress:
-        specifier: 15.8.0
-        version: 15.8.0
+        specifier: 15.8.1
+        version: 15.8.1
       serve:
         specifier: 14.2.5
         version: 14.2.5
@@ -20,8 +20,8 @@ importers:
   packages/workspace-2:
     devDependencies:
       cypress:
-        specifier: 15.8.0
-        version: 15.8.0
+        specifier: 15.8.1
+        version: 15.8.1
       serve:
         specifier: 14.2.5
         version: 14.2.5
@@ -260,8 +260,8 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
-  cypress@15.8.0:
-    resolution: {integrity: sha512-/k/KT8IIvcxarRSNb5AIhT1Yxx1pXsNIrL96Ht/c0pBOO/XcsjgjD4ZlG16V/08dRmvU/gT7PW8FBz5YV+ahsA==}
+  cypress@15.8.1:
+    resolution: {integrity: sha512-ogc62stTQGh1395ipKxfCE5hQuSApTzeH5e0d9U6m7wYO9HQeCpgnkYtBtd0MbkN2Fnch5Od2mX9u4hoTlrH4Q==}
     engines: {node: ^20.1.0 || ^22.0.0 || >=24.0.0}
     hasBin: true
 
@@ -792,8 +792,8 @@ packages:
     resolution: {integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==}
     engines: {node: '>=10'}
 
-  systeminformation@5.27.7:
-    resolution: {integrity: sha512-saaqOoVEEFaux4v0K8Q7caiauRwjXC4XbD2eH60dxHXbpKxQ8kH9Rf7Jh+nryKpOUSEFxtCdBlSUx0/lO6rwRg==}
+  systeminformation@5.27.14:
+    resolution: {integrity: sha512-3DoNDYSZBLxBwaJtQGWNpq0fonga/VZ47HY1+7/G3YoIPaPz93Df6egSzzTKbEMmlzUpy3eQ0nR9REuYIycXGg==}
     engines: {node: '>=8.0.0'}
     os: [darwin, linux, win32, freebsd, openbsd, netbsd, sunos, android]
     hasBin: true
@@ -1140,7 +1140,7 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
-  cypress@15.8.0:
+  cypress@15.8.1:
     dependencies:
       '@cypress/request': 3.0.9
       '@cypress/xvfb': 1.2.4(supports-color@8.1.1)
@@ -1179,7 +1179,7 @@ snapshots:
       proxy-from-env: 1.0.0
       request-progress: 3.0.0
       supports-color: 8.1.1
-      systeminformation: 5.27.7
+      systeminformation: 5.27.14
       tmp: 0.2.5
       tree-kill: 1.2.2
       untildify: 4.0.0
@@ -1715,7 +1715,7 @@ snapshots:
     dependencies:
       has-flag: 4.0.0
 
-  systeminformation@5.27.7: {}
+  systeminformation@5.27.14: {}
 
   throttleit@1.0.1: {}
 

--- a/examples/start-and-yarn-workspaces/workspace-1/package.json
+++ b/examples/start-and-yarn-workspaces/workspace-1/package.json
@@ -10,7 +10,7 @@
   },
   "private": true,
   "devDependencies": {
-    "cypress": "15.8.0",
+    "cypress": "15.8.1",
     "serve": "14.2.5"
   }
 }

--- a/examples/start-and-yarn-workspaces/workspace-2/package.json
+++ b/examples/start-and-yarn-workspaces/workspace-2/package.json
@@ -10,7 +10,7 @@
   },
   "private": true,
   "devDependencies": {
-    "cypress": "15.8.0",
+    "cypress": "15.8.1",
     "serve": "14.2.5"
   }
 }

--- a/examples/start-and-yarn-workspaces/yarn.lock
+++ b/examples/start-and-yarn-workspaces/yarn.lock
@@ -431,10 +431,10 @@ cross-spawn@^7.0.0, cross-spawn@^7.0.3:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
-cypress@15.8.0:
-  version "15.8.0"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-15.8.0.tgz#b6d9d0b921eeb4be3b393fb5f974c7588e4da584"
-  integrity sha512-/k/KT8IIvcxarRSNb5AIhT1Yxx1pXsNIrL96Ht/c0pBOO/XcsjgjD4ZlG16V/08dRmvU/gT7PW8FBz5YV+ahsA==
+cypress@15.8.1:
+  version "15.8.1"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-15.8.1.tgz#48fcb0859b8b656534c9bb3f3abbf37554a2bb2d"
+  integrity sha512-ogc62stTQGh1395ipKxfCE5hQuSApTzeH5e0d9U6m7wYO9HQeCpgnkYtBtd0MbkN2Fnch5Od2mX9u4hoTlrH4Q==
   dependencies:
     "@cypress/request" "^3.0.9"
     "@cypress/xvfb" "^1.2.4"
@@ -473,7 +473,7 @@ cypress@15.8.0:
     proxy-from-env "1.0.0"
     request-progress "^3.0.0"
     supports-color "^8.1.1"
-    systeminformation "5.27.7"
+    systeminformation "^5.27.14"
     tmp "~0.2.4"
     tree-kill "1.2.2"
     untildify "^4.0.0"
@@ -1418,10 +1418,10 @@ supports-color@^8.1.1:
   dependencies:
     has-flag "^4.0.0"
 
-systeminformation@5.27.7:
-  version "5.27.7"
-  resolved "https://registry.yarnpkg.com/systeminformation/-/systeminformation-5.27.7.tgz#4dc9d436419948cd5e5f076779a1298220d19a72"
-  integrity sha512-saaqOoVEEFaux4v0K8Q7caiauRwjXC4XbD2eH60dxHXbpKxQ8kH9Rf7Jh+nryKpOUSEFxtCdBlSUx0/lO6rwRg==
+systeminformation@^5.27.14:
+  version "5.27.14"
+  resolved "https://registry.yarnpkg.com/systeminformation/-/systeminformation-5.27.14.tgz#9f2b181521c151dad4972d47936ebb49a3271e9d"
+  integrity sha512-3DoNDYSZBLxBwaJtQGWNpq0fonga/VZ47HY1+7/G3YoIPaPz93Df6egSzzTKbEMmlzUpy3eQ0nR9REuYIycXGg==
 
 throttleit@^1.0.0:
   version "1.0.0"

--- a/examples/start/package-lock.json
+++ b/examples/start/package-lock.json
@@ -8,7 +8,7 @@
       "name": "example-start",
       "version": "1.0.0",
       "devDependencies": {
-        "cypress": "15.8.0",
+        "cypress": "15.8.1",
         "serve": "14.2.5"
       }
     },
@@ -903,9 +903,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "15.8.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-15.8.0.tgz",
-      "integrity": "sha512-/k/KT8IIvcxarRSNb5AIhT1Yxx1pXsNIrL96Ht/c0pBOO/XcsjgjD4ZlG16V/08dRmvU/gT7PW8FBz5YV+ahsA==",
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-15.8.1.tgz",
+      "integrity": "sha512-ogc62stTQGh1395ipKxfCE5hQuSApTzeH5e0d9U6m7wYO9HQeCpgnkYtBtd0MbkN2Fnch5Od2mX9u4hoTlrH4Q==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -947,7 +947,7 @@
         "proxy-from-env": "1.0.0",
         "request-progress": "^3.0.0",
         "supports-color": "^8.1.1",
-        "systeminformation": "5.27.7",
+        "systeminformation": "^5.27.14",
         "tmp": "~0.2.4",
         "tree-kill": "1.2.2",
         "untildify": "^4.0.0",
@@ -2498,9 +2498,9 @@
       }
     },
     "node_modules/systeminformation": {
-      "version": "5.27.7",
-      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.27.7.tgz",
-      "integrity": "sha512-saaqOoVEEFaux4v0K8Q7caiauRwjXC4XbD2eH60dxHXbpKxQ8kH9Rf7Jh+nryKpOUSEFxtCdBlSUx0/lO6rwRg==",
+      "version": "5.27.14",
+      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.27.14.tgz",
+      "integrity": "sha512-3DoNDYSZBLxBwaJtQGWNpq0fonga/VZ47HY1+7/G3YoIPaPz93Df6egSzzTKbEMmlzUpy3eQ0nR9REuYIycXGg==",
       "dev": true,
       "license": "MIT",
       "os": [

--- a/examples/start/package.json
+++ b/examples/start/package.json
@@ -11,7 +11,7 @@
   },
   "private": true,
   "devDependencies": {
-    "cypress": "15.8.0",
+    "cypress": "15.8.1",
     "serve": "14.2.5"
   }
 }

--- a/examples/wait-on-vite/package-lock.json
+++ b/examples/wait-on-vite/package-lock.json
@@ -8,7 +8,7 @@
       "name": "example-wait-on-vite",
       "version": "2.0.0",
       "devDependencies": {
-        "cypress": "15.8.0",
+        "cypress": "15.8.1",
         "vite": "^7.1.5"
       }
     },
@@ -1306,9 +1306,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "15.8.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-15.8.0.tgz",
-      "integrity": "sha512-/k/KT8IIvcxarRSNb5AIhT1Yxx1pXsNIrL96Ht/c0pBOO/XcsjgjD4ZlG16V/08dRmvU/gT7PW8FBz5YV+ahsA==",
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-15.8.1.tgz",
+      "integrity": "sha512-ogc62stTQGh1395ipKxfCE5hQuSApTzeH5e0d9U6m7wYO9HQeCpgnkYtBtd0MbkN2Fnch5Od2mX9u4hoTlrH4Q==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -1350,7 +1350,7 @@
         "proxy-from-env": "1.0.0",
         "request-progress": "^3.0.0",
         "supports-color": "^8.1.1",
-        "systeminformation": "5.27.7",
+        "systeminformation": "^5.27.14",
         "tmp": "~0.2.4",
         "tree-kill": "1.2.2",
         "untildify": "^4.0.0",
@@ -2867,9 +2867,9 @@
       }
     },
     "node_modules/systeminformation": {
-      "version": "5.27.7",
-      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.27.7.tgz",
-      "integrity": "sha512-saaqOoVEEFaux4v0K8Q7caiauRwjXC4XbD2eH60dxHXbpKxQ8kH9Rf7Jh+nryKpOUSEFxtCdBlSUx0/lO6rwRg==",
+      "version": "5.27.14",
+      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.27.14.tgz",
+      "integrity": "sha512-3DoNDYSZBLxBwaJtQGWNpq0fonga/VZ47HY1+7/G3YoIPaPz93Df6egSzzTKbEMmlzUpy3eQ0nR9REuYIycXGg==",
       "dev": true,
       "license": "MIT",
       "os": [

--- a/examples/wait-on-vite/package.json
+++ b/examples/wait-on-vite/package.json
@@ -10,7 +10,7 @@
   },
   "private": true,
   "devDependencies": {
-    "cypress": "15.8.0",
+    "cypress": "15.8.1",
     "vite": "^7.1.5"
   }
 }

--- a/examples/wait-on/package-lock.json
+++ b/examples/wait-on/package-lock.json
@@ -12,7 +12,7 @@
         "debug": "4.3.6"
       },
       "devDependencies": {
-        "cypress": "15.8.0"
+        "cypress": "15.8.1"
       }
     },
     "node_modules/@cypress/request": {
@@ -556,9 +556,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "15.8.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-15.8.0.tgz",
-      "integrity": "sha512-/k/KT8IIvcxarRSNb5AIhT1Yxx1pXsNIrL96Ht/c0pBOO/XcsjgjD4ZlG16V/08dRmvU/gT7PW8FBz5YV+ahsA==",
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-15.8.1.tgz",
+      "integrity": "sha512-ogc62stTQGh1395ipKxfCE5hQuSApTzeH5e0d9U6m7wYO9HQeCpgnkYtBtd0MbkN2Fnch5Od2mX9u4hoTlrH4Q==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -600,7 +600,7 @@
         "proxy-from-env": "1.0.0",
         "request-progress": "^3.0.0",
         "supports-color": "^8.1.1",
-        "systeminformation": "5.27.7",
+        "systeminformation": "^5.27.14",
         "tmp": "~0.2.4",
         "tree-kill": "1.2.2",
         "untildify": "^4.0.0",
@@ -1870,9 +1870,9 @@
       }
     },
     "node_modules/systeminformation": {
-      "version": "5.27.7",
-      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.27.7.tgz",
-      "integrity": "sha512-saaqOoVEEFaux4v0K8Q7caiauRwjXC4XbD2eH60dxHXbpKxQ8kH9Rf7Jh+nryKpOUSEFxtCdBlSUx0/lO6rwRg==",
+      "version": "5.27.14",
+      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.27.14.tgz",
+      "integrity": "sha512-3DoNDYSZBLxBwaJtQGWNpq0fonga/VZ47HY1+7/G3YoIPaPz93Df6egSzzTKbEMmlzUpy3eQ0nR9REuYIycXGg==",
       "dev": true,
       "license": "MIT",
       "os": [

--- a/examples/wait-on/package.json
+++ b/examples/wait-on/package.json
@@ -20,6 +20,6 @@
     "debug": "4.3.6"
   },
   "devDependencies": {
-    "cypress": "15.8.0"
+    "cypress": "15.8.1"
   }
 }

--- a/examples/webpack/package-lock.json
+++ b/examples/webpack/package-lock.json
@@ -8,7 +8,7 @@
       "name": "example-webpack",
       "version": "1.0.0",
       "devDependencies": {
-        "cypress": "15.8.0",
+        "cypress": "15.8.1",
         "webpack": "^5.99.6",
         "webpack-cli": "^5.1.4",
         "webpack-dev-server": "^5.2.1"
@@ -1613,9 +1613,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "15.8.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-15.8.0.tgz",
-      "integrity": "sha512-/k/KT8IIvcxarRSNb5AIhT1Yxx1pXsNIrL96Ht/c0pBOO/XcsjgjD4ZlG16V/08dRmvU/gT7PW8FBz5YV+ahsA==",
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-15.8.1.tgz",
+      "integrity": "sha512-ogc62stTQGh1395ipKxfCE5hQuSApTzeH5e0d9U6m7wYO9HQeCpgnkYtBtd0MbkN2Fnch5Od2mX9u4hoTlrH4Q==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -1657,7 +1657,7 @@
         "proxy-from-env": "1.0.0",
         "request-progress": "^3.0.0",
         "supports-color": "^8.1.1",
-        "systeminformation": "5.27.7",
+        "systeminformation": "^5.27.14",
         "tmp": "~0.2.4",
         "tree-kill": "1.2.2",
         "untildify": "^4.0.0",
@@ -4779,9 +4779,9 @@
       }
     },
     "node_modules/systeminformation": {
-      "version": "5.27.7",
-      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.27.7.tgz",
-      "integrity": "sha512-saaqOoVEEFaux4v0K8Q7caiauRwjXC4XbD2eH60dxHXbpKxQ8kH9Rf7Jh+nryKpOUSEFxtCdBlSUx0/lO6rwRg==",
+      "version": "5.27.14",
+      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.27.14.tgz",
+      "integrity": "sha512-3DoNDYSZBLxBwaJtQGWNpq0fonga/VZ47HY1+7/G3YoIPaPz93Df6egSzzTKbEMmlzUpy3eQ0nR9REuYIycXGg==",
       "dev": true,
       "license": "MIT",
       "os": [

--- a/examples/webpack/package.json
+++ b/examples/webpack/package.json
@@ -8,7 +8,7 @@
   },
   "private": true,
   "devDependencies": {
-    "cypress": "15.8.0",
+    "cypress": "15.8.1",
     "webpack": "^5.99.6",
     "webpack-cli": "^5.1.4",
     "webpack-dev-server": "^5.2.1"

--- a/examples/yarn-classic/package.json
+++ b/examples/yarn-classic/package.json
@@ -7,6 +7,6 @@
   },
   "private": true,
   "devDependencies": {
-    "cypress": "15.8.0"
+    "cypress": "15.8.1"
   }
 }

--- a/examples/yarn-classic/yarn.lock
+++ b/examples/yarn-classic/yarn.lock
@@ -293,10 +293,10 @@ cross-spawn@^7.0.0:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
-cypress@15.8.0:
-  version "15.8.0"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-15.8.0.tgz#b6d9d0b921eeb4be3b393fb5f974c7588e4da584"
-  integrity sha512-/k/KT8IIvcxarRSNb5AIhT1Yxx1pXsNIrL96Ht/c0pBOO/XcsjgjD4ZlG16V/08dRmvU/gT7PW8FBz5YV+ahsA==
+cypress@15.8.1:
+  version "15.8.1"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-15.8.1.tgz#48fcb0859b8b656534c9bb3f3abbf37554a2bb2d"
+  integrity sha512-ogc62stTQGh1395ipKxfCE5hQuSApTzeH5e0d9U6m7wYO9HQeCpgnkYtBtd0MbkN2Fnch5Od2mX9u4hoTlrH4Q==
   dependencies:
     "@cypress/request" "^3.0.9"
     "@cypress/xvfb" "^1.2.4"
@@ -335,7 +335,7 @@ cypress@15.8.0:
     proxy-from-env "1.0.0"
     request-progress "^3.0.0"
     supports-color "^8.1.1"
-    systeminformation "5.27.7"
+    systeminformation "^5.27.14"
     tmp "~0.2.4"
     tree-kill "1.2.2"
     untildify "^4.0.0"
@@ -1066,10 +1066,10 @@ supports-color@^8.1.1:
   dependencies:
     has-flag "^4.0.0"
 
-systeminformation@5.27.7:
-  version "5.27.7"
-  resolved "https://registry.yarnpkg.com/systeminformation/-/systeminformation-5.27.7.tgz#4dc9d436419948cd5e5f076779a1298220d19a72"
-  integrity sha512-saaqOoVEEFaux4v0K8Q7caiauRwjXC4XbD2eH60dxHXbpKxQ8kH9Rf7Jh+nryKpOUSEFxtCdBlSUx0/lO6rwRg==
+systeminformation@^5.27.14:
+  version "5.27.14"
+  resolved "https://registry.yarnpkg.com/systeminformation/-/systeminformation-5.27.14.tgz#9f2b181521c151dad4972d47936ebb49a3271e9d"
+  integrity sha512-3DoNDYSZBLxBwaJtQGWNpq0fonga/VZ47HY1+7/G3YoIPaPz93Df6egSzzTKbEMmlzUpy3eQ0nR9REuYIycXGg==
 
 throttleit@^1.0.0:
   version "1.0.0"

--- a/examples/yarn-modern-pnp/package.json
+++ b/examples/yarn-modern-pnp/package.json
@@ -8,6 +8,6 @@
   "private": true,
   "packageManager": "yarn@4.12.0",
   "devDependencies": {
-    "cypress": "15.8.0"
+    "cypress": "15.8.1"
   }
 }

--- a/examples/yarn-modern-pnp/yarn.lock
+++ b/examples/yarn-modern-pnp/yarn.lock
@@ -386,9 +386,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cypress@npm:15.8.0":
-  version: 15.8.0
-  resolution: "cypress@npm:15.8.0"
+"cypress@npm:15.8.1":
+  version: 15.8.1
+  resolution: "cypress@npm:15.8.1"
   dependencies:
     "@cypress/request": "npm:^3.0.9"
     "@cypress/xvfb": "npm:^1.2.4"
@@ -427,14 +427,14 @@ __metadata:
     proxy-from-env: "npm:1.0.0"
     request-progress: "npm:^3.0.0"
     supports-color: "npm:^8.1.1"
-    systeminformation: "npm:5.27.7"
+    systeminformation: "npm:^5.27.14"
     tmp: "npm:~0.2.4"
     tree-kill: "npm:1.2.2"
     untildify: "npm:^4.0.0"
     yauzl: "npm:^2.10.0"
   bin:
     cypress: bin/cypress
-  checksum: 10c0/f0cddee7d2ebfb251db3ca9d6fd3bff489f6fedf84f95f5c74579f515eac0bfadadfb69f2505a9959e911c21a5a5ff8f5667ccb2c28c8f7371ffe7bf7b8625d3
+  checksum: 10c0/6c5a5dba566b7bd939c3aa0fec23814ee16ca40a28f3a1b3a64ab18fc5e9c31725c9a128a45fcca9d2e1d9be3cbca7fbfbcc95a4be00157942b440a987b2e9a8
   languageName: node
   linkType: hard
 
@@ -582,7 +582,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "example-yarn-modern-pnp@workspace:."
   dependencies:
-    cypress: "npm:15.8.0"
+    cypress: "npm:15.8.1"
   languageName: unknown
   linkType: soft
 
@@ -1403,12 +1403,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"systeminformation@npm:5.27.7":
-  version: 5.27.7
-  resolution: "systeminformation@npm:5.27.7"
+"systeminformation@npm:^5.27.14":
+  version: 5.27.14
+  resolution: "systeminformation@npm:5.27.14"
   bin:
     systeminformation: lib/cli.js
-  checksum: 10c0/92a9f3a2f37e135422da745be8e51984d66ae4c411e3d5c0ffdab9aef5cd8abc45d0d476bfa28c4bfee30a6e73722649544a88c4b6fa82b426c291adbfcdd8f9
+  checksum: 10c0/dd2887c19d46ae378cd916a25a6e8e323a86e5c20f456c724b6b954e8f0b78c0bd536e6a988482b1b70ce712c07c4146a471a712a650eefae13312c6ca06aebf
   conditions: (os=darwin | os=linux | os=win32 | os=freebsd | os=openbsd | os=netbsd | os=sunos | os=android)
   languageName: node
   linkType: hard

--- a/examples/yarn-modern/package.json
+++ b/examples/yarn-modern/package.json
@@ -8,6 +8,6 @@
   "private": true,
   "packageManager": "yarn@4.12.0",
   "devDependencies": {
-    "cypress": "15.8.0"
+    "cypress": "15.8.1"
   }
 }

--- a/examples/yarn-modern/yarn.lock
+++ b/examples/yarn-modern/yarn.lock
@@ -386,9 +386,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cypress@npm:15.8.0":
-  version: 15.8.0
-  resolution: "cypress@npm:15.8.0"
+"cypress@npm:15.8.1":
+  version: 15.8.1
+  resolution: "cypress@npm:15.8.1"
   dependencies:
     "@cypress/request": "npm:^3.0.9"
     "@cypress/xvfb": "npm:^1.2.4"
@@ -427,14 +427,14 @@ __metadata:
     proxy-from-env: "npm:1.0.0"
     request-progress: "npm:^3.0.0"
     supports-color: "npm:^8.1.1"
-    systeminformation: "npm:5.27.7"
+    systeminformation: "npm:^5.27.14"
     tmp: "npm:~0.2.4"
     tree-kill: "npm:1.2.2"
     untildify: "npm:^4.0.0"
     yauzl: "npm:^2.10.0"
   bin:
     cypress: bin/cypress
-  checksum: 10c0/f0cddee7d2ebfb251db3ca9d6fd3bff489f6fedf84f95f5c74579f515eac0bfadadfb69f2505a9959e911c21a5a5ff8f5667ccb2c28c8f7371ffe7bf7b8625d3
+  checksum: 10c0/6c5a5dba566b7bd939c3aa0fec23814ee16ca40a28f3a1b3a64ab18fc5e9c31725c9a128a45fcca9d2e1d9be3cbca7fbfbcc95a4be00157942b440a987b2e9a8
   languageName: node
   linkType: hard
 
@@ -582,7 +582,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "example-yarn-modern@workspace:."
   dependencies:
-    cypress: "npm:15.8.0"
+    cypress: "npm:15.8.1"
   languageName: unknown
   linkType: soft
 
@@ -1403,12 +1403,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"systeminformation@npm:5.27.7":
-  version: 5.27.7
-  resolution: "systeminformation@npm:5.27.7"
+"systeminformation@npm:^5.27.14":
+  version: 5.27.14
+  resolution: "systeminformation@npm:5.27.14"
   bin:
     systeminformation: lib/cli.js
-  checksum: 10c0/92a9f3a2f37e135422da745be8e51984d66ae4c411e3d5c0ffdab9aef5cd8abc45d0d476bfa28c4bfee30a6e73722649544a88c4b6fa82b426c291adbfcdd8f9
+  checksum: 10c0/dd2887c19d46ae378cd916a25a6e8e323a86e5c20f456c724b6b954e8f0b78c0bd536e6a988482b1b70ce712c07c4146a471a712a650eefae13312c6ca06aebf
   conditions: (os=darwin | os=linux | os=win32 | os=freebsd | os=openbsd | os=netbsd | os=sunos | os=android)
   languageName: node
   linkType: hard


### PR DESCRIPTION
This PR updates the [examples](https://github.com/cypress-io/github-action/tree/master/examples) to [cypress@15.8.1](https://docs.cypress.io/app/references/changelog#15-8-1) released Dec 18, 2025.