### PR TITLE
test: update Yarn Modern to 4.14.1

### DIFF
--- a/examples/yarn-modern-pnp/.yarnrc.yml
+++ b/examples/yarn-modern-pnp/.yarnrc.yml
@@ -2,5 +2,3 @@ approvedGitRepositories:
   - "**"
 
 enableScripts: true
-
-nodeLinker: node-modules

--- a/examples/yarn-modern-pnp/.yarnrc.yml
+++ b/examples/yarn-modern-pnp/.yarnrc.yml
@@ -1,4 +1,4 @@
 approvedGitRepositories:
-  - "**"
+  - '**'
 
 enableScripts: true

--- a/examples/yarn-modern-pnp/package.json
+++ b/examples/yarn-modern-pnp/package.json
@@ -7,7 +7,7 @@
     "test": "cypress run"
   },
   "private": true,
-  "packageManager": "yarn@4.13.0",
+  "packageManager": "yarn@4.14.1",
   "devDependencies": {
     "cypress": "15.13.1"
   }

--- a/examples/yarn-modern-pnp/yarn.lock
+++ b/examples/yarn-modern-pnp/yarn.lock
@@ -2,7 +2,7 @@
 # Manual changes might be lost - proceed with caution!
 
 __metadata:
-  version: 8
+  version: 9
   cacheKey: 10c0
 
 "@cypress/request@npm:^3.0.10":

--- a/examples/yarn-modern/.yarnrc.yml
+++ b/examples/yarn-modern/.yarnrc.yml
@@ -1,5 +1,5 @@
 approvedGitRepositories:
-  - "**"
+  - '**'
 
 enableScripts: true
 

--- a/examples/yarn-modern/package.json
+++ b/examples/yarn-modern/package.json
@@ -7,7 +7,7 @@
     "test": "cypress run"
   },
   "private": true,
-  "packageManager": "yarn@4.13.0",
+  "packageManager": "yarn@4.14.1",
   "devDependencies": {
     "cypress": "15.13.1"
   }

--- a/examples/yarn-modern/yarn.lock
+++ b/examples/yarn-modern/yarn.lock
@@ -2,7 +2,7 @@
 # Manual changes might be lost - proceed with caution!
 
 __metadata:
-  version: 8
+  version: 9
   cacheKey: 10c0
 
 "@cypress/request@npm:^3.0.10":


### PR DESCRIPTION
## Situation

The currently configured Yarn Modern 4.13.0 is not compatible with the update to Node.js 24.15.0 LTS. Also the attempted Renovate update to Yarn 4.14.0 in PR https://github.com/cypress-io/github-action/pull/1725 failed for the same compatibility reason.

[Yarn Berry 4.14.1](https://github.com/yarnpkg/berry/releases/tag/%40yarnpkg%2Fcli%2F4.14.1), released Apr 17, 2026 resolves the incompatibility.

## Change

In the example directories:

- [examples/yarn-modern](https://github.com/cypress-io/github-action/tree/master/examples/yarn-modern)
- [examples/yarn-modern-pnp](https://github.com/cypress-io/github-action/tree/master/examples/yarn-modern-pnp)

currently using Yarn Modern 4.13.0, execute:

```shell
yarn set version latest
yarn
```

to update and migrate to the latest Yarn Modern release [Yarn Berry 4.14.1](https://github.com/yarnpkg/berry/releases/tag/%40yarnpkg%2Fcli%2F4.14.1)

This is beyond the scope of what a Renovate update could do.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to example projects’ Yarn configuration and lockfile metadata, with no production/runtime code impacted.
> 
> **Overview**
> Updates the `examples/yarn-modern` and `examples/yarn-modern-pnp` projects to use **Yarn 4.14.1** (from 4.13.0) via `packageManager`.
> 
> Adds Yarn config in `.yarnrc.yml` to allow `approvedGitRepositories` and enable `enableScripts`, and regenerates `yarn.lock` to the newer lockfile metadata version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2a51ba2998811687f93f75502df45033f42cde2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->