### PR TITLE
test: extend Docker example to ubuntu-24.04-arm

### DIFF
--- a/.github/workflows/example-docker.yml
+++ b/.github/workflows/example-docker.yml
@@ -10,15 +10,25 @@ permissions:
 
 jobs:
   docker-browsers:
-    runs-on: ubuntu-24.04
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        browser: [chrome, edge, electron, firefox]
+        os:
+          - ubuntu-24.04
+          - ubuntu-24.04-arm
+        browser:
+          # Available browsers listed on https://github.com/cypress-io/cypress-docker-images#browsers
+          - chrome
+          - edge
+          - electron
+          - firefox
+        exclude:
+          - os: ubuntu-24.04-arm
+            browser: edge # not available for Linux/arm64
     # Cypress Docker image documentation on https://github.com/cypress-io/cypress-docker-images
-    # Available cypress/browsers tags listed on https://hub.docker.com/r/cypress/browsers/tags
     container:
-      image: cypress/browsers:24.18.1
+      image: cypress/browsers:24.19.0
       options: --user 1001
     steps:
       - name: Checkout


### PR DESCRIPTION
## Situation

The [cypress/browsers](https://github.com/cypress-io/cypress-docker-images/tree/master/browsers#readme) Docker image contains browsers for both Linux/amd64 and Linux/arm64. Now only Edge is missing on Linux/arm64:

| Browser | Linux/amd64 | Linux/arm64 |
| ------- | ----------- | ----------- |
| Chrome  | YES         | YES         |
| Edge    | YES         | -           |
| Firefox | YES         | YES         |

The example workflow [.github/workflows/example-docker.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-docker.yml) only tests against [ubuntu-24.04](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md#browsers-and-drivers) not [ubuntu-24.04-arm](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Arm64-Readme.md#browsers-and-drivers).

## Change

Extend the matrix in the example workflow [.github/workflows/example-docker.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-docker.yml) to test also under [ubuntu-24.04-arm](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Arm64-Readme.md#browsers-and-drivers), excluding Edge (due to unavailability under Linux/arm64).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only affect an example GitHub Actions workflow and Docker image tag; no runtime or application code is modified.
> 
> **Overview**
> The **example Docker** workflow (`.github/workflows/example-docker.yml`) now runs Cypress browser tests on both **ubuntu-24.04** and **ubuntu-24.04-arm** via a matrix `os` dimension, with `runs-on` set to `${{ matrix.os }}`.
> 
> **Edge** is excluded on **ubuntu-24.04-arm** because it is not available on Linux/arm64 in the Cypress browsers image. The job container image is bumped from `cypress/browsers:24.18.1` to **`24.19.0`**, with minor comment tweaks around browser availability docs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7e8be6b42997204d1597cff901e9339a8c1ebae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->