### PR TITLE
chore: remove Renovate weekend schedule

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -13,10 +13,6 @@
   ],
   "prConcurrentLimit": 5,
   "prHourlyLimit": 1,
-  "timezone": "America/New_York",
-  "schedule": [
-    "every weekend"
-  ],
   "packageRules": [
     {
       "matchDepTypes": ["dependencies"],


### PR DESCRIPTION
## Situation

[renovate.json](https://github.com/cypress-io/github-action/blob/master/renovate.json) currently specifies

```json
  "schedule": [
    "every weekend"
  ]
```

which causes PRs to be generated only on weekends. In practice, I am the only one who regularly reviews these PRs and I would prefer them not to be restricted to the weekend and instead be generated when ready.

[Renovate Scheduling](https://docs.renovatebot.com/key-concepts/scheduling/) documentation contains background information.

## Change

Remove the weekend schedule from [renovate.json](https://github.com/cypress-io/github-action/blob/master/renovate.json) in which case it will use the default [schedule](https://docs.renovatebot.com/configuration-options/#schedule) configuration of `["at any time"]`.

The [timezone](https://docs.renovatebot.com/configuration-options/#timezone) option is also removed, since this is only used when scheduling is specified. Renovate recommends only specifying [timezone](https://docs.renovatebot.com/configuration-options/#timezone) together with [schedule](https://docs.renovatebot.com/configuration-options/#schedule).