### PR TITLE
chore(deps): set pnpm minimumReleaseAge to 10080 minutes (7 days)

### DIFF
--- a/examples/basic-pnpm/pnpm-lock.yaml
+++ b/examples/basic-pnpm/pnpm-lock.yaml
@@ -471,8 +471,8 @@ packages:
   pump@3.0.4:
     resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
 
-  qs@6.15.2:
-    resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
+  qs@6.15.3:
+    resolution: {integrity: sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==}
     engines: {node: '>=0.6'}
 
   request-progress@3.0.0:
@@ -567,8 +567,8 @@ packages:
     resolution: {integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==}
     engines: {node: '>=10'}
 
-  systeminformation@5.31.7:
-    resolution: {integrity: sha512-/8NC53e5nP9nmhn42/ncdOkyJnOoue/Vy+tJOyUGd1Yv66G069wK4rrziwhrqDETgk78CudTQupw5z19S5uoZw==}
+  systeminformation@5.31.11:
+    resolution: {integrity: sha512-I6O7iaUj23AXRgCPDDnvi3xHvdOLp4+1YMbF+X194lJwY1NeWojgHJPhslVKcmTtrLTguRk3QJK+xEdTiI3P0w==}
     engines: {node: '>=8.0.0'}
     os: [darwin, linux, win32, freebsd, openbsd, netbsd, sunos, android]
     hasBin: true
@@ -653,7 +653,7 @@ snapshots:
       json-stringify-safe: 5.0.1
       mime-types: 2.1.35
       performance-now: 2.1.0
-      qs: 6.15.2
+      qs: 6.15.3
       safe-buffer: 5.2.1
       tough-cookie: 5.1.2
       tunnel-agent: 0.6.0
@@ -814,7 +814,7 @@ snapshots:
       proxy-from-env: 1.0.0
       request-progress: 3.0.0
       supports-color: 8.1.1
-      systeminformation: 5.31.7
+      systeminformation: 5.31.11
       tmp: 0.2.7
       tree-kill: 1.2.2
       tslib: 1.14.1
@@ -1110,8 +1110,9 @@ snapshots:
       end-of-stream: 1.4.5
       once: 1.4.0
 
-  qs@6.15.2:
+  qs@6.15.3:
     dependencies:
+      es-define-property: 1.0.1
       side-channel: 1.1.1
 
   request-progress@3.0.0:
@@ -1224,7 +1225,7 @@ snapshots:
     dependencies:
       has-flag: 4.0.0
 
-  systeminformation@5.31.7: {}
+  systeminformation@5.31.11: {}
 
   throttleit@1.0.1: {}
 

--- a/examples/basic-pnpm/pnpm-workspace.yaml
+++ b/examples/basic-pnpm/pnpm-workspace.yaml
@@ -1,6 +1,6 @@
 allowBuilds:
   cypress: true
 sideEffectsCache: false
-minimumReleaseAge: 4320
+minimumReleaseAge: 10080 # 10,080 minutes = 7 days
 minimumReleaseAgeExclude:
   - cypress

--- a/examples/start-and-pnpm-workspaces/pnpm-lock.yaml
+++ b/examples/start-and-pnpm-workspaces/pnpm-lock.yaml
@@ -637,8 +637,8 @@ packages:
   pump@3.0.4:
     resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
 
-  qs@6.15.2:
-    resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
+  qs@6.15.3:
+    resolution: {integrity: sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==}
     engines: {node: '>=0.6'}
 
   range-parser@1.2.0:
@@ -768,8 +768,8 @@ packages:
     resolution: {integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==}
     engines: {node: '>=10'}
 
-  systeminformation@5.31.7:
-    resolution: {integrity: sha512-/8NC53e5nP9nmhn42/ncdOkyJnOoue/Vy+tJOyUGd1Yv66G069wK4rrziwhrqDETgk78CudTQupw5z19S5uoZw==}
+  systeminformation@5.31.11:
+    resolution: {integrity: sha512-I6O7iaUj23AXRgCPDDnvi3xHvdOLp4+1YMbF+X194lJwY1NeWojgHJPhslVKcmTtrLTguRk3QJK+xEdTiI3P0w==}
     engines: {node: '>=8.0.0'}
     os: [darwin, linux, win32, freebsd, openbsd, netbsd, sunos, android]
     hasBin: true
@@ -873,7 +873,7 @@ snapshots:
       json-stringify-safe: 5.0.1
       mime-types: 2.1.35
       performance-now: 2.1.0
-      qs: 6.15.2
+      qs: 6.15.3
       safe-buffer: 5.2.1
       tough-cookie: 5.1.2
       tunnel-agent: 0.6.0
@@ -1107,7 +1107,7 @@ snapshots:
       proxy-from-env: 1.0.0
       request-progress: 3.0.0
       supports-color: 8.1.1
-      systeminformation: 5.31.7
+      systeminformation: 5.31.11
       tmp: 0.2.7
       tree-kill: 1.2.2
       tslib: 1.14.1
@@ -1467,8 +1467,9 @@ snapshots:
       end-of-stream: 1.4.5
       once: 1.4.0
 
-  qs@6.15.2:
+  qs@6.15.3:
     dependencies:
+      es-define-property: 1.0.1
       side-channel: 1.1.1
 
   range-parser@1.2.0: {}
@@ -1635,7 +1636,7 @@ snapshots:
     dependencies:
       has-flag: 4.0.0
 
-  systeminformation@5.31.7: {}
+  systeminformation@5.31.11: {}
 
   throttleit@1.0.1: {}
 

--- a/examples/start-and-pnpm-workspaces/pnpm-workspace.yaml
+++ b/examples/start-and-pnpm-workspaces/pnpm-workspace.yaml
@@ -3,6 +3,6 @@ packages:
 allowBuilds:
   cypress: true
 sideEffectsCache: false
-minimumReleaseAge: 4320
+minimumReleaseAge: 10080 # 10,080 minutes = 7 days
 minimumReleaseAgeExclude:
   - cypress


### PR DESCRIPTION
- supports resolution of issue https://github.com/cypress-io/github-action/issues/1816

## Situation

The [renovate.json](https://github.com/cypress-io/github-action/blob/master/renovate.json) configuration includes:

```json
    "minimumReleaseAge": "7 days",
    {
      "matchPackageNames": ["cypress"],
      "minimumReleaseAge": "0 days"
    }
```

pnpm examples are set up with [minimumReleaseAge](https://pnpm.io/settings#minimumreleaseage) of `4320` in minutes. This is equivalent to 3 days.

An exception for `cypress` is in place using [minimumreleaseageexclude](https://pnpm.io/settings#minimumreleaseageexclude).

## Change

In pnpm examples:

- [examples/basic-pnpm/pnpm-workspace.yaml](https://github.com/cypress-io/github-action/blob/master/examples/basic-pnpm/pnpm-workspace.yaml)
- [examples/start-and-pnpm-workspaces/pnpm-workspace.yaml](https://github.com/cypress-io/github-action/blob/master/examples/start-and-pnpm-workspaces/pnpm-workspace.yaml)

update [minimumReleaseAge](https://pnpm.io/settings#minimumreleaseage):

| BEFORE                | AFTER                  |
| --------------------- | ---------------------- |
| 4320 minutes (3 days) | 10080 minutes (7 days) |

Execute `pnpm update --recursive --save` to update all dependencies according to changed age rules.

## Verification

Using Ubuntu 24.04.4 LTS with Node.js 24.18.0 LTS execute:

```shell
npm install pnpm@latest -g
git clean -xfd
cd examples
cd basic-pnpm
pnpm update --recursive --save
cd ..
cd start-and-pnpm-workspaces
pnpm update --recursive --save
cd ..
cd ..
```

Confirm logs show:

✓ Lockfile passes supply-chain policies (167 entries in 1.2s)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Example-only pnpm policy and lockfile updates with no application or CI workflow logic changes.
> 
> **Overview**
> Raises **pnpm** `minimumReleaseAge` from **4320** (3 days) to **10080** (7 days) in `examples/basic-pnpm` and `examples/start-and-pnpm-workspaces`, matching Renovate’s **7 days** policy while keeping **`cypress`** on `minimumReleaseAgeExclude`.
> 
> Lockfiles were refreshed under the stricter age rules, bumping transitive deps **`qs`** (6.15.2 → 6.15.3) and **`systeminformation`** (5.31.7 → 5.31.11) in both example projects.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fdaa5c0ad822328293c75b0612a0f508288b61e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->