### PR TITLE
feat: add Yarn Modern yarn install --immutable

### DIFF
--- a/.github/workflows/example-yarn-modern-pnp.yml
+++ b/.github/workflows/example-yarn-modern-pnp.yml
@@ -28,10 +28,8 @@ jobs:
         run: |
           npm install -g corepack
           corepack enable yarn
-      - name: Custom Yarn command
+      - name: Custom Yarn Modern command
         uses: ./ # if copying, replace with cypress-io/github-action@v7
         with:
           working-directory: examples/yarn-modern-pnp
-          # https://yarnpkg.com/cli/install
-          install-command: yarn install
           command: yarn run --binaries-only cypress run

--- a/.github/workflows/example-yarn-modern.yml
+++ b/.github/workflows/example-yarn-modern.yml
@@ -28,9 +28,7 @@ jobs:
         run: |
           npm install -g corepack
           corepack enable yarn
-      - name: Custom Yarn command
+      - name: Test with Yarn Modern
         uses: ./ # if copying, replace with cypress-io/github-action@v7
         with:
           working-directory: examples/yarn-modern
-          # https://yarnpkg.com/cli/install
-          install-command: yarn install

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ See [Releases](https://github.com/cypress-io/github-action/releases) for full de
 
 | Version | Changes                                                                                                      |
 | ------- | ------------------------------------------------------------------------------------------------------------ |
+| v7.5.0  | Add Yarn Modern `yarn install --immutable`                                                                   |
 | v7.4.0  | Examples remove Node.js 25. End of support for Node.js 25.                                                   |
 | v7.3.0  | Add parameter `expose` for [`Cypress.expose()`](https://docs.cypress.io/api/cypress-api/expose) support      |
 | v7.2.0  | Examples remove Node.js 20. End of support for Node.js 20.                                                   |

--- a/README.md
+++ b/README.md
@@ -1262,7 +1262,7 @@ See the example project [start-and-pnpm-workspaces](examples/start-and-pnpm-work
 
 ### Yarn Classic
 
-If a `yarn.lock` file is found, the action uses the [Yarn 1 (Classic)](https://classic.yarnpkg.com/) command `yarn --frozen-lockfile` by default to install dependencies.
+If a `yarn.lock` file is found, the action uses the [Yarn 1 (Classic)](https://classic.yarnpkg.com/) command `yarn --frozen-lockfile` by default to install dependencies, unless [Yarn Modern](#yarn-modern) is detected.
 
 ```yaml
 name: example-yarn-classic
@@ -1283,7 +1283,7 @@ jobs:
 
 ### Yarn Modern
 
-To install dependencies using a `yarn.lock` file from [Yarn Modern](https://yarnpkg.com/) (Yarn 2 and later) you need to override the default [Yarn 1 (Classic)](https://classic.yarnpkg.com/) installation command `yarn --frozen-lockfile`. You can do this by using the `install-command` parameter and specifying `yarn install` as in the example below.
+If a `yarn.lock` file is found with a Yarn Modern format, the [Yarn Modern install](https://yarnpkg.com/cli/install) command, `yarn install --immutable`, is used to install dependencies.
 
 The action supports built-in caching of Yarn Classic dependencies only. To cache Yarn Modern dependencies additionally use [actions/setup-node](https://github.com/actions/setup-node) and specify `cache: yarn`.
 
@@ -1307,7 +1307,6 @@ jobs:
         uses: cypress-io/github-action@v7
         with:
           working-directory: examples/yarn-modern
-          install-command: yarn install
 ```
 
 This example covers the [`.yarnrc.yml`](https://yarnpkg.com/configuration/yarnrc#nodeLinker) configuration `nodeLinker: node-modules` which Yarn uses by default for projects updated from Yarn Classic. For `nodeLinker: pnp` see [Yarn Plug'n'Play](#yarn-plugnplay) below.
@@ -1325,7 +1324,7 @@ See the above [Yarn Modern](#yarn-modern) section for information on caching Yar
 name: example-yarn-modern-pnp
 on: push
 jobs:
-  yarn-classic:
+  yarn-modern-pnp:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
@@ -1334,7 +1333,6 @@ jobs:
         uses: cypress-io/github-action@v7
         with:
           working-directory: examples/yarn-modern-pnp
-          install-command: yarn install
           command: yarn run --binaries-only cypress run
 ```
 
@@ -1668,8 +1666,7 @@ This action installs local dependencies using lock files. Ensure that exactly on
 | `package-lock.json` | [npm](https://docs.npmjs.com/cli/v9/commands/npm-ci)                                             | `npm ci`                         |
 | `pnpm-lock.yaml`    | [pnpm](https://pnpm.io/cli/install#--frozen-lockfile)                                            | `pnpm install --frozen-lockfile` |
 | `yarn.lock`         | [Yarn Classic](https://classic.yarnpkg.com/en/docs/cli/install#toc-yarn-install-frozen-lockfile) | `yarn --frozen-lockfile`         |
-
-See section [Yarn Modern](#yarn-modern) for information about using Yarn version 2 and later.
+| `yarn.lock`         | [Yarn Modern](https://yarnpkg.com/cli/install)                                                   | `yarn install --immutable`       |
 
 ### Caching
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -101888,14 +101888,9 @@ const packageLockFilename = path.join(
 )
 
 const useYarn = () => fs.existsSync(yarnFilename)
-const isYarnModern = () => {
-  if (!useYarn()) return false
-  const fd = fs.openSync(yarnFilename, 'r')
-  const buffer = Buffer.alloc(256)
-  fs.readSync(fd, buffer, 0, 256, 0)
-  fs.closeSync(fd)
-  return buffer.toString('utf8').includes('__metadata:')
-}
+const isYarnModern = () =>
+  useYarn() &&
+  fs.readFileSync(yarnFilename, 'utf8').includes('__metadata:')
 const usePnpm = () => fs.existsSync(pnpmLockFilename)
 const useNpm = () => fs.existsSync(packageLockFilename)
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -101888,6 +101888,14 @@ const packageLockFilename = path.join(
 )
 
 const useYarn = () => fs.existsSync(yarnFilename)
+const isYarnModern = () => {
+  if (!useYarn()) return false
+  const fd = fs.openSync(yarnFilename, 'r')
+  const buffer = Buffer.alloc(256)
+  fs.readSync(fd, buffer, 0, 256, 0)
+  fs.closeSync(fd)
+  return buffer.toString('utf8').includes('__metadata:')
+}
 const usePnpm = () => fs.existsSync(pnpmLockFilename)
 const useNpm = () => fs.existsSync(packageLockFilename)
 
@@ -102030,15 +102038,27 @@ const install = () => {
   }
 
   if (useYarn()) {
-    debug('installing npm dependencies using Yarn')
-    return io.which('yarn', true).then((yarnPath) => {
-      debug(`yarn at "${yarnPath}"`)
-      return exec.exec(
-        quote(yarnPath),
-        ['--frozen-lockfile'],
-        cypressCommandOptions
-      )
-    })
+    if (isYarnModern()) {
+      debug('installing npm dependencies using Yarn Modern')
+      return io.which('yarn', true).then((yarnPath) => {
+        debug(`yarn at "${yarnPath}"`)
+        return exec.exec(
+          quote(yarnPath),
+          ['install', '--immutable'],
+          cypressCommandOptions
+        )
+      })
+    } else {
+      debug('installing npm dependencies using Yarn Classic')
+      return io.which('yarn', true).then((yarnPath) => {
+        debug(`yarn at "${yarnPath}"`)
+        return exec.exec(
+          quote(yarnPath),
+          ['--frozen-lockfile'],
+          cypressCommandOptions
+        )
+      })
+    }
   } else if (usePnpm()) {
     debug('installing npm dependencies using pnpm')
     return io.which('pnpm', true).then((pnpmPath) => {

--- a/index.js
+++ b/index.js
@@ -103,14 +103,9 @@ const packageLockFilename = path.join(
 )
 
 const useYarn = () => fs.existsSync(yarnFilename)
-const isYarnModern = () => {
-  if (!useYarn()) return false
-  const fd = fs.openSync(yarnFilename, 'r')
-  const buffer = Buffer.alloc(256)
-  fs.readSync(fd, buffer, 0, 256, 0)
-  fs.closeSync(fd)
-  return buffer.toString('utf8').includes('__metadata:')
-}
+const isYarnModern = () =>
+  useYarn() &&
+  fs.readFileSync(yarnFilename, 'utf8').includes('__metadata:')
 const usePnpm = () => fs.existsSync(pnpmLockFilename)
 const useNpm = () => fs.existsSync(packageLockFilename)
 

--- a/index.js
+++ b/index.js
@@ -103,6 +103,14 @@ const packageLockFilename = path.join(
 )
 
 const useYarn = () => fs.existsSync(yarnFilename)
+const isYarnModern = () => {
+  if (!useYarn()) return false
+  const fd = fs.openSync(yarnFilename, 'r')
+  const buffer = Buffer.alloc(256)
+  fs.readSync(fd, buffer, 0, 256, 0)
+  fs.closeSync(fd)
+  return buffer.toString('utf8').includes('__metadata:')
+}
 const usePnpm = () => fs.existsSync(pnpmLockFilename)
 const useNpm = () => fs.existsSync(packageLockFilename)
 
@@ -245,15 +253,27 @@ const install = () => {
   }
 
   if (useYarn()) {
-    debug('installing npm dependencies using Yarn')
-    return io.which('yarn', true).then((yarnPath) => {
-      debug(`yarn at "${yarnPath}"`)
-      return exec.exec(
-        quote(yarnPath),
-        ['--frozen-lockfile'],
-        cypressCommandOptions
-      )
-    })
+    if (isYarnModern()) {
+      debug('installing npm dependencies using Yarn Modern')
+      return io.which('yarn', true).then((yarnPath) => {
+        debug(`yarn at "${yarnPath}"`)
+        return exec.exec(
+          quote(yarnPath),
+          ['install', '--immutable'],
+          cypressCommandOptions
+        )
+      })
+    } else {
+      debug('installing npm dependencies using Yarn Classic')
+      return io.which('yarn', true).then((yarnPath) => {
+        debug(`yarn at "${yarnPath}"`)
+        return exec.exec(
+          quote(yarnPath),
+          ['--frozen-lockfile'],
+          cypressCommandOptions
+        )
+      })
+    }
   } else if (usePnpm()) {
     debug('installing npm dependencies using pnpm')
     return io.which('pnpm', true).then((pnpmPath) => {


### PR DESCRIPTION
- closes https://github.com/cypress-io/github-action/issues/1822

## Situation

If `yarn.lock` is detected, the action installs using `yarn --frozen-lockfile`. Although this works for Yarn v1 Classic and Yarn Modern, it is deprecated for Yarn Modern and causes a warning.

Because of this, the action documentation section [Yarn Modern](https://github.com/cypress-io/github-action/blob/master/README.md#yarn-modern) currently advises using the `install-command` parameter to install Yarn Modern as a workaround.

## Change

If `yarn.lock` is detected, examine the contents of the beginning of the lockfile. Yarn Modern lockfiles typically begin like this:

```yaml
# This file is generated by running "yarn install" inside your project.
# Manual changes might be lost - proceed with caution!

__metadata:
  version: 10
  cacheKey: 10c0
```

If `__metadata:` is detected, Yarn Modern is assumed and `yarn install --immutable` is used. Although `--immutable` is set by default in CI, applying it explicitly makes the intent clearer.

There is no change to the command used to install Yarn v1 Classic, `yarn --frozen-lockfile`, which remains the default after `yarn.lock` detection, in order to avoid a breaking change for Yarn v1 Classic users.

The Yarn Modern workflows are modified to remove the `install-command` parameter workaround:

- [example-yarn-modern.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-yarn-modern.yml)
- [example-yarn-modern-pnp.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-yarn-modern-pnp.yml)

The following [README](https://github.com/cypress-io/github-action#readme) sections are updated to describe the changes:

- [Yarn Modern](https://github.com/cypress-io/github-action#yarn-modern)
- [Yarn Plug'n'Play](https://github.com/cypress-io/github-action#yarn-plugnplay)
- [Installation](https://github.com/cypress-io/github-action#installation)

The [CHANGELOG.md](https://github.com/cypress-io/github-action/blob/master/CHANGELOG.md) is updated with the expected new version `v7.5.0`.

## Verification

### Yarn Classic

Run the workflow [example-yarn-classic.yml](https://github.com/cypress-io/github-action/actions/workflows/example-yarn-classic.yml)

Confirm that installation step "Test with Yarn Classic" shows the following and is successful:

```console
/usr/local/bin/yarn --frozen-lockfile
```

### Yarn Modern

Run the workflow [example-yarn-modern.yml](https://github.com/cypress-io/github-action/actions/workflows/example-yarn-modern.yml)

Confirm that installation step "Test with Yarn Modern" shows the following and is successful:

```console
/opt/hostedtoolcache/node/24.18.0/x64/bin/yarn install --immutable
```

### Yarn Modern pnp

Run the workflow [example-yarn-modern-pnp.yml](https://github.com/MikeMcC399/github-action/actions/workflows/example-yarn-modern-pnp.yml)

Confirm that installation step "Test with Yarn Modern" shows the following and is successful:

```console
/opt/hostedtoolcache/node/24.18.0/x64/bin/yarn install --immutable
```

Note that verification continues to use `npx` to test potentially the wrong version of Cypress in Yarn Modern pnp. This was described in issue https://github.com/cypress-io/github-action/issues/971 and is not targeted for a fix. [Cypress documentation](https://docs.cypress.io/app/get-started/install-cypress#Yarn-users) prefers the `node-modules` setting for Yarn Modern, and notes that `pnp` is not compatible with Cypress component testing.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Install-path change is limited to Yarn Modern lockfiles and preserves Classic behavior; mis-detection is unlikely given the `__metadata` marker.
> 
> **Overview**
> When a `yarn.lock` is present, the action now **detects Yarn Modern** by looking for `__metadata:` in the first bytes of the lockfile. Modern projects get **`yarn install --immutable`** by default; **Yarn Classic still uses `yarn --frozen-lockfile`**, so existing v1 behavior is unchanged.
> 
> Docs and **v7.5.0** changelog describe the new default. **Yarn Modern example workflows** no longer need the `install-command: yarn install` workaround; the PnP example only keeps its custom `command` for running Cypress.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1515e840845e4fda262edad21c7e28eb9d25ab48. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->