### PR TITLE
chore(renovate): disable pnpm version updates in actions

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -66,6 +66,11 @@
       "matchManagers": ["github-actions"],
       "matchPackageNames": ["pnpm/action-setup"],
       "enabled": false
+    },
+    {
+      "matchDepTypes": ["uses-with"],
+      "matchPackageNames": ["pnpm"],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
## Situation

Renovate attempts to update the pnpm version in related workflows where the version is specified by the `with.version` clause using the JavaScript action [pnpm/action-setup](https://github.com/pnpm/action-setup).

To remain aligned with the [README > pnpm](https://github.com/cypress-io/github-action#pnpm) documentation section we want to keep:

```yml
      - name: Install pnpm
        uses: pnpm/action-setup@v5
        with:
          version: 10
```

using the major version of pnpm only, without pinning it to an exact pnpm version.

An update to version 11, currently in release candidate status, is also not desired, since this requires manual update and testing of the related example directories.

## Change

Disable Renovate updates for the pnpm version in GitHub Action [pnpm/action-setup](https://github.com/pnpm/action-setup) in the [renovate.json](https://github.com/cypress-io/github-action/blob/master/renovate.json) configuration.

The Renovate configuration uses `"matchDepTypes": ["uses-with"]`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that just alters Renovate behavior for GitHub Actions; impact is limited to dependency update PRs (pnpm updates will no longer be proposed).
> 
> **Overview**
> Disables Renovate PRs that try to update the `pnpm` version specified via `with.version` in GitHub Actions by adding a new `packageRules` entry matching `matchDepTypes: ["uses-with"]` for `pnpm`.
> 
> Keeps the existing rule that already disables updates to the `pnpm/action-setup` action itself, but now also prevents Renovate from proposing pnpm runtime version bumps (e.g., major upgrades) inside workflows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit acccaec58c4042a2045a4103bdb5362d8b49737f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->