### PR TITLE
test: set defaultBrowser to chrome

### DIFF
--- a/.github/workflows/example-docker.yml
+++ b/.github/workflows/example-docker.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        browser: [chrome, edge, electron, firefox]
+        browser: [chrome, edge, firefox]
     # Cypress Docker image documentation on https://github.com/cypress-io/cypress-docker-images
     # Available cypress/browsers tags listed on https://hub.docker.com/r/cypress/browsers/tags
     container:

--- a/examples/basic-pnpm/cypress.config.js
+++ b/examples/basic-pnpm/cypress.config.js
@@ -1,6 +1,7 @@
 import { defineConfig } from 'cypress'
 
 export default defineConfig({
+  defaultBrowser: 'chrome',
   fixturesFolder: false,
   e2e: {
     supportFile: false,

--- a/examples/basic/cypress.config.js
+++ b/examples/basic/cypress.config.js
@@ -1,6 +1,7 @@
 import { defineConfig } from 'cypress'
 
 export default defineConfig({
+  defaultBrowser: 'chrome',
   fixturesFolder: false,
   e2e: {
     supportFile: false,

--- a/examples/browser/cypress.config.js
+++ b/examples/browser/cypress.config.js
@@ -2,6 +2,7 @@ import { defineConfig } from 'cypress'
 import os from 'node:os'
 
 export default defineConfig({
+  defaultBrowser: 'chrome',
   fixturesFolder: false,
   e2e: {
     setupNodeEvents (on) {

--- a/examples/component-tests/cypress.config.js
+++ b/examples/component-tests/cypress.config.js
@@ -1,6 +1,7 @@
 import { defineConfig } from 'cypress'
 
 export default defineConfig({
+  defaultBrowser: 'chrome',
   component: {
     devServer: {
       framework: 'react',

--- a/examples/config/cypress.config-alternate.js
+++ b/examples/config/cypress.config-alternate.js
@@ -1,6 +1,7 @@
 import { defineConfig } from 'cypress'
 
 export default defineConfig({
+  defaultBrowser: 'chrome',
   fixturesFolder: false,
   e2e: {
     baseUrl: 'http://localhost:3333',

--- a/examples/config/cypress.config.js
+++ b/examples/config/cypress.config.js
@@ -1,6 +1,7 @@
 import { defineConfig } from 'cypress'
 
 export default defineConfig({
+  defaultBrowser: 'chrome',
   fixturesFolder: false,
   e2e: {
     supportFile: false,

--- a/examples/custom-command/cypress.config.js
+++ b/examples/custom-command/cypress.config.js
@@ -1,6 +1,7 @@
 import { defineConfig } from 'cypress'
 
 export default defineConfig({
+  defaultBrowser: 'chrome',
   fixturesFolder: false,
   e2e: {
     supportFile: false,

--- a/examples/env/cypress.config.js
+++ b/examples/env/cypress.config.js
@@ -1,6 +1,7 @@
 import { defineConfig } from 'cypress'
 
 export default defineConfig({
+  defaultBrowser: 'chrome',
   fixturesFolder: false,
   e2e: {
     setupNodeEvents (on, config) {

--- a/examples/install-command/cypress.config.js
+++ b/examples/install-command/cypress.config.js
@@ -1,6 +1,7 @@
 import { defineConfig } from 'cypress'
 
 export default defineConfig({
+  defaultBrowser: 'chrome',
   fixturesFolder: false,
   e2e: {
     supportFile: false,

--- a/examples/install-only/cypress.config.js
+++ b/examples/install-only/cypress.config.js
@@ -1,6 +1,7 @@
 import { defineConfig } from 'cypress'
 
 export default defineConfig({
+  defaultBrowser: 'chrome',
   fixturesFolder: false,
   e2e: {
     supportFile: false,

--- a/examples/nextjs/cypress.config.js
+++ b/examples/nextjs/cypress.config.js
@@ -1,6 +1,7 @@
 import { defineConfig } from 'cypress'
 
 export default defineConfig({
+  defaultBrowser: 'chrome',
   fixturesFolder: false,
   e2e: {
     supportFile: false,

--- a/examples/node-versions/cypress.config.js
+++ b/examples/node-versions/cypress.config.js
@@ -1,6 +1,7 @@
 import { defineConfig } from 'cypress'
 
 export default defineConfig({
+  defaultBrowser: 'chrome',
   fixturesFolder: false,
   e2e: {
     supportFile: false,

--- a/examples/quiet/cypress.config.js
+++ b/examples/quiet/cypress.config.js
@@ -1,6 +1,7 @@
 import { defineConfig } from 'cypress'
 
 export default defineConfig({
+  defaultBrowser: 'chrome',
   fixturesFolder: false,
   e2e: {
     setupNodeEvents (on) {

--- a/examples/recording/cypress.config.js
+++ b/examples/recording/cypress.config.js
@@ -1,6 +1,7 @@
 import { defineConfig } from 'cypress'
 
 export default defineConfig({
+  defaultBrowser: 'chrome',
   fixturesFolder: false,
   projectId: '3tb7jn',
   e2e: {

--- a/examples/start-and-pnpm-workspaces/packages/workspace-1/cypress.config.js
+++ b/examples/start-and-pnpm-workspaces/packages/workspace-1/cypress.config.js
@@ -1,6 +1,7 @@
 import { defineConfig } from 'cypress'
 
 export default defineConfig({
+  defaultBrowser: 'chrome',
   fixturesFolder: false,
   e2e: {
     supportFile: false,

--- a/examples/start-and-pnpm-workspaces/packages/workspace-2/cypress.config.js
+++ b/examples/start-and-pnpm-workspaces/packages/workspace-2/cypress.config.js
@@ -1,6 +1,7 @@
 import { defineConfig } from 'cypress'
 
 export default defineConfig({
+  defaultBrowser: 'chrome',
   fixturesFolder: false,
   e2e: {
     supportFile: false,

--- a/examples/start-and-yarn-workspaces/workspace-1/cypress.config.js
+++ b/examples/start-and-yarn-workspaces/workspace-1/cypress.config.js
@@ -1,6 +1,7 @@
 import { defineConfig } from 'cypress'
 
 export default defineConfig({
+  defaultBrowser: 'chrome',
   fixturesFolder: false,
   e2e: {
     supportFile: false,

--- a/examples/start-and-yarn-workspaces/workspace-2/cypress.config.js
+++ b/examples/start-and-yarn-workspaces/workspace-2/cypress.config.js
@@ -1,6 +1,7 @@
 import { defineConfig } from 'cypress'
 
 export default defineConfig({
+  defaultBrowser: 'chrome',
   fixturesFolder: false,
   e2e: {
     supportFile: false,

--- a/examples/start/cypress.config.js
+++ b/examples/start/cypress.config.js
@@ -1,6 +1,7 @@
 import { defineConfig } from 'cypress'
 
 export default defineConfig({
+  defaultBrowser: 'chrome',
   fixturesFolder: false,
   e2e: {
     supportFile: false,

--- a/examples/wait-on-vite/cypress.config.js
+++ b/examples/wait-on-vite/cypress.config.js
@@ -1,6 +1,7 @@
 import { defineConfig } from 'cypress'
 
 export default defineConfig({
+  defaultBrowser: 'chrome',
   fixturesFolder: false,
   e2e: {
     supportFile: false,

--- a/examples/wait-on/cypress.config.js
+++ b/examples/wait-on/cypress.config.js
@@ -1,6 +1,7 @@
 import { defineConfig } from 'cypress'
 
 export default defineConfig({
+  defaultBrowser: 'chrome',
   fixturesFolder: false,
   e2e: {
     supportFile: false,

--- a/examples/webpack/cypress.config.js
+++ b/examples/webpack/cypress.config.js
@@ -1,6 +1,7 @@
 import { defineConfig } from 'cypress'
 
 export default defineConfig({
+  defaultBrowser: 'chrome',
   fixturesFolder: false,
   e2e: {
     supportFile: false,

--- a/examples/yarn-classic/cypress.config.js
+++ b/examples/yarn-classic/cypress.config.js
@@ -1,6 +1,7 @@
 import { defineConfig } from 'cypress'
 
 export default defineConfig({
+  defaultBrowser: 'chrome',
   fixturesFolder: false,
   e2e: {
     supportFile: false,

--- a/examples/yarn-modern-pnp/cypress.config.js
+++ b/examples/yarn-modern-pnp/cypress.config.js
@@ -1,6 +1,7 @@
 import { defineConfig } from 'cypress'
 
 export default defineConfig({
+  defaultBrowser: 'chrome',
   fixturesFolder: false,
   e2e: {
     supportFile: false,

--- a/examples/yarn-modern/cypress.config.js
+++ b/examples/yarn-modern/cypress.config.js
@@ -1,6 +1,7 @@
 import { defineConfig } from 'cypress'
 
 export default defineConfig({
+  defaultBrowser: 'chrome',
   fixturesFolder: false,
   e2e: {
     supportFile: false,


### PR DESCRIPTION
## Situation

Cypress 16 plans to remove Electron as default browser with open plans for exact replacement options (see https://github.com/cypress-io/cypress/issues/33524). Workflows that do not define a browser may fail.

## Change

Chrome is the most used browser and is available in GitHub-hosted runners for each operating system.

For those examples that are not browser-specific add the [Browsers](https://docs.cypress.io/app/references/configuration#Browser) configuration setting `defaultBrowsers: chrome`.

Remove tests that explicitly specify `electron`.

## Follow-on actions

Prior to release of Cypress 16, documentation that refers to Electron being the default browser for Cypress will need updating.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk since this only adjusts Cypress example configs and CI test matrix; main impact is reduced browser coverage (Electron no longer exercised) and any implicit reliance on Electron defaults.
> 
> **Overview**
> Sets `defaultBrowser: 'chrome'` across Cypress example `cypress.config.js` files so runs don’t depend on Electron being the implicit default.
> 
> Updates the `example-docker` GitHub Actions workflow matrix to stop running tests in `electron`, leaving `chrome`, `edge`, and `firefox`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5ea7191d0378149e0302a654a2f834395a09f249. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->