### PR TITLE
test(deps): add npm@latest to node-versions example

### DIFF
--- a/.github/workflows/example-node-versions.yml
+++ b/.github/workflows/example-node-versions.yml
@@ -19,14 +19,19 @@ jobs:
           - 22
           - 24
           - 26
-    name: Cypress E2E on Node v${{ matrix.node }}
+          - latest
+    name: Cypress E2E on Node.js ${{ matrix.node }}
     steps:
       - name: Checkout
         uses: actions/checkout@v7
       - name: Install Node.js
+        # https://github.com/actions/setup-node
         uses: actions/setup-node@v7
         with:
           node-version: ${{ matrix.node }}
+      - if: matrix.node == 'latest'
+        # test with bundled version of npm, except for with Node.js latest
+        run: npm install -g npm@latest
       - run: node -v
       - run: npm -v
 


### PR DESCRIPTION
## Situation

- [npm@12.0.0](https://github.com/npm/cli/releases/tag/v12.0.0) was released on Jul 8, 2026 and includes multiple breaking changes. It is not bundled into currently supported Node.js release lines. The Node.js Releasers Team decided against backporting it to Node.js 26 and below.
- Since it is not bundled, it is also not otherwise tested in the action examples.
- It may however be independently upgraded in workflows by users.

## Change

Using the Node.js version alias `latest`, test also under `npm@latest`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only matrix expansion for an example workflow; no action runtime, auth, or product logic changes.
> 
> **Overview**
> Extends the node-versions example workflow so Cypress E2E also runs on Node.js `latest`, not only 22/24/26.
> 
> On that matrix entry it globally installs `npm@latest` (npm 12+ is not bundled in current Node lines), then still prints `node`/`npm` versions before running the example tests. Job names now say “Node.js”.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ccec17df0525d4d9d07fc5fcda1e6338fe7d86e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->