### PR TITLE
chore: add Yarn v1 allow-scripts in update script

### DIFF
--- a/scripts/update-cypress-latest-yarn.sh
+++ b/scripts/update-cypress-latest-yarn.sh
@@ -25,7 +25,7 @@ cd examples
 # Yarn 1 Classic section
 # No corepack
 corepack disable yarn
-npm install yarn@1 -g
+npm install yarn@1 --global --allow-scripts=yarn
 echo yarn version $(yarn --version) is installed
 
 # examples/start-and-yarn-workspaces (yarn)
@@ -81,7 +81,7 @@ cd ..
 echo
 corepack disable yarn
 echo corepack is now disabled for Yarn
-npm install yarn@1 -g
+npm install yarn@1 --global --allow-scripts=yarn
 echo yarn version $(yarn --version) is installed
 echo
 # End of Yarn 4 Modern section


### PR DESCRIPTION
## Situation

With the rollout of [npm@11.16.0](https://github.com/npm/cli/releases/tag/v11.16.0) to [Node.js 24.18.0](https://nodejs.org/en/blog/release/v24.18.0) Active LTS, running the script [scripts/update-cypress-latest-yarn.sh](https://github.com/cypress-io/github-action/blob/master/scripts/update-cypress-latest-yarn.sh) results in a warning:

```console
npm warn allow-scripts 1 package has install scripts not yet covered by allowScripts:
npm warn allow-scripts   yarn@1.22.22 (preinstall: :; (node ./preinstall.js > /dev/null 2>&1 || true))
```

## Change

Modify [scripts/update-cypress-latest-yarn.sh](https://github.com/cypress-io/github-action/blob/master/scripts/update-cypress-latest-yarn.sh) to install Yarn Classic with:

```shell
npm install yarn@1 --global --allow-scripts=yarn
```

## Verification

Ubuntu 24.04.4 LTS, Node.js 24.18.0 LTS and execute:

```shell
./scripts/update-cypress-latest-yarn.sh
```

Confirm no npm `allow-scripts` warnings appear.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev-only script change with no runtime, auth, or production impact.
> 
> **Overview**
> Updates **both** global Yarn Classic installs in `scripts/update-cypress-latest-yarn.sh` from `npm install yarn@1 -g` to `npm install yarn@1 --global --allow-scripts=yarn`.
> 
> This opts in to Yarn v1’s install lifecycle scripts under **npm 11.16+** (e.g. on Node.js 24.18 LTS), so running the Cypress example update script no longer emits `allow-scripts` warnings for `yarn@1.22.22`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68ca6829edf1e1d5cf0c878f2998c31433f766e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->