### PR TITLE
chore: group webpack* dependencies for Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -21,6 +21,11 @@
       "enabled": false
     },
     {
+      "matchPackageNames": ["/webpack/"],
+      "groupName": "webpack",
+      "extends": ["schedule:weekly"]
+    },
+    {
       "matchPackageNames": [
         "/eslint/",
         "globals"


### PR DESCRIPTION
## Situation

Renovate is now updating examples, including the [examples/webpack](https://github.com/cypress-io/github-action/tree/master/examples/webpack). Each dependency is handled separately, and this directory includes:

- `webpack`
- `webpack-cli`
- `webpack-dev-server`

## Change

Group the webpack* dependencies together in the Renovate config to reduce the number of PRs that Renovate generates, in the case of webpack simultaneously releasing updates. Limit to weekly updates.

## Verification

```shell
npx --yes --package renovate -- renovate-config-validator
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that just alters how Renovate groups and schedules dependency update PRs. No runtime code or dependency versions are modified.
> 
> **Overview**
> Renovate configuration now **groups all `webpack`-matching packages** (e.g., `webpack`, `webpack-cli`, `webpack-dev-server`) under a single `webpack` group and schedules those updates *weekly*, reducing the number of Renovate PRs when webpack-related packages release together.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9a194eaea56cbb753dfd239dfd360b1f8e6683dc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->