### PR TITLE
chore(deps): update basic-ftp to 5.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1100,9 +1100,9 @@
       "license": "MIT"
     },
     "node_modules/basic-ftp": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.0.tgz",
-      "integrity": "sha512-VoMINM2rqJwJgfdHq6RiUudKt2BV+FY5ZFezP/ypmwayk68+NzzAQy4XXLlqsGD4MCzq3DrmNFD/uUmBJuGoXw==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.0.tgz",
+      "integrity": "sha512-5K9eNNn7ywHPsYnFwjKgYH8Hf8B5emh7JKcPaVjjrMJFQQwGpwowEnZNEtHs7DfR7hCZsmaK3VA4HUK0YarT+w==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
## Situation

`npm audit` and Dependabot report several high severity vulnerabilities in [basic-ftp@5.2.0](https://github.com/patrickjuchli/basic-ftp/releases/tag/v5.2.0), a transient dependency of [markdown-link-check@3.14.2](https://github.com/tcort/markdown-link-check/releases/tag/v3.14.2) (current `latest`).

```
$ npm audit
# npm audit report

basic-ftp  <=5.2.2
Severity: high
basic-ftp: Incomplete CRLF Injection Protection Allows Arbitrary FTP Command Execution via Credentials and MKD Commands - https://github.com/advisories/GHSA-6v7q-wjvx-w8wg
basic-ftp has FTP Command Injection via CRLF - https://github.com/advisories/GHSA-chqc-8p9q-pq6q
basic-ftp vulnerable to denial of service via unbounded memory consumption in Client.list() - https://github.com/advisories/GHSA-rp42-5vxx-qpwr
fix available via `npm audit fix`
node_modules/basic-ftp

1 high severity vulnerability

To address all issues, run:
  npm audit fix
```

## Change

Execute `npm audit fix` to update to [basic-ftp@5.3.0](https://github.com/patrickjuchli/basic-ftp/releases/tag/v5.3.0).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lockfile-only dependency bump for a dev/transitive package; low risk beyond potential install/CI reproducibility differences.
> 
> **Overview**
> Updates the `basic-ftp` transitive dependency in `package-lock.json` from `5.2.0` to `5.3.0` (new tarball URL and integrity hash) to pick up upstream security fixes reported by `npm audit`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c67512b85032bd24dfbb6aa6667da60d7643ff2a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->