### PR TITLE
feat: add explicit cypress install step after dependency install

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -101895,15 +101895,19 @@ const install = () => {
 }
 
 /**
- * Runs an explicit, package-manager-aware "cypress install" after the
- * dependencies have been installed. This downloads the Cypress binary when
- * it is missing and is a no-op when it is already present.
+ * Runs an explicit "cypress install" after the dependencies have been
+ * installed. This downloads the Cypress binary when it is missing and is a
+ * no-op when it is already present.
  *
  * Package managers may no longer run a dependency's `postinstall` script by
  * default, which means the script that normally downloads the Cypress binary
  * no longer runs during a package-manager install. Running the install
  * explicitly keeps the binary available on a cold cache regardless of package
  * manager.
+ *
+ * Like "cypress verify" and "cypress cache list", this is invoked via npx for
+ * all package managers so the Cypress binary is resolved consistently,
+ * including within pnpm and Yarn workspaces.
  */
 const installCypressBinary = () => {
   debug('installing Cypress binary')
@@ -101913,34 +101917,13 @@ const installCypressBinary = () => {
     return Promise.resolve()
   }
 
-  if (useYarn()) {
-    debug('installing Cypress binary using Yarn')
-    return io.which('yarn', true).then((yarnPath) => {
-      return exec.exec(
-        quote(yarnPath),
-        ['cypress', 'install'],
-        cypressCommandOptions
-      )
-    })
-  } else if (usePnpm()) {
-    debug('installing Cypress binary using pnpm')
-    return io.which('pnpm', true).then((pnpmPath) => {
-      return exec.exec(
-        quote(pnpmPath),
-        ['cypress', 'install'],
-        cypressCommandOptions
-      )
-    })
-  } else {
-    debug('installing Cypress binary using npx')
-    return io.which('npx', true).then((npxPath) => {
-      return exec.exec(
-        quote(npxPath),
-        ['cypress', 'install'],
-        cypressCommandOptions
-      )
-    })
-  }
+  return io.which('npx', true).then((npxPath) => {
+    return exec.exec(
+      quote(npxPath),
+      ['cypress', 'install'],
+      cypressCommandOptions
+    )
+  })
 }
 
 const listCypressBinaries = () => {

--- a/dist/index.js
+++ b/dist/index.js
@@ -101894,6 +101894,55 @@ const install = () => {
   }
 }
 
+/**
+ * Runs an explicit, package-manager-aware "cypress install" after the
+ * dependencies have been installed. This downloads the Cypress binary when
+ * it is missing and is a no-op when it is already present.
+ *
+ * Package managers may no longer run a dependency's `postinstall` script by
+ * default, which means the script that normally downloads the Cypress binary
+ * no longer runs during a package-manager install. Running the install
+ * explicitly keeps the binary available on a cold cache regardless of package
+ * manager.
+ */
+const installCypressBinary = () => {
+  debug('installing Cypress binary')
+
+  if (isCypressBinarySkipped()) {
+    debug('Skipping Cypress install, binary installation is disabled')
+    return Promise.resolve()
+  }
+
+  if (useYarn()) {
+    debug('installing Cypress binary using Yarn')
+    return io.which('yarn', true).then((yarnPath) => {
+      return exec.exec(
+        quote(yarnPath),
+        ['cypress', 'install'],
+        cypressCommandOptions
+      )
+    })
+  } else if (usePnpm()) {
+    debug('installing Cypress binary using pnpm')
+    return io.which('pnpm', true).then((pnpmPath) => {
+      return exec.exec(
+        quote(pnpmPath),
+        ['cypress', 'install'],
+        cypressCommandOptions
+      )
+    })
+  } else {
+    debug('installing Cypress binary using npx')
+    return io.which('npx', true).then((npxPath) => {
+      return exec.exec(
+        quote(npxPath),
+        ['cypress', 'install'],
+        cypressCommandOptions
+      )
+    })
+  }
+}
+
 const listCypressBinaries = () => {
   debug(
     `Cypress versions in the cache folder ${CYPRESS_CACHE_FOLDER}`
@@ -102628,19 +102677,22 @@ const installMaybe = () => {
 
     return install().then(() => {
       debug('install has finished')
-      return listCypressBinaries().then(() => {
-        if (npmCacheHit && cypressCacheHit) {
-          debug('no need to verify Cypress binary or save caches')
-          return Promise.resolve(undefined)
-        }
+      return installCypressBinary().then(() => {
+        debug('Cypress binary install has finished')
+        return listCypressBinaries().then(() => {
+          if (npmCacheHit && cypressCacheHit) {
+            debug('no need to verify Cypress binary or save caches')
+            return Promise.resolve(undefined)
+          }
 
-        debug('verifying Cypress binary')
-        const saveNpmPromise = packageManagerCacheEnabled
-          ? saveCachedNpm()
-          : Promise.resolve(undefined)
-        return verifyCypressBinary()
-          .then(() => saveNpmPromise)
-          .then(saveCachedCypressBinary)
+          debug('verifying Cypress binary')
+          const saveNpmPromise = packageManagerCacheEnabled
+            ? saveCachedNpm()
+            : Promise.resolve(undefined)
+          return verifyCypressBinary()
+            .then(() => saveNpmPromise)
+            .then(saveCachedCypressBinary)
+        })
       })
     })
   })

--- a/dist/index.js
+++ b/dist/index.js
@@ -101906,8 +101906,7 @@ const install = () => {
  * manager.
  *
  * Like "cypress verify" and "cypress cache list", this is invoked via npx for
- * all package managers so the Cypress binary is resolved consistently,
- * including within pnpm and Yarn workspaces.
+ * all package managers so the Cypress binary is resolved consistently.
  */
 const installCypressBinary = () => {
   debug('installing Cypress binary')

--- a/index.js
+++ b/index.js
@@ -273,6 +273,55 @@ const install = () => {
   }
 }
 
+/**
+ * Runs an explicit, package-manager-aware "cypress install" after the
+ * dependencies have been installed. This downloads the Cypress binary when
+ * it is missing and is a no-op when it is already present.
+ *
+ * Package managers may no longer run a dependency's `postinstall` script by
+ * default, which means the script that normally downloads the Cypress binary
+ * no longer runs during a package-manager install. Running the install
+ * explicitly keeps the binary available on a cold cache regardless of package
+ * manager.
+ */
+const installCypressBinary = () => {
+  debug('installing Cypress binary')
+
+  if (isCypressBinarySkipped()) {
+    debug('Skipping Cypress install, binary installation is disabled')
+    return Promise.resolve()
+  }
+
+  if (useYarn()) {
+    debug('installing Cypress binary using Yarn')
+    return io.which('yarn', true).then((yarnPath) => {
+      return exec.exec(
+        quote(yarnPath),
+        ['cypress', 'install'],
+        cypressCommandOptions
+      )
+    })
+  } else if (usePnpm()) {
+    debug('installing Cypress binary using pnpm')
+    return io.which('pnpm', true).then((pnpmPath) => {
+      return exec.exec(
+        quote(pnpmPath),
+        ['cypress', 'install'],
+        cypressCommandOptions
+      )
+    })
+  } else {
+    debug('installing Cypress binary using npx')
+    return io.which('npx', true).then((npxPath) => {
+      return exec.exec(
+        quote(npxPath),
+        ['cypress', 'install'],
+        cypressCommandOptions
+      )
+    })
+  }
+}
+
 const listCypressBinaries = () => {
   debug(
     `Cypress versions in the cache folder ${CYPRESS_CACHE_FOLDER}`
@@ -1007,19 +1056,22 @@ const installMaybe = () => {
 
     return install().then(() => {
       debug('install has finished')
-      return listCypressBinaries().then(() => {
-        if (npmCacheHit && cypressCacheHit) {
-          debug('no need to verify Cypress binary or save caches')
-          return Promise.resolve(undefined)
-        }
+      return installCypressBinary().then(() => {
+        debug('Cypress binary install has finished')
+        return listCypressBinaries().then(() => {
+          if (npmCacheHit && cypressCacheHit) {
+            debug('no need to verify Cypress binary or save caches')
+            return Promise.resolve(undefined)
+          }
 
-        debug('verifying Cypress binary')
-        const saveNpmPromise = packageManagerCacheEnabled
-          ? saveCachedNpm()
-          : Promise.resolve(undefined)
-        return verifyCypressBinary()
-          .then(() => saveNpmPromise)
-          .then(saveCachedCypressBinary)
+          debug('verifying Cypress binary')
+          const saveNpmPromise = packageManagerCacheEnabled
+            ? saveCachedNpm()
+            : Promise.resolve(undefined)
+          return verifyCypressBinary()
+            .then(() => saveNpmPromise)
+            .then(saveCachedCypressBinary)
+        })
       })
     })
   })

--- a/index.js
+++ b/index.js
@@ -285,8 +285,7 @@ const install = () => {
  * manager.
  *
  * Like "cypress verify" and "cypress cache list", this is invoked via npx for
- * all package managers so the Cypress binary is resolved consistently,
- * including within pnpm and Yarn workspaces.
+ * all package managers so the Cypress binary is resolved consistently.
  */
 const installCypressBinary = () => {
   debug('installing Cypress binary')

--- a/index.js
+++ b/index.js
@@ -274,15 +274,19 @@ const install = () => {
 }
 
 /**
- * Runs an explicit, package-manager-aware "cypress install" after the
- * dependencies have been installed. This downloads the Cypress binary when
- * it is missing and is a no-op when it is already present.
+ * Runs an explicit "cypress install" after the dependencies have been
+ * installed. This downloads the Cypress binary when it is missing and is a
+ * no-op when it is already present.
  *
  * Package managers may no longer run a dependency's `postinstall` script by
  * default, which means the script that normally downloads the Cypress binary
  * no longer runs during a package-manager install. Running the install
  * explicitly keeps the binary available on a cold cache regardless of package
  * manager.
+ *
+ * Like "cypress verify" and "cypress cache list", this is invoked via npx for
+ * all package managers so the Cypress binary is resolved consistently,
+ * including within pnpm and Yarn workspaces.
  */
 const installCypressBinary = () => {
   debug('installing Cypress binary')
@@ -292,34 +296,13 @@ const installCypressBinary = () => {
     return Promise.resolve()
   }
 
-  if (useYarn()) {
-    debug('installing Cypress binary using Yarn')
-    return io.which('yarn', true).then((yarnPath) => {
-      return exec.exec(
-        quote(yarnPath),
-        ['cypress', 'install'],
-        cypressCommandOptions
-      )
-    })
-  } else if (usePnpm()) {
-    debug('installing Cypress binary using pnpm')
-    return io.which('pnpm', true).then((pnpmPath) => {
-      return exec.exec(
-        quote(pnpmPath),
-        ['cypress', 'install'],
-        cypressCommandOptions
-      )
-    })
-  } else {
-    debug('installing Cypress binary using npx')
-    return io.which('npx', true).then((npxPath) => {
-      return exec.exec(
-        quote(npxPath),
-        ['cypress', 'install'],
-        cypressCommandOptions
-      )
-    })
-  }
+  return io.which('npx', true).then((npxPath) => {
+    return exec.exec(
+      quote(npxPath),
+      ['cypress', 'install'],
+      cypressCommandOptions
+    )
+  })
 }
 
 const listCypressBinaries = () => {


### PR DESCRIPTION
## What

Adds an explicit `cypress install` step that runs after dependency install in `index.js`, invoked via `npx` for all package managers:

```
npx cypress install
```

The step runs on every install path (including a custom `install-command`), is skipped when `install: false`, and respects `CYPRESS_INSTALL_BINARY=0`. It's a no-op when the binary is already present.

## Why

Package managers may no longer run a dependency's `postinstall` script by default — pnpm and Yarn Berry (≥4.14) already block them, and npm 12 will via [RFC #868](https://github.com/npm/rfcs/pull/868). Cypress downloads its binary via a `postinstall` script, so without an explicit install:

- **Cache hit (steady-state CI):** binary restored from `~/.cache/Cypress`, unaffected.
- **Cache miss / first run / cache-key change:** the binary is never downloaded and `cypress verify` fails.

Running `cypress install` explicitly downloads the binary on a cold cache regardless of package manager.

## Why `npx` for all package managers (not `pnpm cypress` / `yarn cypress`)

The first iteration used package-manager-specific commands (`pnpm cypress install`, `yarn cypress install`). That broke the pnpm-workspaces example with:

```
[ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL] Command "cypress" not found
```

Root cause: `pnpm <command>` resolves `<command>` relative to the **current directory's package**. The action installs dependencies in the pnpm **workspace root**, whose `package.json` declares no `cypress` dependency and no `cypress` script (cypress is a devDependency of the child packages only). pnpm therefore has no `cypress` command to run there and errors out.

`npx cypress` instead resolves cypress from the dependency tree and finds the workspace's pinned version (verified: `npx --no-install cypress --version` returns the locked `15.17.0` from the workspace root, no download). This also matches how the action's existing `cypress verify` and `cypress cache list` steps already invoke cypress, so behavior is consistent across all three.

## Notes for reviewers

- Wired into `installMaybe()` between `install()` and `listCypressBinaries()`.
- No `core.exportVariable('CYPRESS_CACHE_FOLDER', ...)` in the new function — `install()` always runs immediately before it and already exports it for the process.
- `dist/index.js` rebuilt via the pre-commit hook (`ncc build`).
- No unit tests in this repo; behavior is exercised via the example workflows (the pnpm-workspaces examples were the ones that caught the original `pnpm cypress` issue).

Closes #1798

## References
- Tracking issue: cypress-io/cypress#33980
- Tech brief: cypress-io/engineering-documentation#496

🤖 Generated with [Claude Code](https://claude.com/claude-code)