### PR TITLE
chore(deps): update fast-xml-builder to 1.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1809,9 +1809,9 @@
       "license": "MIT"
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
-      "integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
       "funding": [
         {
           "type": "github",
@@ -1820,7 +1820,8 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "path-expression-matcher": "^1.1.3"
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
       }
     },
     "node_modules/fast-xml-parser": {
@@ -3090,6 +3091,21 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
     },
     "node_modules/xmlbuilder2": {
       "version": "4.0.0",


### PR DESCRIPTION
## Situation

`npm audit` and Dependabot report a moderate severity vulnerability https://github.com/advisories/GHSA-gh4j-gqv2-49f6 in [fast-xml-builder@1.1.5](https://www.npmjs.com/package/fast-xml-builder), a transient dependency of [@actions/cache@5.0.5](https://github.com/actions/toolkit/blob/main/packages/cache/RELEASES.md).

```text
$ npm audit
# npm audit report

fast-xml-builder  <=1.1.6
Severity: high
fast-xml-builder allows attribute values with unwanted quotes to bypass malicious or unwanted attributes - https://github.com/advisories/GHSA-5wm8-gmm8-39j9
fast-xml-builder Comment Value regex can be bypassed - https://github.com/advisories/GHSA-45c6-75p6-83cc
fix available via `npm audit fix`
node_modules/fast-xml-builder

1 high severity vulnerability

To address all issues, run:
  npm audit fix
```

## Change

Use `npm audit fix` to update to [fast-xml-builder@1.2.0](https://www.npmjs.com/package/fast-xml-builder).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk lockfile-only dependency update to pick up security fixes; main risk is unexpected behavior changes in the transitive XML builder dependency.
> 
> **Overview**
> Updates `package-lock.json` to upgrade transitive dependency `fast-xml-builder` from `1.1.5` to `1.2.0` to address reported vulnerabilities.
> 
> This also updates `fast-xml-builder`’s dependency constraints (`path-expression-matcher` to `^1.5.0`) and adds the new transitive package `xml-naming@0.1.0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ea030e6998273bb07344a534708f20cf204316f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->