### PR TITLE
test: exclude Cypress from Yarn Modern npmMinimalAgeGate

### DIFF
--- a/examples/yarn-modern-pnp/.yarnrc.yml
+++ b/examples/yarn-modern-pnp/.yarnrc.yml
@@ -1,1 +1,5 @@
 enableScripts: true
+
+npmMinimalAgeGate: 3d
+npmPreapprovedPackages:
+  - cypress

--- a/examples/yarn-modern/.yarnrc.yml
+++ b/examples/yarn-modern/.yarnrc.yml
@@ -1,3 +1,7 @@
 enableScripts: true
 
 nodeLinker: node-modules
+
+npmMinimalAgeGate: 3d
+npmPreapprovedPackages:
+  - cypress


### PR DESCRIPTION
## Situation

- Renovate PR https://github.com/cypress-io/github-action/pull/1768 updated Yarn Modern to 4.15.0
- [Yarn Modern 4.15.0](https://github.com/yarnpkg/berry/releases/tag/%40yarnpkg%2Fcli%2F4.15.0) sets [npmMinimalAgeGate: 1d](https://yarnpkg.com/configuration/yarnrc#npmMinimalAgeGate) as default
- Renovate PR https://github.com/cypress-io/github-action/pull/1773 attempts to update Cypress to 15.16.0 and fails for Yarn Modern examples, since Cypress has age <1d

## Change

In Yarn Modern examples:

- [examples/yarn-modern](https://github.com/cypress-io/github-action/tree/master/examples/yarn-modern)
- [examples/yarn-modern-pnp](https://github.com/cypress-io/github-action/tree/master/examples/yarn-modern-pnp)

set Yarn Modern configuration with:

- explicit [npmMinimalAgeGate: 3d](https://yarnpkg.com/configuration/yarnrc#npmMinimalAgeGate) (aligning with pnpm examples)
- `cypress` listed in [npmPreapprovedPackages](https://yarnpkg.com/configuration/yarnrc#npmPreapprovedPackages)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Example-only Yarn configuration; no runtime, auth, or application logic changes.
> 
> **Overview**
> Yarn Modern **4.15** defaults to a **1-day** `npmMinimalAgeGate`, which blocks Renovate from bumping **Cypress** when the release is newer than that. Both Yarn Modern example projects now set **`npmMinimalAgeGate: 3d`** and add **`cypress`** under **`npmPreapprovedPackages`** so example installs and CI can resolve current Cypress versions without fighting the age gate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3dbc8f9c520f956af352bbe18586ac94543b524c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->