### PR TITLE
chore(deps): update transient devDependencies of markdown-link-check

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1112,9 +1112,9 @@
       "license": "MIT"
     },
     "node_modules/basic-ftp": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.0.tgz",
-      "integrity": "sha512-5K9eNNn7ywHPsYnFwjKgYH8Hf8B5emh7JKcPaVjjrMJFQQwGpwowEnZNEtHs7DfR7hCZsmaK3VA4HUK0YarT+w==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.1.tgz",
+      "integrity": "sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2151,9 +2151,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
## Situation

`npm audit` reports 2 vulnerabilities (1 moderate, 1 high) in transient dependencies of `markdown-link-check@3.14.2` (current `latest`) defined in `devDependencies`:

```text
# npm audit report

basic-ftp  <=5.3.0
Severity: high
basic-ftp allows a malicious FTP server to cause client-side denial of service via unbounded multiline control response buffering - https://github.com/advisories/GHSA-rpmf-866q-6p89
fix available via `npm audit fix`
node_modules/basic-ftp

ip-address  <=10.1.0
Severity: moderate
ip-address has XSS in Address6 HTML-emitting methods - https://github.com/advisories/GHSA-v2v4-37r5-5v8g
fix available via `npm audit fix`
node_modules/ip-address

2 vulnerabilities (1 moderate, 1 high)

To address all issues, run:
  npm audit fix
```

## Change

Execute `npm audit fix` to remediate the vulnerabilities.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk lockfile-only change updating transitive dev-only packages to remediate reported vulnerabilities; minimal runtime impact unless tooling relies on specific patched behavior.
> 
> **Overview**
> Updates `package-lock.json` to bump transitive dependencies pulled in by `markdown-link-check`, upgrading `basic-ftp` to `5.3.1` and `ip-address` to `10.2.0` to address `npm audit` vulnerabilities.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c992800215ecdb58777236a35e0134f04913736. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->