### PR TITLE
test: extend Firefox example to ubuntu-24.04-arm

### DIFF
--- a/.github/workflows/example-firefox.yml
+++ b/.github/workflows/example-firefox.yml
@@ -10,7 +10,13 @@ permissions:
 
 jobs:
   firefox:
-    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-24.04
+          - ubuntu-24.04-arm
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -27,7 +33,7 @@ jobs:
       # report screenshot size and store the screenshots as test artifacts
       - uses: actions/upload-artifact@v7
         with:
-          name: screenshots-in-firefox
+          name: screenshots-in-firefox-${{ matrix.os }}
           path: examples/browser/cypress/screenshots
 
       - run: npx image-size cypress/screenshots/**/*.png


### PR DESCRIPTION
## Situation

The GitHub Actions runner image [ubuntu-24.04-arm](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Arm64-Readme.md#browsers-and-drivers) contains browsers:

- Selenium server 4.47.0
- Mozilla Firefox 153.0.3
- Geckodriver 0.37.1

The example workflow [.github/workflows/example-firefox.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-firefox.yml) only tests against [ubuntu-24.04](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md#browsers-and-drivers) not [ubuntu-24.04-arm](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Arm64-Readme.md#browsers-and-drivers).

## Change

Add a matrix to the example workflow [.github/workflows/example-firefox.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-firefox.yml) and test in addition:

- Firefox running under [ubuntu-24.04-arm](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Arm64-Readme.md#browsers-and-drivers)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow matrix change with no application or runtime behavior impact.
> 
> **Overview**
> Extends the **example-firefox** workflow so Cypress Firefox runs on both **ubuntu-24.04** and **ubuntu-24.04-arm**, matching the ARM coverage pattern used in other example workflows.
> 
> Adds a `strategy.matrix` with `fail-fast: false`, sets `runs-on` from `matrix.os`, and suffixes screenshot upload artifacts with `${{ matrix.os }}` so x64 and ARM runs don’t overwrite each other.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0614c8948288ff7848cece0519da1760c1bc42cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->