### PR TITLE
chore(renovate): enable lockfileMaintenance for examples/**

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -15,7 +15,19 @@
   "prConcurrentLimit": 5,
   "prHourlyLimit": 1,
   "rangeStrategy": "bump",
+  "lockFileMaintenance": {
+    "enabled": true
+  },
   "packageRules": [
+    {
+      "matchUpdateTypes": ["lockFileMaintenance"],
+      "enabled": false
+    },
+    {
+      "matchUpdateTypes": ["lockFileMaintenance"],
+      "matchFileNames": ["examples/**"],
+      "enabled": true
+    },
     {
       "matchDepTypes": ["dependencies"],
       "enabled": false


### PR DESCRIPTION
## Situation

Renovate is currently not configured in [renovate.json](https://github.com/cypress-io/github-action/blob/master/renovate.json) for `lockfileMaintenance` since this could cause the need for an action rebuild, and so far there hasn't been a process set up that could deal with this.

This means however that vulnerabilities in the [examples](https://github.com/cypress-io/github-action/tree/master/examples) sub-directories caused by transient dependencies such as `lodash` are currently not addressed by Renovate updates.

## Change

Enable `lockFileMaintenance` in the [renovate.json](https://github.com/cypress-io/github-action/blob/master/renovate.json) configuration for [examples/**](https://github.com/cypress-io/github-action/tree/master/examples) only.

`lockFileMaintenance` runs weekly by default. It can also be intiated manually through the [Dependency Dashboard](https://github.com/cypress-io/github-action/issues/108) or through the [Renovate Web UI](https://developer.mend.io/github/cypress-io/github-action).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates Renovate configuration to control when lockfile maintenance PRs are created, without touching runtime code.
> 
> **Overview**
> Enables Renovate `lockFileMaintenance`, then adds package rules to **disable lockfile maintenance by default** and **re-enable it only for `examples/**`** so Renovate can refresh example lockfiles without triggering lockfile maintenance across the rest of the repo.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 428cb26878464217beba1af6407d914aab46a413. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->