### PR TITLE
test: set npm allow-scripts for cypress

### DIFF
--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -10,5 +10,8 @@
   "private": true,
   "devDependencies": {
     "cypress": "15.16.0"
+  },
+  "allowScripts": {
+    "cypress": true
   }
 }

--- a/examples/browser/package.json
+++ b/examples/browser/package.json
@@ -16,5 +16,8 @@
   "devDependencies": {
     "cypress": "15.16.0",
     "image-size": "2.0.2"
+  },
+  "allowScripts": {
+    "cypress": true
   }
 }

--- a/examples/component-tests/package.json
+++ b/examples/component-tests/package.json
@@ -19,5 +19,8 @@
     "@vitejs/plugin-react": "^6.0.2",
     "cypress": "15.16.0",
     "vite": "^8.0.14"
+  },
+  "allowScripts": {
+    "cypress": true
   }
 }

--- a/examples/config/package.json
+++ b/examples/config/package.json
@@ -14,5 +14,8 @@
   "devDependencies": {
     "cypress": "15.16.0",
     "serve": "^14.2.6"
+  },
+  "allowScripts": {
+    "cypress": true
   }
 }

--- a/examples/custom-command/package.json
+++ b/examples/custom-command/package.json
@@ -12,5 +12,8 @@
   "devDependencies": {
     "cypress": "15.16.0",
     "lodash": "^4.18.1"
+  },
+  "allowScripts": {
+    "cypress": true
   }
 }

--- a/examples/env/package.json
+++ b/examples/env/package.json
@@ -10,5 +10,8 @@
   "private": true,
   "devDependencies": {
     "cypress": "15.16.0"
+  },
+  "allowScripts": {
+    "cypress": true
   }
 }

--- a/examples/expose/package.json
+++ b/examples/expose/package.json
@@ -10,5 +10,8 @@
   "private": true,
   "devDependencies": {
     "cypress": "15.16.0"
+  },
+  "allowScripts": {
+    "cypress": true
   }
 }

--- a/examples/install-only/package.json
+++ b/examples/install-only/package.json
@@ -13,5 +13,8 @@
   },
   "devDependencies": {
     "cypress": "15.16.0"
+  },
+  "allowScripts": {
+    "cypress": true
   }
 }

--- a/examples/nextjs/package.json
+++ b/examples/nextjs/package.json
@@ -19,5 +19,9 @@
     "@tailwindcss/postcss": "^4.3.0",
     "cypress": "15.16.0",
     "tailwindcss": "^4.3.0"
+  },
+  "allowScripts": {
+    "cypress": true,
+    "sharp": true
   }
 }

--- a/examples/node-versions/package.json
+++ b/examples/node-versions/package.json
@@ -10,5 +10,8 @@
   "private": true,
   "devDependencies": {
     "cypress": "15.16.0"
+  },
+  "allowScripts": {
+    "cypress": true
   }
 }

--- a/examples/quiet/package.json
+++ b/examples/quiet/package.json
@@ -12,5 +12,8 @@
   "devDependencies": {
     "cypress": "15.16.0",
     "image-size": "2.0.2"
+  },
+  "allowScripts": {
+    "cypress": true
   }
 }

--- a/examples/recording/package.json
+++ b/examples/recording/package.json
@@ -11,5 +11,8 @@
   "private": true,
   "devDependencies": {
     "cypress": "15.16.0"
+  },
+  "allowScripts": {
+    "cypress": true
   }
 }

--- a/examples/start/package.json
+++ b/examples/start/package.json
@@ -14,5 +14,8 @@
   "devDependencies": {
     "cypress": "15.16.0",
     "serve": "^14.2.6"
+  },
+  "allowScripts": {
+    "cypress": true
   }
 }

--- a/examples/wait-on-vite/package.json
+++ b/examples/wait-on-vite/package.json
@@ -13,5 +13,8 @@
   "devDependencies": {
     "cypress": "15.16.0",
     "vite": "^8.0.14"
+  },
+  "allowScripts": {
+    "cypress": true
   }
 }

--- a/examples/wait-on/package.json
+++ b/examples/wait-on/package.json
@@ -22,5 +22,8 @@
   },
   "devDependencies": {
     "cypress": "15.16.0"
+  },
+  "allowScripts": {
+    "cypress": true
   }
 }

--- a/examples/webpack/package.json
+++ b/examples/webpack/package.json
@@ -13,5 +13,8 @@
     "webpack": "^5.107.2",
     "webpack-cli": "^7.0.2",
     "webpack-dev-server": "^5.2.4"
+  },
+  "allowScripts": {
+    "cypress": true
   }
 }


### PR DESCRIPTION
- closes https://github.com/cypress-io/github-action/issues/1782

## Situation

When the [.github/workflows/example-node-versions.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-node-versions.yml) is run, it now outputs a warning for Node.js 26

```console
npm warn allow-scripts 1 package has install scripts not yet covered by allowScripts:
npm warn allow-scripts   cypress@15.16.0 (postinstall: node dist/index.js --exec install)
npm warn allow-scripts
npm warn allow-scripts Run `npm approve-scripts --allow-scripts-pending` to review, or `npm approve-scripts <pkg>` to allow.
```

Node.js 26.3.0 is installed with bundled npm 11.16.0

## Change

Running under Node.js 26.3.0 (with npm 11.16.0), and for all npm-based Cypress examples, apply:

```shell
npm approve-scripts cypress --no-allow-scripts-pin
```

Use a copy of [scripts/update-cypress-latest-npm.sh](https://github.com/cypress-io/github-action/blob/master/scripts/update-cypress-latest-npm.sh) to assist looping through all sub-directories.

For [examples/nextjs](https://github.com/cypress-io/github-action/tree/master/examples/nextjs) additionally allow [sharp](https://www.npmjs.com/package/sharp) as a dependency of [next](https://www.npmjs.com/package/next) since it requires `node-gyp` to rebuild.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Example-only package.json metadata changes; no runtime or CI workflow logic is modified beyond silencing npm install-script warnings.
> 
> **Overview**
> Adds npm **`allowScripts`** configuration to every npm-based Cypress example **`package.json`** so installs under **Node.js 26 / npm 11** no longer emit `allow-scripts` warnings about Cypress’s postinstall.
> 
> Each example now sets **`"cypress": true`** under **`allowScripts`**. **`examples/nextjs`** also allows **`sharp`** (Next.js dependency with native install scripts).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70d7d0e7b06b2ac2811a6a0f531df968bdc2cf5a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->