### PR TITLE
test(deps): update examples to pnpm 11

### DIFF
--- a/.github/workflows/example-basic-pnpm.yml
+++ b/.github/workflows/example-basic-pnpm.yml
@@ -22,9 +22,9 @@ jobs:
 
         # See https://github.com/pnpm/action-setup
       - name: Install pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@v6
         with:
-          version: 10
+          version: 11
 
         # See https://github.com/actions/setup-node
       - name: Install Node.js

--- a/.github/workflows/example-start-and-pnpm-workspaces.yml
+++ b/.github/workflows/example-start-and-pnpm-workspaces.yml
@@ -28,9 +28,9 @@ jobs:
 
         # See https://github.com/pnpm/action-setup
       - name: Install pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@v6
         with:
-          version: 10
+          version: 11
 
         # See https://github.com/actions/setup-node
       - name: Install Node.js
@@ -78,10 +78,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
+        # See https://github.com/pnpm/action-setup
       - name: Install pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@v6
         with:
-          version: 10
+          version: 11
 
       - name: Install Node.js
         uses: actions/setup-node@v6

--- a/README.md
+++ b/README.md
@@ -1215,9 +1215,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
       - name: Install pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@v6
         with:
-          version: 10
+          version: 11
       - name: Install Node.js
         uses: actions/setup-node@v6
         with:


### PR DESCRIPTION
- closes https://github.com/cypress-io/github-action/issues/1751

## Situation

The [pnpm package manager module](https://www.npmjs.com/package/pnpm?activeTab=versions) now tags `pnpm@11.0.8` as `latest`

[pnpm@11.0.8](https://github.com/pnpm/pnpm/releases/tag/v11.0.8) was released on May 7, 2026.

Examples and documentation use the previous `latest` version `pnpm@10`

## Change

Update to

```yml
      - name: Install pnpm
        uses: pnpm/action-setup@v6
        with:
          version: 11
```

- [.github/workflows/example-basic-pnpm.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-basic-pnpm.yml)
- [.github/workflows/example-start-and-pnpm-workspaces.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-start-and-pnpm-workspaces.yml)

and in the

- [README > pnpm](https://github.com/cypress-io/github-action/blob/master/README.md#pnpm) section

## References

- [pnpm documentation](https://pnpm.io/)
- https://pnpm.io/11.x/migration
- [pnpm 11.0.8 release](https://github.com/pnpm/pnpm/releases/tag/v11.0.8)

## Verification

### local

On Ubuntu `24.04.4` LTS
Use Node.js `v24.15.0` LTS

```shell
npm ci
npm install pnpm@11 -g
cd examples/basic-pnpm
pnpm install --frozen-lockfile
pnpm test
cd ../..
```

```shell
cd examples/start-and-pnpm-workspaces
pnpm install --frozen-lockfile
cd packages/workspace-1
pnpm start
```

In a separate terminal window set to `examples/start-and-pnpm-workspaces/packages/workspace-1`

```shell
pnpm test
```

kill server from workspace-1

repeat test for workspace-2
```shell
cd ../workspace-2
pnpm start
```

In a separate terminal window set to `examples/start-and-pnpm-workspaces/packages/workspace-2`

```shell
pnpm test
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation/CI example updates only; the main risk is CI example workflows breaking if `pnpm/action-setup@v6` or pnpm 11 behavior differs on runners.
> 
> **Overview**
> Updates the pnpm-based example GitHub workflows and the README snippet to use `pnpm/action-setup@v6` and install pnpm `v11` (was `v10` / `action-setup@v5`). This keeps the project’s pnpm guidance aligned with the current pnpm `latest` release and the updated setup action.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a1cb51f5352de6090122286766ea4e6c701d1c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->