### PR TITLE
test(deps): update actions/setup-node to v7

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
       - name: Install Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           # Action runs: using: node24 as defined in
           # https://github.com/cypress-io/github-action/blob/master/action.yml

--- a/.github/workflows/example-basic-pnpm.yml
+++ b/.github/workflows/example-basic-pnpm.yml
@@ -30,7 +30,7 @@ jobs:
 
         # See https://github.com/actions/setup-node
       - name: Install Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version-file: '.node-version'
           cache: pnpm

--- a/.github/workflows/example-basic.yml
+++ b/.github/workflows/example-basic.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version-file: .node-version
           cache: npm

--- a/.github/workflows/example-node-versions.yml
+++ b/.github/workflows/example-node-versions.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
       - name: Install Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ matrix.node }}
       - run: node -v

--- a/.github/workflows/example-start-and-pnpm-workspaces.yml
+++ b/.github/workflows/example-start-and-pnpm-workspaces.yml
@@ -36,7 +36,7 @@ jobs:
 
         # See https://github.com/actions/setup-node
       - name: Install Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version-file: '.node-version'
           cache: pnpm
@@ -87,7 +87,7 @@ jobs:
           version: 11
 
       - name: Install Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version-file: '.node-version'
           cache: pnpm

--- a/.github/workflows/example-yarn-classic.yml
+++ b/.github/workflows/example-yarn-classic.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version-file: .node-version
           cache: yarn

--- a/.github/workflows/example-yarn-modern-pnp.yml
+++ b/.github/workflows/example-yarn-modern-pnp.yml
@@ -19,7 +19,7 @@ jobs:
           npm install -g corepack
           corepack enable yarn
       - name: Set up Yarn cache
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version-file: '.node-version'
           cache: yarn

--- a/.github/workflows/example-yarn-modern.yml
+++ b/.github/workflows/example-yarn-modern.yml
@@ -19,7 +19,7 @@ jobs:
           npm install -g corepack
           corepack enable yarn
       - name: Set up Yarn cache
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version-file: '.node-version'
           cache: yarn

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
       - name: Install Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           # Action runs: using: node24 as defined in
           # https://github.com/cypress-io/github-action/blob/master/action.yml

--- a/README.md
+++ b/README.md
@@ -598,7 +598,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
       - name: Install Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ matrix.node }}
       - run: node -v
@@ -1218,7 +1218,7 @@ jobs:
         with:
           version: 11
       - name: Install Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: 24
           cache: 'pnpm'
@@ -1298,7 +1298,7 @@ jobs:
         uses: actions/checkout@v7
       - run: corepack enable # (experimental and optional)
       - name: Set up Yarn cache
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: 24
           cache: yarn
@@ -1391,7 +1391,7 @@ jobs:
     name:
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: lts
           cache: 'pnpm'
@@ -1423,7 +1423,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
       - name: Install Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ matrix.node }}
       # run Cypress tests and record them under the same run
@@ -1458,7 +1458,7 @@ jobs:
     name: E2E on Node v${{ matrix.node }}
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: ${{ matrix.node }}
       - uses: cypress-io/github-action@v7


### PR DESCRIPTION
## Situation

Workflows and examples currently use the GitHub Actions [actions/setup-node](https://github.com/actions/setup-node) version [v6](https://github.com/actions/setup-node/tree/v6).

GitHub has released [actions/setup-node@v7](https://github.com/actions/setup-node/releases/tag/v7.0.0) with updated caching.

## Change

Update all usage of [actions/setup-node](https://github.com/actions/setup-node) in examples and documentation

| BEFORE                                                                 | AFTER                                                                  |
| ---------------------------------------------------------------------- | ---------------------------------------------------------------------- |
| [actions/setup-node@v6](https://github.com/actions/setup-node/tree/v6) | [actions/setup-node@v7](https://github.com/actions/setup-node/tree/v7) |

## Comment

This is a manual update because Renovate only updates workflow, not the corresponding documentation, which would leave the runnable examples out of sync with the documentation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only bump in CI and docs; no application or Cypress action logic changes, though v7’s caching behavior could affect workflow cache hits until caches warm again.
> 
> **Overview**
> Bumps **`actions/setup-node`** from **v6** to **v7** everywhere Node is installed in CI and in copy-paste examples.
> 
> Workflows under `.github/workflows/` (`main`, `check-dist`, and the `example-*` jobs for npm, pnpm, Yarn Classic/Modern, and Node version matrices) now reference **`actions/setup-node@v7`**. Existing `with:` settings (Node version, `cache`, `cache-dependency-path`) are unchanged.
> 
> **README.md** workflow snippets are updated the same way so documentation stays aligned with the runnable workflows (pnpm, Yarn Modern, package-manager caching, Node versions, tags).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22ff43184e0659adebeecaba3046a58683bddcdd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->