### PR TITLE
feat(deps): remove Node.js 25

### DIFF
--- a/.github/workflows/example-node-versions.yml
+++ b/.github/workflows/example-node-versions.yml
@@ -18,7 +18,6 @@ jobs:
         node:
           - 22
           - 24
-          - 25
           - 26
     name: Cypress E2E on Node v${{ matrix.node }}
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ See [Releases](https://github.com/cypress-io/github-action/releases) for full de
 
 | Version | Changes                                                                                                      |
 | ------- | ------------------------------------------------------------------------------------------------------------ |
+| v7.4.0  | Examples remove Node.js 25. End of support for Node.js 25.                                                   |
 | v7.3.0  | Add parameter `expose` for [`Cypress.expose()`](https://docs.cypress.io/api/cypress-api/expose) support      |
 | v7.2.0  | Examples remove Node.js 20. End of support for Node.js 20.                                                   |
 | v7.1.0  | Add parameter `package-manager-cache`                                                                        |

--- a/README.md
+++ b/README.md
@@ -592,7 +592,6 @@ jobs:
         node:
           - 22
           - 24
-          - 25
           - 26
     name: E2E on Node v${{ matrix.node }}
     steps:
@@ -1418,7 +1417,6 @@ jobs:
         node:
           - 22
           - 24
-          - 25
           - 26
     name: E2E on Node v${{ matrix.node }}
     steps:
@@ -1456,7 +1454,6 @@ jobs:
         node:
           - 22
           - 24
-          - 25
           - 26
     name: E2E on Node v${{ matrix.node }}
     steps:
@@ -1925,7 +1922,7 @@ jobs:
 
 Node.js is required to run this action. The recommended version `v7` supports:
 
-- **Node.js** 22.x, 24.x, 25.x and 26.x
+- **Node.js** 22.x, 24.x and 26.x
 
 and is generally aligned with [Node.js's release schedule](https://github.com/nodejs/Release#readme).
 

--- a/docs/MAINTENANCE.md
+++ b/docs/MAINTENANCE.md
@@ -18,7 +18,9 @@ The examples make use of [npm](https://www.npmjs.com/), [pnpm](https://pnpm.io/)
 
 - [npm](https://www.npmjs.com/), which is installed with [Node.js](https://nodejs.org/).
 
-- [corepack](https://github.com/nodejs/corepack). This is currently installed with [Node.js](https://nodejs.org/). Due to plans of Node.js to remove it in versions Node.js `25.x` and later, you may need to install it separately with `npm install -g corepack`.
+- [corepack](https://github.com/nodejs/corepack).
+  This is installed with [Node.js](https://nodejs.org/) <=24 and is only used for Yarn Modern examples.
+  You may need to install it separately with `npm install -g corepack` for Node.js >24.
 
 - [Visual Studio Code](https://code.visualstudio.com/) or other editor
 


### PR DESCRIPTION
## Situation

Node.js 25.x transitioned into [End-of-life](https://github.com/nodejs/release#readme) status on June 1, 2026.

## Change

This PR removes Node.js 25:

- from the matrix of tested nodes under [.github/workflows/example-node-versions.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-node-versions.yml)
- from the [README > Examples](https://github.com/cypress-io/github-action/blob/master/README.md#examples) section
- from the [README > Node.js > Support](https://github.com/cypress-io/github-action/blob/master/README.md#examples) section

and adds the change to the [CHANGELOG](https://github.com/cypress-io/github-action/blob/master/CHANGELOG.md).

[docs/MAINTENANCE.md](https://github.com/cypress-io/github-action/blob/master/docs/MAINTENANCE.md) is also modified to note that Corepack is not packaged in Node.js >=25.

## Comments

- Although there is no change to the action itself, this PR triggers a minor version release in order to republish the [README](https://github.com/cypress-io/github-action/blob/master/README.md) to the npm registry for reference. It also provides a release milestone for reference in the [CHANGELOG](https://github.com/cypress-io/github-action/blob/master/CHANGELOG.md).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and example workflow matrix changes only; no changes to action runtime or security-sensitive code.
> 
> **Overview**
> Drops **Node.js 25** from supported/tested versions now that 25.x is end-of-life. CI matrix in `example-node-versions.yml` and README example workflows no longer include 25; the **Node.js > Support** section lists **22.x, 24.x, and 26.x** only. **CHANGELOG** records this under **v7.4.0**.
> 
> **docs/MAINTENANCE.md** clarifies that **corepack** ships with Node.js **≤24** (for Yarn Modern examples) and may need `npm install -g corepack` on **Node.js >24**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5983a274ca514d13b0b37004a095d3b13b2106d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->