### PR TITLE
docs: update README to actions/cache@v6

### DIFF
--- a/README.md
+++ b/README.md
@@ -1555,7 +1555,7 @@ If the project has many dependencies, but you want to install just Cypress you c
 
 ```yml
 - uses: actions/checkout@v7
-- uses: actions/cache@v5
+- uses: actions/cache@v6
   with:
     path: |
       ~/.cache/Cypress


### PR DESCRIPTION
## Situation

- PR https://github.com/cypress-io/github-action/pull/1812 bumped to `actions/cache@v6` in the workflow [example-install-only.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-install-only.yml) only, without updating [README > Install Cypress only](https://github.com/cypress-io/github-action/tree/master#install-cypress-only).

This is outside the capabilities of Renovate and has to be handled manually.

## Change

- Update [README > Install Cypress only](https://github.com/cypress-io/github-action/tree/master#install-cypress-only) to `actions/cache@v6`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to a README code sample; no CI or application code is modified.
> 
> **Overview**
> Aligns the **Install Cypress only** README workflow snippet with the repo’s live example workflow by bumping **`actions/cache` from `v5` to `v6`**.
> 
> No runtime or action behavior changes—only the documented copy-paste YAML for manual Cypress-only install + cache.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6622c7430c60e3c927cf0ba45b702a1d46ea714f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->