### PR TITLE
chore(deps): set npm min-release-age to 7 days

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,4 @@
 save-exact=true
 package-lock=true
+min-release-age=7
+min-release-age-exclude[]="cypress"


### PR DESCRIPTION
- supports resolution of issue https://github.com/cypress-io/github-action/issues/1816

## Situation

The [renovate.json](https://github.com/cypress-io/github-action/blob/master/renovate.json) configuration includes:

```json
    "minimumReleaseAge": "7 days",
    {
      "matchPackageNames": ["cypress"],
      "minimumReleaseAge": "0 days"
    }
```

npm is not yet set up for [min-release-age](https://docs.npmjs.com/cli/v11/using-npm/config#min-release-age)

- [min-release-age](https://docs.npmjs.com/cli/v11/using-npm/config#min-release-age) available since [npm@11.10.0](https://github.com/npm/cli/releases/tag/v11.10.0)
- [min-release-age-exclude](https://docs.npmjs.com/cli/v11/using-npm/config#min-release-age-exclude) available in [npm@11.17.0](https://github.com/npm/cli/releases/tag/v11.17.0)

## Change

Add settings to the root [.npmrc](https://github.com/cypress-io/github-action/blob/master/.npmrc) configuration:

```text
min-release-age=7
min-release-age-exclude[]="cypress"
```

## Verification

Using Ubuntu 24.04.4 LTS with Node.js 24.19.0 LTS execute:

```shell
npm ci
./scripts/update-cypress-latest-npm.sh
```

There should be no errors and Cypress should be (temporarily) updated to `16.0.0`. Not committed in this PR though.


## Reference

- [min-release-age](https://docs.npmjs.com/cli/v11/using-npm/config#min-release-age) available since [npm@11.10.0](https://github.com/npm/cli/releases/tag/v11.10.0)
- [min-release-age-exclude](https://docs.npmjs.com/cli/v11/using-npm/config#min-release-age-exclude) available in [npm@11.17.0](https://github.com/npm/cli/releases/tag/v11.17.0) bundled in [Node.js 24.19.0](https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V24.md#24.19.0)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only change to dependency install policy; no application or CI script logic is modified.
> 
> **Overview**
> Adds **npm `min-release-age`** settings to the root `.npmrc` so local `npm install` / `npm ci` match Renovate’s **7-day** wait before pulling newly published packages.
> 
> **`cypress`** is excluded via `min-release-age-exclude[]`, so Cypress can still resolve to the latest release immediately (same exception as in `renovate.json`). Requires npm 11.10+ / 11.17+ for the exclude list, as noted in the PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab1eda62688001b7b6cb46a0fac326c1da4b127a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->