### PR TITLE
test: add arm images to example-basic workflow

### DIFF
--- a/.github/workflows/example-basic.yml
+++ b/.github/workflows/example-basic.yml
@@ -22,8 +22,11 @@ jobs:
       matrix:
         os:
           - ubuntu-22.04
+          - ubuntu-22.04-arm
           - ubuntu-24.04
+          - ubuntu-24.04-arm
           - windows-2025
+          - windows-11-arm
           - macos-26
           - macos-26-intel
     runs-on: ${{ matrix.os }}
@@ -49,8 +52,11 @@ jobs:
       matrix:
         os:
           - ubuntu-22.04
+          - ubuntu-22.04-arm
           - ubuntu-24.04
+          - ubuntu-24.04-arm
           - windows-2025
+          - windows-11-arm
           - macos-26
           - macos-26-intel
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
## Situation

- Arm64-based runner images, that were previously sourced from the https://github.com/actions/partner-runner-images repo of Arm Limited, LLC, have now transitioned to the mainstream https://github.com/actions/runner-images repo supported directly by GitHub.
- [Available Images](https://github.com/actions/runner-images#available-images) lists labels:
  - ubuntu-26.04-arm (preview)
  - ubuntu-24.04-arm
  - ubuntu-22.04-arm
  - windows-11-arm
  - windows-11-arm-vs2006-arm (preview)

## Change

Add matrix entries for the non-preview Arm64 runner images:

  - ubuntu-24.04-arm
  - ubuntu-22.04-arm
  - windows-11-arm

to the workflow [.github/workflows/example-basic.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-basic.yml) jobs `basic` and `basic-npm-cache` to demonstrate the capability of the Cypress GitHub Action to run under these OS versions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only matrix expansion in an example workflow; no production code, auth, or data handling changes.
> 
> **Overview**
> Expands the **example-basic** CI matrix so Cypress runs on GitHub’s mainstream **Arm64** runners, not only x64.
> 
> Both **`basic`** and **`basic-npm-cache`** now include **`ubuntu-22.04-arm`**, **`ubuntu-24.04-arm`**, and **`windows-11-arm`** alongside the existing OS labels, demonstrating the action on these images without changing test steps or action inputs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1723201a272ec2b5262f346bf7b556031da1488. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->