### PR TITLE
test(deps): remove unsupported image-size from examples

### DIFF
--- a/.github/workflows/example-chrome.yml
+++ b/.github/workflows/example-chrome.yml
@@ -43,9 +43,6 @@ jobs:
           name: screenshots-headless-chrome
           path: examples/browser/cypress/screenshots
 
-      - run: npx image-size cypress/screenshots/**/*.png
-        working-directory: examples/browser
-
       - name: Chrome headed
         uses: ./
         with:
@@ -60,6 +57,3 @@ jobs:
         with:
           name: screenshots-headed-chrome
           path: examples/browser/cypress/screenshots
-
-      - run: npx image-size cypress/screenshots/**/*.png
-        working-directory: examples/browser

--- a/.github/workflows/example-firefox.yml
+++ b/.github/workflows/example-firefox.yml
@@ -35,6 +35,3 @@ jobs:
         with:
           name: screenshots-in-firefox-${{ matrix.os }}
           path: examples/browser/cypress/screenshots
-
-      - run: npx image-size cypress/screenshots/**/*.png
-        working-directory: examples/browser

--- a/examples/browser/package-lock.json
+++ b/examples/browser/package-lock.json
@@ -6,10 +6,8 @@
   "packages": {
     "": {
       "name": "example-browser",
-      "version": "2.0.0",
       "devDependencies": {
-        "cypress": "15.21.1",
-        "image-size": "2.0.2"
+        "cypress": "15.21.1"
       }
     },
     "node_modules/@cypress/request": {
@@ -1104,19 +1102,6 @@
         }
       ],
       "license": "BSD-3-Clause"
-    },
-    "node_modules/image-size": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/image-size/-/image-size-2.0.2.tgz",
-      "integrity": "sha512-IRqXKlaXwgSMAMtpNzZa1ZAe8m+Sa1770Dhk8VkSsP9LS+iHD62Zd8FQKs8fbPiagBE7BzoFX23cxFnwshpV6w==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "image-size": "bin/image-size.js"
-      },
-      "engines": {
-        "node": ">=16.x"
-      }
     },
     "node_modules/ini": {
       "version": "2.0.0",

--- a/examples/browser/package.json
+++ b/examples/browser/package.json
@@ -1,9 +1,7 @@
 {
   "name": "example-browser",
-  "version": "2.0.0",
   "description": "running Cypress using different browsers",
   "type": "module",
-  "main": "index.js",
   "scripts": {
     "test": "npm run cy:run",
     "info": "cypress info",
@@ -14,8 +12,7 @@
   },
   "private": true,
   "devDependencies": {
-    "cypress": "15.21.1",
-    "image-size": "2.0.2"
+    "cypress": "15.21.1"
   },
   "allowScripts": {
     "cypress": true

--- a/examples/quiet/package-lock.json
+++ b/examples/quiet/package-lock.json
@@ -6,10 +6,8 @@
   "packages": {
     "": {
       "name": "example-quiet",
-      "version": "2.0.0",
       "devDependencies": {
-        "cypress": "15.21.1",
-        "image-size": "2.0.2"
+        "cypress": "15.21.1"
       }
     },
     "node_modules/@cypress/request": {
@@ -1104,19 +1102,6 @@
         }
       ],
       "license": "BSD-3-Clause"
-    },
-    "node_modules/image-size": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/image-size/-/image-size-2.0.2.tgz",
-      "integrity": "sha512-IRqXKlaXwgSMAMtpNzZa1ZAe8m+Sa1770Dhk8VkSsP9LS+iHD62Zd8FQKs8fbPiagBE7BzoFX23cxFnwshpV6w==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "image-size": "bin/image-size.js"
-      },
-      "engines": {
-        "node": ">=16.x"
-      }
     },
     "node_modules/ini": {
       "version": "2.0.0",

--- a/examples/quiet/package.json
+++ b/examples/quiet/package.json
@@ -1,17 +1,14 @@
 {
   "name": "example-quiet",
-  "version": "2.0.0",
   "description": "running Cypress with quiet flag",
   "type": "module",
-  "main": "index.js",
   "scripts": {
     "test": "cypress run",
     "info": "cypress info"
   },
   "private": true,
   "devDependencies": {
-    "cypress": "15.21.1",
-    "image-size": "2.0.2"
+    "cypress": "15.21.1"
   },
   "allowScripts": {
     "cypress": true


### PR DESCRIPTION
## Situation

- `npm audit` reports high severity vulnerabilities https://github.com/advisories/GHSA-w3rx-r6r6-pgpr and https://github.com/advisories/GHSA-5p2g-fcmc-qvqq for npm package [image-size](https://www.npmjs.com/package/image-size) used in examples.

```console
$ npm audit
# npm audit report

image-size  *
Severity: high
image-size: ICNS parser allows denial of service through an infinite loop - https://github.com/advisories/GHSA-w3rx-r6r6-pgpr
image-size: JXL and HEIF parsers allow denial of service through infinite loops - https://github.com/advisories/GHSA-5p2g-fcmc-qvqq
No fix available
node_modules/image-size

1 high severity vulnerability

Some issues need review, and may require choosing
a different dependency.
```

- The [image-size](https://github.com/image-size/image-size) repo was archived on Jun 3, 2026 meaning that it is no longer supported.

It is used in:

- [examples/browser](https://github.com/cypress-io/github-action/tree/master/examples/browser)
- [examples/quiet](https://github.com/cypress-io/github-action/tree/master/examples/quiet)
- [.github/workflows/example-chrome.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-chrome.yml)
- [.github/workflows/example-firefox.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-firefox.yml)

## Change

- Remove [image-size](https://github.com/image-size/image-size) from the examples, without replacement.

Also tidied up corresponding example `package.json` contents:
- remove `version` - only relevant if the private package were to be published
- remove `main` - referred to non-existent `index.js`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Example-only dependency and workflow cleanup with no runtime or security-sensitive path changes.
> 
> **Overview**
> Removes the archived **`image-size`** dependency from the `examples/browser` and `examples/quiet` packages and drops the CI steps that ran `npx image-size` on Cypress screenshots in **`example-chrome`** and **`example-firefox`**. Screenshot artifacts are still uploaded; only the dimension-reporting step is gone.
> 
> Example **`package.json`** files are also trimmed by removing unused **`version`** and **`main`** fields that pointed at a non-existent entry file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a713f0279cbf3ef53e48a7df48b9e5290235b047. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->