### PR TITLE
test(deps): add Node.js 26 (current) support

### DIFF
--- a/.github/workflows/example-node-versions.yml
+++ b/.github/workflows/example-node-versions.yml
@@ -17,6 +17,7 @@ jobs:
           - 22
           - 24
           - 25
+          - 26
     name: Cypress E2E on Node v${{ matrix.node }}
     steps:
       - name: Checkout

--- a/README.md
+++ b/README.md
@@ -568,6 +568,7 @@ jobs:
           - 22
           - 24
           - 25
+          - 26
     name: E2E on Node v${{ matrix.node }}
     steps:
       - name: Checkout
@@ -1393,6 +1394,7 @@ jobs:
           - 22
           - 24
           - 25
+          - 26
     name: E2E on Node v${{ matrix.node }}
     steps:
       - name: Checkout
@@ -1430,6 +1432,7 @@ jobs:
           - 22
           - 24
           - 25
+          - 26
     name: E2E on Node v${{ matrix.node }}
     steps:
       - uses: actions/checkout@v6
@@ -1896,7 +1899,7 @@ jobs:
 
 Node.js is required to run this action. The recommended version `v7` supports:
 
-- **Node.js** 22.x, 24.x and 25.x
+- **Node.js** 22.x, 24.x, 25.x and 26.x
 
 and is generally aligned with [Node.js's release schedule](https://github.com/nodejs/Release#readme).
 


### PR DESCRIPTION
## Situation

[Node.js v26.0.0 (Current)](https://nodejs.org/en/blog/release/v26.0.0) was released on May 5, 2026.

## Change

This PR adds Node.js `26`:

- to the matrix of tested nodes under [.github/workflows/example-node-versions.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-node-versions.yml)
- to the [README](https://github.com/cypress-io/github-action/blob/master/README.md) sections that describe testing across multiple node versions in a `matrix`
- to the [README > Node.js > Support](https://github.com/cypress-io/github-action/blob/master/README.md#examples) section

## Comments

- Since there is no change to the action itself, and the additional support of Node.js `26.x` is an extension, there is no version change of the action.

- According to [Node.js release schedule](https://github.com/nodejs/release) plans, Node.js `26.x` is expected to transition to LTS status on Oct 28, 2026.

- Cypress itself continues to run under Node.js `node24` within the action, and using the Cypress Module API, as explained in the [README > Usage](https://github.com/cypress-io/github-action/blob/master/README.md#usage) section.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: updates only CI example matrices and README documentation to include Node.js 26, without changing action/runtime behavior.
> 
> **Overview**
> Adds **Node.js 26** to the Node version matrix used by the `example-node-versions` GitHub Actions workflow, expanding CI coverage to run the same Cypress E2E example on `22/24/25/26`.
> 
> Updates the README’s workflow snippets and the *Node.js Support* section to document `26.x` as supported alongside `22.x`, `24.x`, and `25.x`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65052fdbe873d1ad13f2b6de9626a52d81e6647a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->