### PR TITLE
test: complete cypress@15.16.0 update

### DIFF
--- a/.github/workflows/example-install-only.yml
+++ b/.github/workflows/example-install-only.yml
@@ -31,7 +31,7 @@ jobs:
           key: my-cache-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
 
       - name: Install Cypress 📥
-        run: npm install cypress@15.12.0 --save-dev
+        run: npm install cypress@15.16.0 --save-dev
 
       - name: Cypress tests 🧪
         uses: ./ # if copying, replace with cypress-io/github-action@v7

--- a/examples/yarn-modern-pnp/.yarnrc.yml
+++ b/examples/yarn-modern-pnp/.yarnrc.yml
@@ -1,5 +1,6 @@
 enableScripts: true
 
 npmMinimalAgeGate: 3d
+
 npmPreapprovedPackages:
   - cypress

--- a/examples/yarn-modern/.yarnrc.yml
+++ b/examples/yarn-modern/.yarnrc.yml
@@ -3,5 +3,6 @@ enableScripts: true
 nodeLinker: node-modules
 
 npmMinimalAgeGate: 3d
+
 npmPreapprovedPackages:
   - cypress


### PR DESCRIPTION
## Situation

Running the script `update:cypress` makes changes that Renovate can not cover.

- Workflow [.github/workflows/example-install-only.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-install-only.yml) uses a pinned version `cypress@15.12.0` that doesn't get automatically updated.
- The Yarn 4 `yarn set version` command causes `yarnrc.yml` to be reformatted. This is a known bug with resolution delayed until Yarn 6.

## Change

- Update workflow [.github/workflows/example-install-only.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-install-only.yml) to use the pinned version `cypress@15.16.0`
- Commit the reformatted results of `yarnrc.yml` after running the Yarn Modern `yarn set version` command

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Example workflow and Yarn config formatting only; no application, auth, or runtime behavior changes.
> 
> **Overview**
> Completes the **Cypress 15.16.0** rollout for repo maintenance that Renovate does not handle automatically.
> 
> The **install-only** example workflow now pins `npm install cypress@15.16.0` instead of `15.12.0`, keeping CI aligned with the rest of the examples updated by `update:cypress`.
> 
> **Yarn Modern** example `.yarnrc.yml` files pick up an extra blank line after `npmMinimalAgeGate` from `yarn set version` reformatting (no policy change to `npmPreapprovedPackages`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1dfa63920ef7dc8cc271709cb11bb546e621355c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->