### PR TITLE
chore: add minimum release age and vulnerability alerts to renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -14,6 +14,11 @@
   ],
   "prConcurrentLimit": 5,
   "prHourlyLimit": 1,
+  "minimumReleaseAge": "7 days",
+  "osvVulnerabilityAlerts": true,
+  "vulnerabilityAlerts": {
+    "minimumReleaseAge": "0 days"
+  },
   "rangeStrategy": "bump",
   "lockFileMaintenance": {
     "enabled": true
@@ -71,6 +76,10 @@
       "matchDepTypes": ["uses-with"],
       "matchPackageNames": ["pnpm"],
       "enabled": false
+    },
+    {
+      "matchPackageNames": ["cypress"],
+      "minimumReleaseAge": "0 days"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Add a 7-day `minimumReleaseAge` for all dependencies to avoid pulling in potentially unstable new releases
- Exempt the `cypress` package from this cooldown so updates are available immediately
- Enable `osvVulnerabilityAlerts` for OSV vulnerability scanning
- Add `vulnerabilityAlerts` config to bypass the 7-day cooldown for security fixes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only `renovate.json` policy changes; no runtime code, with faster paths for security and Cypress updates.
> 
> **Overview**
> Renovate is configured to wait **7 days** after a release before opening routine dependency update PRs, reducing churn from brand-new publishes.
> 
> **OSV vulnerability alerts** are turned on, and **`vulnerabilityAlerts`** sets **`minimumReleaseAge`** to **0 days** so security-related updates are not held behind that cooldown.
> 
> A **`packageRules`** entry for **`cypress`** also sets **`minimumReleaseAge`** to **0 days**, so Cypress updates can land immediately while other packages still use the global delay.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 625ebb0a6be1df69b49e81feb2bc59d73ac1c9fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->