### PR TITLE
chore(deps): set Yarn Modern minimumReleaseAge to 7d (7 days)

### DIFF
--- a/examples/yarn-modern-pnp/.yarnrc.yml
+++ b/examples/yarn-modern-pnp/.yarnrc.yml
@@ -1,6 +1,6 @@
 enableScripts: true
 
-npmMinimalAgeGate: 3d
+npmMinimalAgeGate: 7d # d = unit of days
 
 npmPreapprovedPackages:
   - cypress

--- a/examples/yarn-modern-pnp/yarn.lock
+++ b/examples/yarn-modern-pnp/yarn.lock
@@ -1139,11 +1139,12 @@ __metadata:
   linkType: hard
 
 "qs@npm:^6.15.2":
-  version: 6.15.2
-  resolution: "qs@npm:6.15.2"
+  version: 6.15.3
+  resolution: "qs@npm:6.15.3"
   dependencies:
-    side-channel: "npm:^1.1.0"
-  checksum: 10c0/e6fd5f6f0aab06d480fe9ab15cebfc4ce4235303e2f91dc69a8f7f4df1e668a61c11d1cfbabacf4295cbbeb7b670ed23db45307480726259761f98e5695e93a7
+    es-define-property: "npm:^1.0.1"
+    side-channel: "npm:^1.1.1"
+  checksum: 10c0/8f3f6e45ece255347d57696628401cde29e9ec649fff698b53bd3150dea7cefdf33036e1bc1826b9f110bfa7cb0ec4ab9f5297eca628ce216c55af82c304e08e
   languageName: node
   linkType: hard
 
@@ -1238,7 +1239,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"side-channel@npm:^1.1.0":
+"side-channel@npm:^1.1.1":
   version: 1.1.1
   resolution: "side-channel@npm:1.1.1"
   dependencies:
@@ -1382,11 +1383,11 @@ __metadata:
   linkType: hard
 
 "systeminformation@npm:^5.31.1":
-  version: 5.31.7
-  resolution: "systeminformation@npm:5.31.7"
+  version: 5.31.11
+  resolution: "systeminformation@npm:5.31.11"
   bin:
     systeminformation: lib/cli.js
-  checksum: 10c0/0da74c1a74c3db401112abc7b5703aa2f42877558d8db9ce0a08eff7eb2b1a2c9415637adab42a17a25e4bb2075eb92fbba43283fb7ebdb701d9dd25d5c8a531
+  checksum: 10c0/36f35364cdd60704d2f2f95c0da953f1d26b65feeb6806f8e8472c52525d685389a1423e6e803c94b7556b90ce2a04b86ffb9e64ce7cf3f6496e54e26983a64d
   conditions: (os=darwin | os=linux | os=win32 | os=freebsd | os=openbsd | os=netbsd | os=sunos | os=android)
   languageName: node
   linkType: hard

--- a/examples/yarn-modern/.yarnrc.yml
+++ b/examples/yarn-modern/.yarnrc.yml
@@ -2,7 +2,7 @@ enableScripts: true
 
 nodeLinker: node-modules
 
-npmMinimalAgeGate: 3d
+npmMinimalAgeGate: 7d # d = unit of days
 
 npmPreapprovedPackages:
   - cypress

--- a/examples/yarn-modern/yarn.lock
+++ b/examples/yarn-modern/yarn.lock
@@ -1139,11 +1139,12 @@ __metadata:
   linkType: hard
 
 "qs@npm:^6.15.2":
-  version: 6.15.2
-  resolution: "qs@npm:6.15.2"
+  version: 6.15.3
+  resolution: "qs@npm:6.15.3"
   dependencies:
-    side-channel: "npm:^1.1.0"
-  checksum: 10c0/e6fd5f6f0aab06d480fe9ab15cebfc4ce4235303e2f91dc69a8f7f4df1e668a61c11d1cfbabacf4295cbbeb7b670ed23db45307480726259761f98e5695e93a7
+    es-define-property: "npm:^1.0.1"
+    side-channel: "npm:^1.1.1"
+  checksum: 10c0/8f3f6e45ece255347d57696628401cde29e9ec649fff698b53bd3150dea7cefdf33036e1bc1826b9f110bfa7cb0ec4ab9f5297eca628ce216c55af82c304e08e
   languageName: node
   linkType: hard
 
@@ -1238,7 +1239,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"side-channel@npm:^1.1.0":
+"side-channel@npm:^1.1.1":
   version: 1.1.1
   resolution: "side-channel@npm:1.1.1"
   dependencies:
@@ -1382,11 +1383,11 @@ __metadata:
   linkType: hard
 
 "systeminformation@npm:^5.31.1":
-  version: 5.31.7
-  resolution: "systeminformation@npm:5.31.7"
+  version: 5.31.11
+  resolution: "systeminformation@npm:5.31.11"
   bin:
     systeminformation: lib/cli.js
-  checksum: 10c0/0da74c1a74c3db401112abc7b5703aa2f42877558d8db9ce0a08eff7eb2b1a2c9415637adab42a17a25e4bb2075eb92fbba43283fb7ebdb701d9dd25d5c8a531
+  checksum: 10c0/36f35364cdd60704d2f2f95c0da953f1d26b65feeb6806f8e8472c52525d685389a1423e6e803c94b7556b90ce2a04b86ffb9e64ce7cf3f6496e54e26983a64d
   conditions: (os=darwin | os=linux | os=win32 | os=freebsd | os=openbsd | os=netbsd | os=sunos | os=android)
   languageName: node
   linkType: hard


### PR DESCRIPTION
- supports resolution of issue https://github.com/cypress-io/github-action/issues/1816

## Situation

The [renovate.json](https://github.com/cypress-io/github-action/blob/master/renovate.json) configuration includes:

```json
    "minimumReleaseAge": "7 days",
    {
      "matchPackageNames": ["cypress"],
      "minimumReleaseAge": "0 days"
    }
```

Yarn Modern examples are set up with [npmMinimalAgeGate](https://yarnpkg.com/configuration/yarnrc#npmMinimalAgeGate) set to `3d` (3 days).

An exception for `cypress` is in place using [npmPreapprovedPackages](https://yarnpkg.com/configuration/yarnrc#npmPreapprovedPackages).

## Change

In Yarn Modern examples:

- [examples/yarn-modern/.yarnrc.yml](https://github.com/cypress-io/github-action/blob/f39c1b7b4905eabdcb1dd1b7cbb51459ac90449b/examples/yarn-modern/.yarnrc.yml)
- [examples/yarn-modern-pnp/.yarnrc.yml](https://github.com/cypress-io/github-action/blob/f39c1b7b4905eabdcb1dd1b7cbb51459ac90449b/examples/yarn-modern-pnp/.yarnrc.yml)

update [npmMinimalAgeGate](https://yarnpkg.com/configuration/yarnrc#npmMinimalAgeGate):

| BEFORE        | AFTER         |
| ------------- | ------------- |
| `3d` (3 days) | `7d` (7 days) |

Refresh `yarn.lock` files as `yarn up --recursive` does not update transient dependencies as documented.

```shell
rm -rf node_modules # only relevant for non-pnp
rm yarn.lock
touch yarn.lock
yarn
```

## Verification

Using Ubuntu 24.04.4 LTS with Node.js 24.18.0 LTS execute:

```shell
corepack enable yarn
git clean -xfd
cd examples
cd yarn-modern
yarn
cd ..
cd yarn-modern-pnp
yarn
cd ..
cd ..
```

Yarn should complete with no errors or warnings.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Example-only Yarn config and lockfile updates with no production runtime or auth changes.
> 
> **Overview**
> Raises **`npmMinimalAgeGate`** from **`3d`** to **`7d`** in the **`yarn-modern`** and **`yarn-modern-pnp`** example **`.yarnrc.yml`** files (with a short comment on the unit), matching Renovate’s **`minimumReleaseAge: "7 days"`** so example policy stays consistent. The existing **`cypress`** **`npmPreapprovedPackages`** exception is unchanged.
> 
> Both example **`yarn.lock`** files were regenerated; transient bumps include **`qs`** **6.15.2 → 6.15.3** (dependency tweaks on **`side-channel`**) and **`systeminformation`** **5.31.7 → 5.31.11**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4c062a1534fc3729e54512036195a800a234063. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->