### PR TITLE
chore(deps): update actions/checkout to v7

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Install Node.js
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/check-markdown.yml
+++ b/.github/workflows/check-markdown.yml
@@ -14,7 +14,7 @@ jobs:
     name: Check Markdown files
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Install dependencies
         run: npm ci
       - name: Check Markdown links

--- a/.github/workflows/example-basic-pnpm.yml
+++ b/.github/workflows/example-basic-pnpm.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
         # See https://github.com/pnpm/action-setup
       - name: Install pnpm

--- a/.github/workflows/example-basic.yml
+++ b/.github/workflows/example-basic.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Cypress tests
         uses: ./
@@ -64,7 +64,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/example-build-artifacts.yml
+++ b/.github/workflows/example-build-artifacts.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Build app
         uses: ./
@@ -54,7 +54,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Restore build artifacts
         uses: actions/download-artifact@v8 # https://github.com/actions/download-artifact

--- a/.github/workflows/example-chrome-for-testing.yml
+++ b/.github/workflows/example-chrome-for-testing.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Install Chrome for Testing
         # https://github.com/browser-actions/setup-chrome
         uses: browser-actions/setup-chrome@v2

--- a/.github/workflows/example-chrome.yml
+++ b/.github/workflows/example-chrome.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Chrome headless
         uses: ./

--- a/.github/workflows/example-component-test.yml
+++ b/.github/workflows/example-component-test.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Cypress run
         uses: ./ # if copying, replace with cypress-io/github-action@v7
         with:

--- a/.github/workflows/example-config.yml
+++ b/.github/workflows/example-config.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Cypress tests
         uses: ./
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Cypress tests
         uses: ./
@@ -51,7 +51,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Cypress tests
         uses: ./
@@ -70,7 +70,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Cypress tests
         uses: ./

--- a/.github/workflows/example-cron.yml
+++ b/.github/workflows/example-cron.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Cypress nightly tests 🌃
         uses: ./ # if copying, replace with cypress-io/github-action@v7

--- a/.github/workflows/example-custom-ci-build-id.yml
+++ b/.github/workflows/example-custom-ci-build-id.yml
@@ -79,7 +79,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Print custom build id
         run: echo "Custom build id is ${{ needs.prepare.outputs.uuid }}"
@@ -110,7 +110,7 @@ jobs:
         containers: [1, 2]
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Print custom build id
         run: echo "Custom build id is ${{ needs.prepare.outputs.uuid }}"

--- a/.github/workflows/example-custom-command.yml
+++ b/.github/workflows/example-custom-command.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Custom tests
         uses: ./ # if copying, replace with cypress-io/github-action@v7

--- a/.github/workflows/example-debug.yml
+++ b/.github/workflows/example-debug.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Cypress action debug logs
         uses: ./
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Cypress debug logs
         uses: ./
@@ -55,7 +55,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Cypress npm install
         # Install only the Cypress npm module

--- a/.github/workflows/example-docker.yml
+++ b/.github/workflows/example-docker.yml
@@ -22,7 +22,7 @@ jobs:
       options: --user 1001
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Cypress tests
         uses: ./ # if copying, replace with cypress-io/github-action@v7
         with:

--- a/.github/workflows/example-edge.yml
+++ b/.github/workflows/example-edge.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Cypress info
         uses: ./ # if copying, replace with cypress-io/github-action@v7

--- a/.github/workflows/example-env.yml
+++ b/.github/workflows/example-env.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       # in the tests below, only the environment
       # variable 'environmentName' will be set
@@ -43,7 +43,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Cypress run with env
         uses: ./
@@ -60,7 +60,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Cypress run with env
         uses: ./
@@ -82,7 +82,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Cypress run with env
         uses: ./

--- a/.github/workflows/example-expose.yml
+++ b/.github/workflows/example-expose.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Cypress run with expose
         uses: ./

--- a/.github/workflows/example-firefox.yml
+++ b/.github/workflows/example-firefox.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Firefox
         uses: ./ # if copying, replace with cypress-io/github-action@v7

--- a/.github/workflows/example-install-command.yml
+++ b/.github/workflows/example-install-command.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Custom Yarn command
         uses: ./ # if copying, replace with cypress-io/github-action@v7

--- a/.github/workflows/example-install-only.yml
+++ b/.github/workflows/example-install-only.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout 🛎
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       # cache npm modules and Cypress binary folder
       # we can use "package-lock.json" as the key file

--- a/.github/workflows/example-node-versions.yml
+++ b/.github/workflows/example-node-versions.yml
@@ -22,7 +22,7 @@ jobs:
     name: Cypress E2E on Node v${{ matrix.node }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Install Node.js
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/example-quiet.yml
+++ b/.github/workflows/example-quiet.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       # Install npm dependencies, cache them correctly
       # and run all Cypress tests with `quiet` parameter
       - name: Cypress run

--- a/.github/workflows/example-recording.yml
+++ b/.github/workflows/example-recording.yml
@@ -53,7 +53,7 @@ jobs:
     if: needs.check-record-key.outputs.record-key-exists == 'true'
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Cypress tests
         uses: ./
@@ -82,7 +82,7 @@ jobs:
     if: needs.check-record-key.outputs.record-key-exists == 'true'
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Cypress tests
         uses: ./

--- a/.github/workflows/example-start-and-pnpm-workspaces.yml
+++ b/.github/workflows/example-start-and-pnpm-workspaces.yml
@@ -26,7 +26,7 @@ jobs:
     name: Single workspace
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
         # See https://github.com/pnpm/action-setup
       - name: Install pnpm
@@ -78,7 +78,7 @@ jobs:
     name: Multiple workspaces
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
         # See https://github.com/pnpm/action-setup
       - name: Install pnpm

--- a/.github/workflows/example-start-and-yarn-workspaces.yml
+++ b/.github/workflows/example-start-and-yarn-workspaces.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Single
         uses: ./
@@ -46,7 +46,7 @@ jobs:
           - working_directory: examples/start-and-yarn-workspaces/workspace-2
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Cypress tests
         uses: ./

--- a/.github/workflows/example-start.yml
+++ b/.github/workflows/example-start.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Cypress tests
         uses: ./
@@ -43,7 +43,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Cypress tests
         uses: ./
@@ -63,7 +63,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Cypress tests
         uses: ./

--- a/.github/workflows/example-wait-on.yml
+++ b/.github/workflows/example-wait-on.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Cypress tests
         uses: ./
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Cypress tests
         uses: ./
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Cypress tests
         uses: ./
@@ -60,7 +60,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Cypress tests
         uses: ./
@@ -73,7 +73,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Cypress tests
         uses: ./
@@ -87,7 +87,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Cypress tests
         uses: ./
         with:
@@ -101,7 +101,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Cypress tests
         uses: ./
         with:
@@ -116,7 +116,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Cypress tests
         uses: ./
         with:
@@ -128,7 +128,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Cypress tests
         uses: ./
         with:
@@ -142,7 +142,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Cypress tests
         uses: ./
         with:
@@ -154,7 +154,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Cypress tests
         uses: ./
         with:
@@ -167,7 +167,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Install dependencies
         run: npm ci
       - name: Run ping from CLI
@@ -177,7 +177,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Cypress tests
         uses: ./
         with:

--- a/.github/workflows/example-webpack.yml
+++ b/.github/workflows/example-webpack.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Cypress tests
         uses: ./ # if copying, replace with cypress-io/github-action@v7

--- a/.github/workflows/example-yarn-classic.yml
+++ b/.github/workflows/example-yarn-classic.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Test with Yarn Classic
         uses: ./
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/example-yarn-modern-pnp.yml
+++ b/.github/workflows/example-yarn-modern-pnp.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Enable Corepack # see https://yarnpkg.com/getting-started/install
         run: |
           npm install -g corepack

--- a/.github/workflows/example-yarn-modern.yml
+++ b/.github/workflows/example-yarn-modern.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Enable Corepack # see https://yarnpkg.com/getting-started/install
         run: |
           npm install -g corepack

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
     name: Build and test
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Install Node.js
         uses: actions/setup-node@v6
         with:
@@ -43,7 +43,7 @@ jobs:
       (github.repository == 'cypress-io/github-action')
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - run: npm ci
       # https://github.com/cycjimmy/semantic-release-action
       - name: Semantic Release

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       # Install dependencies with caching
       # and run all Cypress tests
       - name: Cypress run
@@ -126,7 +126,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Cypress run
         uses: cypress-io/github-action@v7
         with:
@@ -179,7 +179,7 @@ jobs:
     runs-on: ubuntu-24.04
     name: E2E on Chrome
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: cypress-io/github-action@v7
         with:
           browser: chrome
@@ -199,7 +199,7 @@ jobs:
     runs-on: ubuntu-24.04
     name: E2E on Chrome for Testing
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: browser-actions/setup-chrome@v2
         with:
           chrome-version: 140
@@ -220,7 +220,7 @@ jobs:
     runs-on: ubuntu-24.04
     name: E2E on Firefox
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: cypress-io/github-action@v7
         with:
           browser: firefox
@@ -238,7 +238,7 @@ jobs:
     runs-on: ubuntu-24.04
     name: E2E on Edge
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: cypress-io/github-action@v7
         with:
           browser: edge
@@ -257,7 +257,7 @@ jobs:
   cypress-run:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: cypress-io/github-action@v7
         with:
           browser: chrome
@@ -280,7 +280,7 @@ jobs:
       image: cypress/browsers:latest
       options: --user 1001
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: cypress-io/github-action@v7
         with:
           browser: chrome
@@ -304,7 +304,7 @@ jobs:
       image: cypress/included:latest
       options: --user 1001
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: cypress-io/github-action@v7
         with:
           browser: chrome
@@ -328,7 +328,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Cypress run with env
         uses: cypress-io/github-action@v7
@@ -346,7 +346,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Cypress run with env
         uses: cypress-io/github-action@v7
@@ -371,7 +371,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Cypress run with expose
         uses: cypress-io/github-action@v7
@@ -396,7 +396,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Cypress run
         uses: cypress-io/github-action@v7
@@ -427,7 +427,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Cypress run
         uses: cypress-io/github-action@v7
         with:
@@ -459,7 +459,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Cypress run
         uses: cypress-io/github-action@v7
@@ -489,7 +489,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Cypress run
         uses: cypress-io/github-action@v7
         with:
@@ -522,7 +522,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Cypress run
         uses: cypress-io/github-action@v7
         with:
@@ -560,7 +560,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Cypress run
         uses: cypress-io/github-action@v7
@@ -596,7 +596,7 @@ jobs:
     name: E2E on Node v${{ matrix.node }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Install Node.js
         uses: actions/setup-node@v6
         with:
@@ -634,7 +634,7 @@ jobs:
     name: E2E
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Cypress run
         uses: cypress-io/github-action@v7
@@ -661,7 +661,7 @@ jobs:
     runs-on: ubuntu-24.04
     name: Artifacts
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: cypress-io/github-action@v7
       # after the test run completes store videos and any screenshots
       - uses: actions/upload-artifact@v7
@@ -690,7 +690,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       # Install dependencies with caching
       # and run all Cypress tests with `quiet` parameter
       - name: Cypress run
@@ -715,7 +715,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Cypress run
         uses: cypress-io/github-action@v7
@@ -738,7 +738,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Cypress run
         uses: cypress-io/github-action@v7
@@ -772,7 +772,7 @@ jobs:
         containers: [1, 2, 3]
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       # because of "record" and "parallel" parameters
       # these containers will load balance all found tests among themselves
@@ -833,7 +833,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Cypress run
         uses: cypress-io/github-action@v7
         with:
@@ -852,7 +852,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Cypress run
         uses: cypress-io/github-action@v7
         with:
@@ -871,7 +871,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Cypress run
         uses: cypress-io/github-action@v7
         with:
@@ -897,7 +897,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Cypress run
         uses: cypress-io/github-action@v7
         with:
@@ -927,7 +927,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Cypress run
         uses: cypress-io/github-action@v7
         with:
@@ -1016,7 +1016,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Cypress run
         uses: cypress-io/github-action@v7
         with:
@@ -1043,7 +1043,7 @@ Correct example snippet:
 
 ```yml
 steps:
-  - uses: actions/checkout@v6
+  - uses: actions/checkout@v7
   - uses: cypress-io/github-action@v7
     with:
       command: npm run custom-test
@@ -1066,7 +1066,7 @@ jobs:
         # run 3 copies of the current job in parallel
         containers: [1, 2, 3]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: cypress-io/github-action@v7
         with:
           record: true
@@ -1101,7 +1101,7 @@ jobs:
   smoke-tests:
     needs: ['prepare']
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: cypress-io/github-action@v7
         with:
           record: true
@@ -1141,7 +1141,7 @@ jobs:
   cypress-run:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: cypress-io/github-action@v7
         with:
           start: npm start
@@ -1179,7 +1179,7 @@ jobs:
   test:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Install root dependencies
         run: npm ci
 
@@ -1212,7 +1212,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Install pnpm
         uses: pnpm/action-setup@v6
         with:
@@ -1272,7 +1272,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Cypress run
         uses: cypress-io/github-action@v7
         with:
@@ -1295,7 +1295,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - run: corepack enable # (experimental and optional)
       - name: Set up Yarn cache
         uses: actions/setup-node@v6
@@ -1329,7 +1329,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Cypress run
         uses: cypress-io/github-action@v7
         with:
@@ -1358,7 +1358,7 @@ jobs:
     # and tests in a subfolder like "workspace-1"
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: cypress-io/github-action@v7
         with:
           working-directory: examples/start-and-yarn-workspaces/workspace-1
@@ -1390,7 +1390,7 @@ jobs:
     runs-on: ubuntu-24.04
     name:
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: actions/setup-node@v6
         with:
           node-version: lts
@@ -1421,7 +1421,7 @@ jobs:
     name: E2E on Node v${{ matrix.node }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Install Node.js
         uses: actions/setup-node@v6
         with:
@@ -1457,7 +1457,7 @@ jobs:
           - 26
     name: E2E on Node v${{ matrix.node }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node }}
@@ -1479,7 +1479,7 @@ jobs:
   test:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Install dependencies
         uses: cypress-io/github-action@v7
         with:
@@ -1512,7 +1512,7 @@ jobs:
   build:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Build app
         uses: cypress-io/github-action@v7
         with:
@@ -1530,7 +1530,7 @@ jobs:
     needs: build
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Restore build artifacts
         uses: actions/download-artifact@v8
         with:
@@ -1554,7 +1554,7 @@ Finally, you might not need this GH Action at all. For example, if you want to s
 If the project has many dependencies, but you want to install just Cypress you can combine this action with `actions/cache` and `npm i cypress` commands yourself.
 
 ```yml
-- uses: actions/checkout@v6
+- uses: actions/checkout@v7
 - uses: actions/cache@v5
   with:
     path: |
@@ -1581,7 +1581,7 @@ jobs:
     # to prevent a hanging process from using all your CI minutes
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: cypress-io/github-action@v7
         # you can specify individual step timeout too
         timeout-minutes: 5
@@ -1624,7 +1624,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Check out repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Cypress run # install dependencies and run Cypress E2E tests
         uses: cypress-io/github-action@v7 # replaces CLI cypress run
         with:
@@ -1812,7 +1812,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Cypress run
         uses: cypress-io/github-action@v7
         with:
@@ -1829,7 +1829,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Cypress install
         uses: cypress-io/github-action@v7
         with:
@@ -1860,7 +1860,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Cypress nightly tests 🌃
         uses: cypress-io/github-action@v7
 ```
@@ -1880,7 +1880,7 @@ jobs:
   tests:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Cypress headless tests
         uses: cypress-io/github-action@v7
         with:
@@ -1909,7 +1909,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Cypress run
         uses: cypress-io/github-action@v7
         with:


### PR DESCRIPTION
## Situation

Documentation, examples and workflows currently use [actions/checkout@v6](https://github.com/actions/checkout/tree/v6).

[actions/checkout@v7](https://github.com/actions/checkout/tree/v7), published on June 18, 2025 has increased security protection.

## Change

Update all [README](https://github.com/cypress-io/github-action/blob/master/README.md) documentation and [.github/workflows](https://github.com/cypress-io/github-action/tree/master/.github/workflows):

| From                                                               | To                                                                 |
| ------------------------------------------------------------------ | ------------------------------------------------------------------ |
| [actions/checkout@v6](https://github.com/actions/checkout/tree/v6) | [actions/checkout@v7](https://github.com/actions/checkout/tree/v7) |

Note that this update has to be done manually, as Renovate only updates workflows, not the associated documentation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical dependency bump on the standard checkout action in CI and documentation only; no application or Cypress action code changes.
> 
> **Overview**
> Bumps the GitHub Actions checkout step from **`actions/checkout@v6`** to **`actions/checkout@v7`** everywhere this repo documents and exercises CI.
> 
> Every checkout step under **`.github/workflows/`** (main build, dist/markdown checks, and all `example-*` Cypress workflows) now uses v7. **`README.md`** sample workflows are updated the same way so copy-paste examples match what the repo actually runs.
> 
> No Cypress action logic, test code, or runtime dependencies change—only the checkout action version in workflows and docs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f60b3c94709cc3d654a8098c301a5c038103e57a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->