### PR TITLE
test: exclude cypress from pnpm minimum age checks

### DIFF
--- a/examples/basic-pnpm/pnpm-workspace.yaml
+++ b/examples/basic-pnpm/pnpm-workspace.yaml
@@ -1,3 +1,6 @@
 allowBuilds:
   cypress: true
 sideEffectsCache: false
+minimumReleaseAge: 4320
+minimumReleaseAgeExclude:
+  - cypress

--- a/examples/start-and-pnpm-workspaces/pnpm-workspace.yaml
+++ b/examples/start-and-pnpm-workspaces/pnpm-workspace.yaml
@@ -3,3 +3,6 @@ packages:
 allowBuilds:
   cypress: true
 sideEffectsCache: false
+minimumReleaseAge: 4320
+minimumReleaseAgeExclude:
+  - cypress


### PR DESCRIPTION
- closes https://github.com/cypress-io/github-action/issues/1762

## Situation

[pnpm@11.0.0](https://github.com/pnpm/pnpm/releases/tag/v11.0.0) introduced a breaking change of setting the configuration parameter [minimumReleaseAge](https://pnpm.io/settings#minimumreleaseage) to 1440 minutes (1 day).

Attempting to install `cypress@latest` immediately after a release, falls back to installing a previous version that satisfies the requirements [minimumReleaseAge](https://pnpm.io/settings#minimumreleaseage). This is a disadvantage when running the npm script `update:cypress` to update Cypress to the latest version for each package manager (npm, pnpm, Yarn v1 & Yarn Modern), as it leaves the pnpm examples lagging behind.

## Change

Configure the pnpm examples with:

- [minimumReleaseAgeExclude](https://pnpm.io/settings#minimumreleaseageexclude) for `cypress`
- [minimumReleaseAge](https://pnpm.io/settings#minimumreleaseage) to 4320 minutes (3 days) for other dependencies

in the workflows:

- [examples/basic-pnpm](https://github.com/cypress-io/github-action/tree/master/examples/basic-pnpm)
- [examples/start-and-pnpm-workspaces](https://github.com/cypress-io/github-action/tree/master/examples/start-and-pnpm-workspaces)




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only adjusts pnpm workspace configuration for example projects; no production code paths or security/data handling logic are affected.
> 
> **Overview**
> Updates the pnpm workspace configs in the example projects to set `minimumReleaseAge: 4320` and exclude `cypress` via `minimumReleaseAgeExclude`.
> 
> This ensures pnpm installs `cypress@latest` immediately after releases while keeping minimum-age constraints for other dependencies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 131a28cd7d8d03c63b65d42dd08b3f130fa48e53. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->