### PR TITLE
test: remove Yarn Modern config comments

### DIFF
--- a/examples/yarn-modern-pnp/.yarnrc.yml
+++ b/examples/yarn-modern-pnp/.yarnrc.yml
@@ -1,6 +1,6 @@
 enableScripts: true
 
-npmMinimalAgeGate: 7d # d = unit of days
+npmMinimalAgeGate: 7d
 
 npmPreapprovedPackages:
   - cypress

--- a/examples/yarn-modern/.yarnrc.yml
+++ b/examples/yarn-modern/.yarnrc.yml
@@ -2,7 +2,7 @@ enableScripts: true
 
 nodeLinker: node-modules
 
-npmMinimalAgeGate: 7d # d = unit of days
+npmMinimalAgeGate: 7d
 
 npmPreapprovedPackages:
   - cypress


### PR DESCRIPTION
## Situation

Due to a bug https://github.com/yarnpkg/berry/issues/1463 in Yarn Modern, any update to the version of Yarn Modern causes the config file `yarnrc.yml` of the two Yarn Modern examples to be re-written with comments removed.

## Change

Execute:

[./scripts/update-cypress-latest-yarn.sh](https://github.com/cypress-io/github-action/blob/master/scripts/update-cypress-latest-yarn.sh)

to allow Yarn Modern to reformat `yarnrc.yml`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only edits in example Yarn config; no runtime, security, or dependency behavior changes.
> 
> **Overview**
> Removes the inline comment on **`npmMinimalAgeGate`** in **`examples/yarn-modern/.yarnrc.yml`** and **`examples/yarn-modern-pnp/.yarnrc.yml`**, leaving the value as `7d` with no behavior change.
> 
> This matches how Yarn Modern rewrites **`.yarnrc.yml`** when the toolchain is updated (see [yarnpkg/berry#1463](https://github.com/yarnpkg/berry/issues/1463)), so the example configs stay stable after running the Cypress/Yarn update script instead of churning on comment removal.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc7429d9575a53ec43879a0effa6e396e2bb1c0f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->