### PR TITLE
ci: add explicit permissions to all GitHub Actions workflows

### DIFF
--- a/.github/workflows/add-issue-to-triage-board.yml
+++ b/.github/workflows/add-issue-to-triage-board.yml
@@ -6,6 +6,7 @@ on:
   pull_request_target:
     types:
       - opened
+permissions: {}
 jobs:
   add-to-triage-project-board:
     # skip in fork

--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -11,6 +11,8 @@ on:
       - 'master'
   pull_request:
   workflow_dispatch:
+permissions:
+  contents: read
 
 jobs:
   check-dist:

--- a/.github/workflows/check-markdown.yml
+++ b/.github/workflows/check-markdown.yml
@@ -5,6 +5,8 @@ on:
       - 'master'
   pull_request:
   workflow_dispatch:
+permissions:
+  contents: read
 
 jobs:
   check-markdown:

--- a/.github/workflows/example-basic-pnpm.yml
+++ b/.github/workflows/example-basic-pnpm.yml
@@ -5,6 +5,8 @@ on:
       - 'master'
   pull_request:
   workflow_dispatch:
+permissions:
+  contents: read
 
 jobs:
   basic-pnpm:

--- a/.github/workflows/example-basic.yml
+++ b/.github/workflows/example-basic.yml
@@ -12,6 +12,8 @@ on:
       - 'master'
   pull_request:
   workflow_dispatch:
+permissions:
+  contents: read
 
 jobs:
   basic:

--- a/.github/workflows/example-build-artifacts.yml
+++ b/.github/workflows/example-build-artifacts.yml
@@ -18,6 +18,8 @@ on:
       - 'master'
   pull_request:
   workflow_dispatch:
+permissions:
+  contents: read
 
 jobs:
   build:

--- a/.github/workflows/example-chrome-for-testing.yml
+++ b/.github/workflows/example-chrome-for-testing.yml
@@ -5,6 +5,8 @@ on:
       - 'master'
   pull_request:
   workflow_dispatch:
+permissions:
+  contents: read
 
 jobs:
   tests:

--- a/.github/workflows/example-chrome.yml
+++ b/.github/workflows/example-chrome.yml
@@ -10,6 +10,8 @@ on:
       - 'master'
   pull_request:
   workflow_dispatch:
+permissions:
+  contents: read
 
 jobs:
   tests:

--- a/.github/workflows/example-component-test.yml
+++ b/.github/workflows/example-component-test.yml
@@ -5,6 +5,8 @@ on:
       - 'master'
   pull_request:
   workflow_dispatch:
+permissions:
+  contents: read
 
 jobs:
   cypress-run:

--- a/.github/workflows/example-config.yml
+++ b/.github/workflows/example-config.yml
@@ -10,6 +10,8 @@ on:
       - 'master'
   pull_request:
   workflow_dispatch:
+permissions:
+  contents: read
 
 jobs:
   start:

--- a/.github/workflows/example-cron.yml
+++ b/.github/workflows/example-cron.yml
@@ -4,6 +4,8 @@ on:
     # runs tests every day at 4am
     - cron: '0 4 * * *'
   workflow_dispatch:
+permissions:
+  contents: read
 
 jobs:
   nightly:

--- a/.github/workflows/example-custom-ci-build-id.yml
+++ b/.github/workflows/example-custom-ci-build-id.yml
@@ -35,6 +35,8 @@ env:
   CYPRESS_PROJECT_ID: ${{ secrets.EXAMPLE_PROJECT_ID }}
   CYPRESS_RECORD_KEY: ${{ secrets.EXAMPLE_RECORDING_KEY }}
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+permissions:
+  contents: read
 
 jobs:
   check-record-key:

--- a/.github/workflows/example-custom-ci-build-id.yml
+++ b/.github/workflows/example-custom-ci-build-id.yml
@@ -37,6 +37,7 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 permissions:
   contents: read
+  actions: read
 
 jobs:
   check-record-key:

--- a/.github/workflows/example-custom-command.yml
+++ b/.github/workflows/example-custom-command.yml
@@ -10,6 +10,8 @@ on:
       - 'master'
   pull_request:
   workflow_dispatch:
+permissions:
+  contents: read
 
 jobs:
   start:

--- a/.github/workflows/example-debug.yml
+++ b/.github/workflows/example-debug.yml
@@ -14,6 +14,8 @@ on:
       - 'master'
   pull_request:
   workflow_dispatch:
+permissions:
+  contents: read
 
 jobs:
   action-debug:

--- a/.github/workflows/example-docker.yml
+++ b/.github/workflows/example-docker.yml
@@ -5,6 +5,8 @@ on:
       - 'master'
   pull_request:
   workflow_dispatch:
+permissions:
+  contents: read
 
 jobs:
   docker-browsers:

--- a/.github/workflows/example-edge.yml
+++ b/.github/workflows/example-edge.yml
@@ -5,6 +5,8 @@ on:
       - 'master'
   pull_request:
   workflow_dispatch:
+permissions:
+  contents: read
 
 jobs:
   tests:

--- a/.github/workflows/example-env.yml
+++ b/.github/workflows/example-env.yml
@@ -17,6 +17,9 @@ env:
   # Cypress.env('environmentName') // 'staging'
   # see https://on.cypress.io/env
   CYPRESS_environmentName: staging
+permissions:
+  contents: read
+
 jobs:
   e2e:
     runs-on: ubuntu-24.04

--- a/.github/workflows/example-expose.yml
+++ b/.github/workflows/example-expose.yml
@@ -10,6 +10,8 @@ on:
       - 'master'
   pull_request:
   workflow_dispatch:
+permissions:
+  contents: read
 
 jobs:
   with-expose:

--- a/.github/workflows/example-firefox.yml
+++ b/.github/workflows/example-firefox.yml
@@ -5,6 +5,8 @@ on:
       - 'master'
   pull_request:
   workflow_dispatch:
+permissions:
+  contents: read
 
 jobs:
   firefox:

--- a/.github/workflows/example-install-command.yml
+++ b/.github/workflows/example-install-command.yml
@@ -5,6 +5,8 @@ on:
       - 'master'
   pull_request:
   workflow_dispatch:
+permissions:
+  contents: read
 
 jobs:
   install-command:

--- a/.github/workflows/example-install-only.yml
+++ b/.github/workflows/example-install-only.yml
@@ -5,6 +5,8 @@ on:
       - 'master'
   pull_request:
   workflow_dispatch:
+permissions:
+  contents: read
 
 jobs:
   # do not install every dependency in this example

--- a/.github/workflows/example-node-versions.yml
+++ b/.github/workflows/example-node-versions.yml
@@ -5,6 +5,8 @@ on:
       - 'master'
   pull_request:
   workflow_dispatch:
+permissions:
+  contents: read
 
 jobs:
   cypress-run:

--- a/.github/workflows/example-quiet.yml
+++ b/.github/workflows/example-quiet.yml
@@ -5,6 +5,8 @@ on:
       - 'master'
   pull_request:
   workflow_dispatch:
+permissions:
+  contents: read
 
 jobs:
   cypress-run:

--- a/.github/workflows/example-recording.yml
+++ b/.github/workflows/example-recording.yml
@@ -25,6 +25,7 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 permissions:
   contents: read
+  actions: read
 
 jobs:
   check-record-key:

--- a/.github/workflows/example-recording.yml
+++ b/.github/workflows/example-recording.yml
@@ -23,6 +23,8 @@ env:
   CYPRESS_PROJECT_ID: ${{ secrets.EXAMPLE_PROJECT_ID }}
   CYPRESS_RECORD_KEY: ${{ secrets.EXAMPLE_RECORDING_KEY }}
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+permissions:
+  contents: read
 
 jobs:
   check-record-key:

--- a/.github/workflows/example-start-and-pnpm-workspaces.yml
+++ b/.github/workflows/example-start-and-pnpm-workspaces.yml
@@ -10,6 +10,8 @@ on:
       - 'master'
   pull_request:
   workflow_dispatch:
+permissions:
+  contents: read
 
 jobs:
   # The example has pnpm workspaces in its "root" folder

--- a/.github/workflows/example-start-and-yarn-workspaces.yml
+++ b/.github/workflows/example-start-and-yarn-workspaces.yml
@@ -10,6 +10,8 @@ on:
       - 'master'
   pull_request:
   workflow_dispatch:
+permissions:
+  contents: read
 
 jobs:
   single:

--- a/.github/workflows/example-start.yml
+++ b/.github/workflows/example-start.yml
@@ -16,6 +16,8 @@ env:
   # works around issue when more than one instance of serve is started
   # See PR https://github.com/vercel/serve/pull/457
   NO_UPDATE_CHECK: 1
+permissions:
+  contents: read
 
 jobs:
   start:

--- a/.github/workflows/example-wait-on.yml
+++ b/.github/workflows/example-wait-on.yml
@@ -10,6 +10,8 @@ on:
       - 'master'
   pull_request:
   workflow_dispatch:
+permissions:
+  contents: read
 
 jobs:
   wait:

--- a/.github/workflows/example-webpack.yml
+++ b/.github/workflows/example-webpack.yml
@@ -5,6 +5,8 @@ on:
       - 'master'
   pull_request:
   workflow_dispatch:
+permissions:
+  contents: read
 
 jobs:
   wait:

--- a/.github/workflows/example-yarn-classic.yml
+++ b/.github/workflows/example-yarn-classic.yml
@@ -10,6 +10,8 @@ on:
       - 'master'
   pull_request:
   workflow_dispatch:
+permissions:
+  contents: read
 
 jobs:
   yarn-classic:

--- a/.github/workflows/example-yarn-modern-pnp.yml
+++ b/.github/workflows/example-yarn-modern-pnp.yml
@@ -5,6 +5,8 @@ on:
       - 'master'
   pull_request:
   workflow_dispatch:
+permissions:
+  contents: read
 
 jobs:
   yarn-modern-pnp:

--- a/.github/workflows/example-yarn-modern.yml
+++ b/.github/workflows/example-yarn-modern.yml
@@ -5,6 +5,8 @@ on:
       - 'master'
   pull_request:
   workflow_dispatch:
+permissions:
+  contents: read
 
 jobs:
   yarn-modern:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,8 @@ on:
     branches:
       - 'master'
   pull_request:
+permissions:
+  contents: read
 jobs:
   build-and-test:
     runs-on: ubuntu-24.04
@@ -28,6 +30,8 @@ jobs:
       - run: npm run format:all:check # Prettier formatting check
 
   release:
+    permissions:
+      contents: write
     runs-on: ubuntu-24.04
     name: release
     needs: [build-and-test]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,6 +32,8 @@ jobs:
   release:
     permissions:
       contents: write
+      issues: write
+      pull-requests: write
     runs-on: ubuntu-24.04
     name: release
     needs: [build-and-test]

--- a/.github/workflows/triage_closed_issue_comment.yml
+++ b/.github/workflows/triage_closed_issue_comment.yml
@@ -3,6 +3,7 @@ on:
   issue_comment:
     types:
       - created
+permissions: {}
 jobs:
   closed-issue-comment:
     # skip in fork


### PR DESCRIPTION
## Summary

- Adds explicit `permissions` blocks to all 34 workflow files
- Workflows are now self-documenting and independent of the repository-level default GITHUB_TOKEN permission setting

## Changes

| Workflow(s) | Permissions |
|---|---|
| `main.yml` | Top-level `contents: read`; release job overrides to `contents: write` (needed for semantic-release and pushing version branches) |
| 29 `example-*.yml` | `contents: read` |
| `check-dist.yml`, `check-markdown.yml` | `contents: read` |
| `add-issue-to-triage-board.yml` | `permissions: {}` |
| `triage_closed_issue_comment.yml` | `permissions: {}` |

## Why

Previously, none of the workflows declared a `permissions` block, relying on the repository default (currently "Read and write"). By making permissions explicit in each workflow:

1. Workflows follow the principle of least privilege regardless of the repo setting
2. The repo default can be safely switched to read-only
3. Each workflow is self-documenting about what access it actually needs

## Test plan

- [x] Verify all existing CI workflows pass with these changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly declarative GitHub Actions permission scoping; the main risk is mis-scoped `GITHUB_TOKEN` permissions causing CI/release/triage automation failures.
> 
> **Overview**
> Adds explicit `permissions` blocks across GitHub Actions workflows to enforce least-privilege `GITHUB_TOKEN` access.
> 
> Most CI/example workflows now request only `contents: read`, triage reusable-workflow triggers explicitly set `permissions: {}`, and `main.yml` scopes read-only at the workflow level while granting the `release` job `contents/issues/pull-requests: write` for publishing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7227f7f3db2b7a1a3daae20ffa40c532182c87fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->