### PR TITLE
test: remove Yarn Modern approvedGitRepositories

### DIFF
--- a/examples/yarn-modern-pnp/.yarnrc.yml
+++ b/examples/yarn-modern-pnp/.yarnrc.yml
@@ -1,4 +1,1 @@
-approvedGitRepositories:
-  - '**'
-
 enableScripts: true

--- a/examples/yarn-modern/.yarnrc.yml
+++ b/examples/yarn-modern/.yarnrc.yml
@@ -1,6 +1,3 @@
-approvedGitRepositories:
-  - '**'
-
 enableScripts: true
 
 nodeLinker: node-modules


### PR DESCRIPTION
## Situation

The configuration files in the Yarn Modern example directories:

- [examples/yarn-modern/.yarnrc.yml](https://github.com/cypress-io/github-action/blob/master/examples/yarn-modern/.yarnrc.yml)
- [examples/yarn-modern-pnp/.yarnrc.yml](https://github.com/cypress-io/github-action/tree/master/examples/yarn-modern-pnp/.yarnrc.yml)

include a section that was automatically added by Yarn migration in preparation of PR https://github.com/cypress-io/github-action/pull/1728:

```yaml
approvedGitRepositories:
  - '**'
```

- Yarn added this for backwards compatibility, however the dependencies for Yarn Modern examples do not require to be installed from a GitHub repository and allowing it is a security risk.
- An additional issue is a conflict between Yarn and Prettier. `yarn set version latest` changes from single quotes to double quotes, whereas Prettier requires single quotes. This is separately reported in https://github.com/yarnpkg/berry/issues/7138

## Change

In the Yarn Modern example configuration files:

- [examples/yarn-modern/.yarnrc.yml](https://github.com/cypress-io/github-action/blob/master/examples/yarn-modern/.yarnrc.yml)
- [examples/yarn-modern-pnp/.yarnrc.yml](https://github.com/cypress-io/github-action/tree/master/examples/yarn-modern-pnp/.yarnrc.yml)

remove the section which allows installing dependencies from arbitrary repositories instead of from the npm registry:

```yaml
approvedGitRepositories:
  - '**'
```

## Verification

```shell
git clean -xfd
npm install corepack@latest -g
corepack enable yarn
corepack install yarn@latest -g

cd examples

cd yarn-modern
yarn install
cd ..

cd yarn-modern-pnp
yarn install
cd ..

cd ..

./scripts/update-cypress-latest-yarn.sh
```

Confirm no errors and no uncommitted changes produced.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change limited to example Yarn settings; it mainly reduces an overly permissive install allowance and shouldn’t affect installs that use registry dependencies.
> 
> **Overview**
> Removes `approvedGitRepositories: ['**']` from the `examples/yarn-modern` and `examples/yarn-modern-pnp` Yarn configs, eliminating the ability for these examples to install dependencies from arbitrary git repositories.
> 
> All other Yarn settings in these examples remain unchanged (e.g., `enableScripts`, and `nodeLinker` for `yarn-modern`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bdd51bafbabc8dface45cde65226fc08463c22c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->