### PR TITLE
test: revert "test: set defaultBrowser to chrome (#1713)"

### DIFF
--- a/.github/workflows/example-docker.yml
+++ b/.github/workflows/example-docker.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        browser: [chrome, edge, firefox]
+        browser: [chrome, edge, electron, firefox]
     # Cypress Docker image documentation on https://github.com/cypress-io/cypress-docker-images
     # Available cypress/browsers tags listed on https://hub.docker.com/r/cypress/browsers/tags
     container:

--- a/examples/basic-pnpm/cypress.config.js
+++ b/examples/basic-pnpm/cypress.config.js
@@ -1,7 +1,6 @@
 import { defineConfig } from 'cypress'
 
 export default defineConfig({
-  defaultBrowser: 'chrome',
   fixturesFolder: false,
   e2e: {
     supportFile: false,

--- a/examples/basic/cypress.config.js
+++ b/examples/basic/cypress.config.js
@@ -1,7 +1,6 @@
 import { defineConfig } from 'cypress'
 
 export default defineConfig({
-  defaultBrowser: 'chrome',
   fixturesFolder: false,
   e2e: {
     supportFile: false,

--- a/examples/browser/cypress.config.js
+++ b/examples/browser/cypress.config.js
@@ -2,7 +2,6 @@ import { defineConfig } from 'cypress'
 import os from 'node:os'
 
 export default defineConfig({
-  defaultBrowser: 'chrome',
   fixturesFolder: false,
   e2e: {
     setupNodeEvents (on) {

--- a/examples/component-tests/cypress.config.js
+++ b/examples/component-tests/cypress.config.js
@@ -1,7 +1,6 @@
 import { defineConfig } from 'cypress'
 
 export default defineConfig({
-  defaultBrowser: 'chrome',
   component: {
     devServer: {
       framework: 'react',

--- a/examples/config/cypress.config-alternate.js
+++ b/examples/config/cypress.config-alternate.js
@@ -1,7 +1,6 @@
 import { defineConfig } from 'cypress'
 
 export default defineConfig({
-  defaultBrowser: 'chrome',
   fixturesFolder: false,
   e2e: {
     baseUrl: 'http://localhost:3333',

--- a/examples/config/cypress.config.js
+++ b/examples/config/cypress.config.js
@@ -1,7 +1,6 @@
 import { defineConfig } from 'cypress'
 
 export default defineConfig({
-  defaultBrowser: 'chrome',
   fixturesFolder: false,
   e2e: {
     supportFile: false,

--- a/examples/custom-command/cypress.config.js
+++ b/examples/custom-command/cypress.config.js
@@ -1,7 +1,6 @@
 import { defineConfig } from 'cypress'
 
 export default defineConfig({
-  defaultBrowser: 'chrome',
   fixturesFolder: false,
   e2e: {
     supportFile: false,

--- a/examples/env/cypress.config.js
+++ b/examples/env/cypress.config.js
@@ -1,7 +1,6 @@
 import { defineConfig } from 'cypress'
 
 export default defineConfig({
-  defaultBrowser: 'chrome',
   fixturesFolder: false,
   e2e: {
     setupNodeEvents (on, config) {

--- a/examples/install-command/cypress.config.js
+++ b/examples/install-command/cypress.config.js
@@ -1,7 +1,6 @@
 import { defineConfig } from 'cypress'
 
 export default defineConfig({
-  defaultBrowser: 'chrome',
   fixturesFolder: false,
   e2e: {
     supportFile: false,

--- a/examples/install-only/cypress.config.js
+++ b/examples/install-only/cypress.config.js
@@ -1,7 +1,6 @@
 import { defineConfig } from 'cypress'
 
 export default defineConfig({
-  defaultBrowser: 'chrome',
   fixturesFolder: false,
   e2e: {
     supportFile: false,

--- a/examples/nextjs/cypress.config.js
+++ b/examples/nextjs/cypress.config.js
@@ -1,7 +1,6 @@
 import { defineConfig } from 'cypress'
 
 export default defineConfig({
-  defaultBrowser: 'chrome',
   fixturesFolder: false,
   e2e: {
     supportFile: false,

--- a/examples/node-versions/cypress.config.js
+++ b/examples/node-versions/cypress.config.js
@@ -1,7 +1,6 @@
 import { defineConfig } from 'cypress'
 
 export default defineConfig({
-  defaultBrowser: 'chrome',
   fixturesFolder: false,
   e2e: {
     supportFile: false,

--- a/examples/quiet/cypress.config.js
+++ b/examples/quiet/cypress.config.js
@@ -1,7 +1,6 @@
 import { defineConfig } from 'cypress'
 
 export default defineConfig({
-  defaultBrowser: 'chrome',
   fixturesFolder: false,
   e2e: {
     setupNodeEvents (on) {

--- a/examples/recording/cypress.config.js
+++ b/examples/recording/cypress.config.js
@@ -1,7 +1,6 @@
 import { defineConfig } from 'cypress'
 
 export default defineConfig({
-  defaultBrowser: 'chrome',
   fixturesFolder: false,
   projectId: '3tb7jn',
   e2e: {

--- a/examples/start-and-pnpm-workspaces/packages/workspace-1/cypress.config.js
+++ b/examples/start-and-pnpm-workspaces/packages/workspace-1/cypress.config.js
@@ -1,7 +1,6 @@
 import { defineConfig } from 'cypress'
 
 export default defineConfig({
-  defaultBrowser: 'chrome',
   fixturesFolder: false,
   e2e: {
     supportFile: false,

--- a/examples/start-and-pnpm-workspaces/packages/workspace-2/cypress.config.js
+++ b/examples/start-and-pnpm-workspaces/packages/workspace-2/cypress.config.js
@@ -1,7 +1,6 @@
 import { defineConfig } from 'cypress'
 
 export default defineConfig({
-  defaultBrowser: 'chrome',
   fixturesFolder: false,
   e2e: {
     supportFile: false,

--- a/examples/start-and-yarn-workspaces/workspace-1/cypress.config.js
+++ b/examples/start-and-yarn-workspaces/workspace-1/cypress.config.js
@@ -1,7 +1,6 @@
 import { defineConfig } from 'cypress'
 
 export default defineConfig({
-  defaultBrowser: 'chrome',
   fixturesFolder: false,
   e2e: {
     supportFile: false,

--- a/examples/start-and-yarn-workspaces/workspace-2/cypress.config.js
+++ b/examples/start-and-yarn-workspaces/workspace-2/cypress.config.js
@@ -1,7 +1,6 @@
 import { defineConfig } from 'cypress'
 
 export default defineConfig({
-  defaultBrowser: 'chrome',
   fixturesFolder: false,
   e2e: {
     supportFile: false,

--- a/examples/start/cypress.config.js
+++ b/examples/start/cypress.config.js
@@ -1,7 +1,6 @@
 import { defineConfig } from 'cypress'
 
 export default defineConfig({
-  defaultBrowser: 'chrome',
   fixturesFolder: false,
   e2e: {
     supportFile: false,

--- a/examples/wait-on-vite/cypress.config.js
+++ b/examples/wait-on-vite/cypress.config.js
@@ -1,7 +1,6 @@
 import { defineConfig } from 'cypress'
 
 export default defineConfig({
-  defaultBrowser: 'chrome',
   fixturesFolder: false,
   e2e: {
     supportFile: false,

--- a/examples/wait-on/cypress.config.js
+++ b/examples/wait-on/cypress.config.js
@@ -1,7 +1,6 @@
 import { defineConfig } from 'cypress'
 
 export default defineConfig({
-  defaultBrowser: 'chrome',
   fixturesFolder: false,
   e2e: {
     supportFile: false,

--- a/examples/webpack/cypress.config.js
+++ b/examples/webpack/cypress.config.js
@@ -1,7 +1,6 @@
 import { defineConfig } from 'cypress'
 
 export default defineConfig({
-  defaultBrowser: 'chrome',
   fixturesFolder: false,
   e2e: {
     supportFile: false,

--- a/examples/yarn-classic/cypress.config.js
+++ b/examples/yarn-classic/cypress.config.js
@@ -1,7 +1,6 @@
 import { defineConfig } from 'cypress'
 
 export default defineConfig({
-  defaultBrowser: 'chrome',
   fixturesFolder: false,
   e2e: {
     supportFile: false,

--- a/examples/yarn-modern-pnp/cypress.config.js
+++ b/examples/yarn-modern-pnp/cypress.config.js
@@ -1,7 +1,6 @@
 import { defineConfig } from 'cypress'
 
 export default defineConfig({
-  defaultBrowser: 'chrome',
   fixturesFolder: false,
   e2e: {
     supportFile: false,

--- a/examples/yarn-modern/cypress.config.js
+++ b/examples/yarn-modern/cypress.config.js
@@ -1,7 +1,6 @@
 import { defineConfig } from 'cypress'
 
 export default defineConfig({
-  defaultBrowser: 'chrome',
   fixturesFolder: false,
   e2e: {
     supportFile: false,


### PR DESCRIPTION
## Situation

Workflows recording to Cypress Cloud are currently sporadically failing due to a [deployment](https://github.com/actions/runner-images/blob/main/README.md#available-images) of [ubuntu-24.04](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md)

This includes a major version update from Google Chrome 146 to 147.

<table>
    <thead>
        <th>Category</th>
        <th>Tool name</th>
        <th>Previous (20260406.80.1)</th>
        <th>Current (20260413.86.1)</th>
    </thead>
    <tbody>
        <tr>
            <td rowspan="7">Browsers and Drivers</td>
            <td>Google Chrome</td>
            <td>146.0.7680.177</td>
            <td>147.0.7727.55</td>
        </tr>
        <tr>
            <td>ChromeDriver</td>
            <td>146.0.7680.165</td>
            <td>147.0.7727.56</td>
        </tr>
        <tr>
            <td>Chromium</td>
            <td>146.0.7680.0</td>
            <td>147.0.7727.0</td>
        </tr>
        <tr>
            <td>Microsoft Edge</td>
            <td>146.0.3856.97</td>
            <td>147.0.3912.60</td>
        </tr>
        <tr>
            <td>Microsoft Edge WebDriver</td>
            <td>146.0.3856.97</td>
            <td>147.0.3912.60</td>
        </tr>
        <tr>
            <td>Selenium server</td>
            <td>4.41.0</td>
            <td>4.43.0</td>
        </tr>
        <tr>
            <td>Mozilla Firefox</td>
            <td>149.0</td>
            <td>149.0.2</td>
        </tr>
    </tbody>
</table>

This is a known issue described in the [README > parallel](https://github.com/cypress-io/github-action/blob/master/README.md#parallel) section:

> During staged rollout of a new GitHub-hosted runner version, GitHub may provide a mixture of current and new image versions used by the container matrix. It is recommended to use a [Docker image](#docker-image) in the parallel job run which avoids any Cypress Cloud errors due to browser major version mismatch from the two different image versions. A [Docker image](#docker-image) is not necessary if testing against the default built-in Electron browser because this browser version is fixed by the Cypress version in use and it is unaffected by any GitHub runner image rollout.

In anticipation of a change in the future Cypress 16 release, which would have removed Electron as the default browser, PR https://github.com/cypress-io/github-action/pull/1713 set Chrome as the default browser in this repo.

In the meantime, the plans for Cypress 16 have changed and Electron remains.

Setting Chrome as default has exposed the workflows to the issue described above, where GitHub Actions randomly provides old and new runner versions in parallel runs.

## Change

Revert https://github.com/cypress-io/github-action/pull/1713 commit https://github.com/cypress-io/github-action/commit/68be0d46e386460c28d16735c7a55a5bb5047ecd to reset the default browser version from an explicit choice of Chrome back to Cypress' default setting of Electron.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CI/test configuration and browser selection; main risk is unintended shifts in which browser tests run under (especially in existing workflows) rather than production behavior.
> 
> **Overview**
> Reverts the examples’ Cypress configuration to stop forcing `defaultBrowser: 'chrome'`, letting Cypress fall back to its default browser (Electron) to reduce flakiness from GitHub runner Chrome version drift.
> 
> Updates the `example-docker` GitHub Actions workflow matrix to also run tests against `electron` alongside `chrome`, `edge`, and `firefox`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 934de0be4c5bce5237f813f191c589041bbba2c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->