### PR TITLE
feat(deps): remove Node.js 20

### DIFF
--- a/.github/workflows/example-node-versions.yml
+++ b/.github/workflows/example-node-versions.yml
@@ -14,7 +14,6 @@ jobs:
       fail-fast: false
       matrix:
         node:
-          - 20
           - 22
           - 24
           - 25

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ See [Releases](https://github.com/cypress-io/github-action/releases) for full de
 
 | Version | Changes                                                                                                      |
 | ------- | ------------------------------------------------------------------------------------------------------------ |
+| v7.2.0  | Examples remove Node.js 20. End of support for Node.js 20.                                                   |
 | v7.1.0  | Add parameter `package-manager-cache`                                                                        |
 | v7.0.0  | Action runs under Node.js 24 instead of Node.js 20                                                           |
 | v6.10.0 | Examples remove Node.js 23. End of support for Node.js 23.                                                   |

--- a/README.md
+++ b/README.md
@@ -564,7 +564,10 @@ jobs:
     # let's make sure our "app" works on several versions of Node
     strategy:
       matrix:
-        node: [20, 22, 24, 25]
+        node:
+          - 22
+          - 24
+          - 25
     name: E2E on Node v${{ matrix.node }}
     steps:
       - name: Checkout
@@ -1386,7 +1389,10 @@ jobs:
     # let's make sure our "app" works on several versions of Node
     strategy:
       matrix:
-        node: [20, 22, 24, 25]
+        node:
+          - 22
+          - 24
+          - 25
     name: E2E on Node v${{ matrix.node }}
     steps:
       - name: Checkout
@@ -1420,7 +1426,10 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        node: [20, 22, 24, 25]
+        node:
+          - 22
+          - 24
+          - 25
     name: E2E on Node v${{ matrix.node }}
     steps:
       - uses: actions/checkout@v6
@@ -1887,9 +1896,9 @@ jobs:
 
 Node.js is required to run this action. The recommended version `v7` supports:
 
-- **Node.js** 20.x, 22.x, 24.x and 25.x
+- **Node.js** 22.x, 24.x and 25.x
 
-and is generally aligned with [Node.js's release schedule](https://github.com/nodejs/Release).
+and is generally aligned with [Node.js's release schedule](https://github.com/nodejs/Release#readme).
 
 ### Usage
 
@@ -1906,7 +1915,7 @@ View the [CHANGELOG](./CHANGELOG.md) document for an overview of version changes
 ## Compatibility
 
 - `github-action@v7` is the current recommended version, uses `node24` and is compatible with Cypress `10` and above.
-- `github-action@v6` is deprecated. It uses `node20` which GitHub has deprecated. GitHub Actions will force runners to use `node24` beginning on Mar 4, 2026 - see [Deprecation of Node 20 on GitHub Actions runners](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/).
+- `github-action@v6` is deprecated. It uses `node20` which has reached its end of life - see [Deprecation of Node 20 on GitHub Actions runners](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/).
 - `github-action@v6.7.9` is the minimum version required to use GitHub Actions caching services. The legacy caching service used by lower versions of the action is no longer available.
 - `github-action` versions `v1` to `v5` are unsupported: they rely on Node.js `12` and `16` in End-of-life status.
 


### PR DESCRIPTION
## Situation

Node.js `20.x` transitioned into [End-of-life](https://github.com/nodejs/Release#end-of-life-releases) status on April 30, 2026.

## Change

This PR removes Node.js `20`:

- from the matrix of tested nodes under [.github/workflows/example-node-versions.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-node-versions.yml)
- from the [README > Examples](https://github.com/cypress-io/github-action/blob/master/README.md#examples) section
- from the [README > Node.js > Support](https://github.com/cypress-io/github-action/blob/master/README.md#examples) section

and adds the change to the [CHANGELOG](https://github.com/cypress-io/github-action/blob/master/CHANGELOG.md).

## Comments

- Although there is no change to the action itself, this PR triggers a minor version release in order to republish the [README](https://github.com/cypress-io/github-action/blob/master/README.md) to the [npm registry](https://www.npmjs.com/package/@cypress/github-action) for reference. It also provides a release milestone for reference in the [CHANGELOG](https://github.com/cypress-io/github-action/blob/master/CHANGELOG.md).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to CI workflow and documentation updates removing Node.js 20 from tested/supported examples, with no runtime code changes.
> 
> **Overview**
> Removes Node.js `20` from the Node version matrices used in the `example-node-versions` workflow and README examples, aligning examples with current supported Node versions (`22`, `24`, `25`).
> 
> Updates the README Node support text/links and adds a `v7.2.0` CHANGELOG entry documenting end of support for Node.js `20`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0911ef125e1fb639327dab361ed85be4676ddf7b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->