### PR TITLE
fix(deps): update @vercel/ncc to 0.45.0

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -102055,6 +102055,9 @@ module.exports = /*#__PURE__*/JSON.parse('{"name":"@actions/cache","version":"5.
 /******/ 	}
 /******/ 	
 /************************************************************************/
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
+/******/ 	
 /******/ 	/* webpack/runtime/define property getters */
 /******/ 	(() => {
 /******/ 		// define getter functions for harmony exports
@@ -102082,10 +102085,6 @@ module.exports = /*#__PURE__*/JSON.parse('{"name":"@actions/cache","version":"5.
 /******/ 			Object.defineProperty(exports, '__esModule', { value: true });
 /******/ 		};
 /******/ 	})();
-/******/ 	
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
 /******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "@eslint/js": "10.0.1",
         "@stylistic/eslint-plugin": "5.10.0",
         "@types/node": "25.9.4",
-        "@vercel/ncc": "0.44.1",
+        "@vercel/ncc": "0.45.0",
         "eslint": "10.8.0",
         "eslint-plugin-cypress": "6.4.3",
         "globals": "17.9.0",
@@ -989,9 +989,9 @@
       }
     },
     "node_modules/@vercel/ncc": {
-      "version": "0.44.1",
-      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.44.1.tgz",
-      "integrity": "sha512-cUjIE5P2YY1n+Kt9rFIazMMpGoPn1Fic04rOmTkElMkiDP5oszGfERMpo2shVkFKDL7rVppdM2pqJKC59shQWQ==",
+      "version": "0.45.0",
+      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.45.0.tgz",
+      "integrity": "sha512-8zPi1yO2mHpoKTD+e+Bf0ZT3e+sWHSOyGapm9s7b5R0gxJi3CiFTqmeQiMEyu6ejrz2s09M8JkEoUaTWjBJPQQ==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@eslint/js": "10.0.1",
     "@stylistic/eslint-plugin": "5.10.0",
     "@types/node": "25.9.4",
-    "@vercel/ncc": "0.44.1",
+    "@vercel/ncc": "0.45.0",
     "eslint": "10.8.0",
     "eslint-plugin-cypress": "6.4.3",
     "globals": "17.9.0",


### PR DESCRIPTION
- Supersedes Renovate PR https://github.com/cypress-io/github-action/pull/1864

## Situation

The currently used [@vercel/ncc@0.44.1](https://github.com/vercel/ncc/releases/tag/0.44.1), which compiles action components into a single file, was released on Jun 29, 2026.

In the meantime [@vercel/ncc@0.45.0](https://github.com/vercel/ncc/releases/tag/0.45.0) is the `latest` version, released on Aug 13, 2026.

Renovate attempted to update this dependency in https://github.com/cypress-io/github-action/pull/1864, however this was unsuccessful, since Renovate did not have the ability to re-build the action, necessary after updating the dependency `@vercel/ncc`.

## Change

Update npm package [@vercel/ncc](https://www.npmjs.com/package/@vercel/ncc) to `latest` version:

| Package                                                  | From                                                                    | To                                                                      |
| -------------------------------------------------------- | ----------------------------------------------------------------------- | ----------------------------------------------------------------------- |
| [@vercel/ncc](https://www.npmjs.com/package/@vercel/ncc) | [@vercel/ncc@0.44.1](https://github.com/vercel/ncc/releases/tag/0.44.1) | [@vercel/ncc@0.45.0](https://github.com/vercel/ncc/releases/tag/0.45.0) |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev-only bundler upgrade with a regenerated dist bundle; no changes to action logic or dependencies shipped at runtime beyond the build artifact.
> 
> **Overview**
> Bumps the **`@vercel/ncc`** dev dependency from **0.44.1** to **0.45.0** and re-runs the bundle so **`dist/index.js`** matches the new compiler.
> 
> The committed bundle diff is limited to **webpack/ncc runtime** output (e.g. **`asset-relocator-loader`** / **`__nccwpck_require__.ab`** placement). **No action source or runtime behavior** changes are introduced—only the build toolchain and its generated single-file artifact.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66aac9620ccc82411db27f58d287aacf1f4c900b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->