### PR TITLE
chore: make Yarn v1 version installation explicit

### DIFF
--- a/scripts/update-cypress-latest-yarn.sh
+++ b/scripts/update-cypress-latest-yarn.sh
@@ -25,7 +25,7 @@ cd examples
 # Yarn 1 Classic section
 # No corepack
 corepack disable yarn
-npm install yarn@latest -g
+npm install yarn@1 -g
 echo yarn version $(yarn --version) is installed
 
 # examples/start-and-yarn-workspaces (yarn)
@@ -81,7 +81,7 @@ cd ..
 echo
 corepack disable yarn
 echo corepack is now disabled for Yarn
-npm install yarn@latest -g
+npm install yarn@1 -g
 echo yarn version $(yarn --version) is installed
 echo
 # End of Yarn 4 Modern section


### PR DESCRIPTION
## Situation

In [scripts/update-cypress-latest-yarn.sh](https://github.com/cypress-io/github-action/blob/master/scripts/update-cypress-latest-yarn.sh) Yarn v1 Classic is globally installed with `npm install yarn@latest -g`

`yarn@latest` currently equates to `yarn@1.22.22`

The Yarn v1 module owner announced plans to re-use the [npm yarn module](https://www.npmjs.com/package/yarn) for future Switch usage with Yarn v6.

## Change

Replace `yarn@latest` with `yarn@1` to install the latest Yarn v1 Classic version in the [scripts/update-cypress-latest-yarn.sh](https://github.com/cypress-io/github-action/blob/master/scripts/update-cypress-latest-yarn.sh) script.

## Verify

Execute

```shell
./scripts/update-cypress-latest-yarn.sh
```

and confirm no errors.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only affects a maintenance script’s global Yarn version specifier; no runtime or CI product logic changes.
> 
> **Overview**
> Pins global Yarn Classic installs in `scripts/update-cypress-latest-yarn.sh` by changing **`npm install yarn@latest -g`** to **`npm install yarn@1 -g`** in both places (start of the Yarn 1 Classic section and after disabling corepack post–Yarn 4 Modern).
> 
> Behavior stays “latest Yarn 1.x,” but the tag avoids accidentally pulling a future non–v1 release if the `yarn` npm package is republished for Yarn v6.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 343f02fc850b14b7509678920575ff0b48e7c50d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->