### PR TITLE
chore(renovate): restrict vite to <8

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -21,6 +21,14 @@
       "enabled": false
     },
     {
+      "matchPackageNames": ["vite"],
+      "allowedVersions": "<8"
+    },
+    {
+      "matchPackageNames": ["@vitejs/plugin-react"],
+      "allowedVersions": "<6"
+    },
+    {
       "matchPackageNames": ["/webpack/"],
       "groupName": "webpack",
       "extends": ["schedule:weekly"]


### PR DESCRIPTION
## Situation

Two example directories are set up with `vite@7`:

- [examples/component-tests](https://github.com/cypress-io/github-action/tree/master/examples/component-tests)
- [examples/wait-on-vite](https://github.com/cypress-io/github-action/tree/master/examples/wait-on-vite)

Cypress Component Testing is not yet compatible with the latest version `vite@8`, see
- https://github.com/cypress-io/cypress/issues/33078

The current configuration is:

https://github.com/cypress-io/github-action/blob/783cb3f07983868532cabaedaa1e6c00ff4786a8/examples/component-tests/package.json#L16-L22

The latest version [@vitejs/plugin-react@6](https://www.npmjs.com/package/@vitejs/plugin-react) shows `"vite": "^8.0.0"` in `peerDependencies`, whereas the currently configured version [@vitejs/plugin-react@5.2.0](https://www.npmjs.com/package/@vitejs/plugin-react/v/5.2.0?activeTab=code) is compatible with `"vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"`

## Change

Modify the [renovate.json](https://github.com/cypress-io/github-action/blob/master/renovate.json) configuration.

For compatibility with Cypress Component Testing, restrict `vite` to `<8` and `@vitejs/plugin-react` to `<6`

Keep both example directories using the same `vite` version for comparability.

## Verification

```shell
npx --yes --package renovate -- renovate-config-validator
```

## References

- [packageRules.matchPackageNames](https://docs.renovatebot.com/configuration-options/#packagerulesmatchpackagenames)
- [packageRules.allowedVersions](https://docs.renovatebot.com/configuration-options/#packagerulesallowedversions)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only change that just limits dependency update ranges; no runtime code or production behavior is modified.
> 
> **Overview**
> Adds Renovate `packageRules` to **prevent major upgrades** of Vite tooling by constraining `vite` to `<8` and `@vitejs/plugin-react` to `<6`, keeping Renovate from opening PRs that would move the examples onto incompatible versions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d63aaa2514129dca0edfc5730bc5692e3edcf0d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->