### PR TITLE
test: add Ubuntu 26.04 to example-basic workflow

### DIFF
--- a/.github/workflows/example-basic.yml
+++ b/.github/workflows/example-basic.yml
@@ -23,6 +23,7 @@ jobs:
         os:
           - ubuntu-22.04
           - ubuntu-24.04
+          - ubuntu-26.04
           - windows-2025
           - macos-26
           - macos-26-intel
@@ -50,6 +51,7 @@ jobs:
         os:
           - ubuntu-22.04
           - ubuntu-24.04
+          - ubuntu-26.04
           - windows-2025
           - macos-26
           - macos-26-intel


### PR DESCRIPTION
## Situation

- [Ubuntu 26.04](https://canonical.com/blog/canonical-releases-ubuntu-26-04-lts-resolute-raccoon) LTS was released on April 23, 2026.
- GitHub Actions has made a preview [Ubuntu 26.04 LTS](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2604-Readme.md) runner image available in the overview on [GitHub Actions Runner Images](https://github.com/actions/runner-images#available-images) using the YAML Label `ubuntu-26.04`. The Label `ubuntu-latest` remains equivalent to the earlier `ubuntu-24.04`.
- [New runner images in public preview](https://github.blog/changelog/2026-06-11-new-runner-images-in-public-preview/) dated June 11, 2026 announces both [Ubuntu 26.04](https://github.blog/changelog/2026-06-11-new-runner-images-in-public-preview/#ubuntu-26-04) and [Windows 11 arm64 with Visual Studio 2026](https://github.blog/changelog/2026-06-11-new-runner-images-in-public-preview/#windows-11-arm64-with-visual-studio-2026).

## Change

A matrix entry `ubuntu-26.04` is added to the workflow [.github/workflows/example-basic.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-basic.yml) jobs `basic` and `basic-npm-cache` to demonstrate the capability of Cypress to run under this OS version. This is in addition to the `ubuntu-22.04` and `ubuntu-24.04` matrix entries in the workflow.

Other workflows are not changed at this time.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only matrix expansion in a demo workflow; no application or action runtime logic changes.
> 
> **Overview**
> Adds **`ubuntu-26.04`** to the OS matrix in `.github/workflows/example-basic.yml` for the **`basic`** and **`basic-npm-cache`** jobs, alongside the existing Ubuntu 22.04/24.04 entries. Each new matrix row runs the same Cypress example steps on GitHub’s preview Ubuntu 26.04 runner to show the action works on that image.
> 
> No other workflows are updated in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d85ea9dc3ca70ef53e060d41ceb1be5c04a6bc4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->