### PR TITLE
test: use Docker image cypress/browsers in parallel record examples

### DIFF
--- a/.github/workflows/example-custom-ci-build-id.yml
+++ b/.github/workflows/example-custom-ci-build-id.yml
@@ -77,6 +77,9 @@ jobs:
   smoke-tests:
     needs: [prepare]
     runs-on: ubuntu-24.04
+    container:
+      image: cypress/browsers:24.20.0
+      options: --user 1001
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -107,7 +110,10 @@ jobs:
       fail-fast: false
       matrix:
         # run 2 copies of the current job in parallel
-        containers: [1, 2]
+        recording-job: [1, 2]
+    container:
+      image: cypress/browsers:24.20.0
+      options: --user 1001
     steps:
       - name: Checkout
         uses: actions/checkout@v7

--- a/.github/workflows/example-recording.yml
+++ b/.github/workflows/example-recording.yml
@@ -49,8 +49,13 @@ jobs:
       fail-fast: false
       matrix:
         # run copies of the current job in parallel
-        containers: [1, 2]
+        recording-job: [1, 2] # the name of the matrix variable is arbitrary, we just need two copies of the job
     if: needs.check-record-key.outputs.record-key-exists == 'true'
+    # Use a Cypress Docker image with browsers pre-installed
+    # to ensure that the tests run in the same consistent environment across each parallel run
+    container:
+      image: cypress/browsers:24.20.0
+      options: --user 1001
     steps:
       - name: Checkout
         uses: actions/checkout@v7

--- a/README.md
+++ b/README.md
@@ -753,7 +753,9 @@ jobs:
 
 **Note:** Cypress parallelization requires a [Cypress Cloud](https://on.cypress.io/cloud-introduction) account.
 
-You can spin multiple containers running in parallel using `strategy: matrix` argument. Just add more dummy items to the `containers: [1, 2, ...]` array to spin more free or paid containers. Then use `record` and `parallel` parameters to [load balance tests](https://on.cypress.io/parallelization).
+You can spin multiple jobs running in parallel using the `strategy: matrix` argument.
+Just add more dummy items to the `recording-job: [1, 2, ...]` array to create multiple job runs.
+Then use `record` and `parallel` parameters to [load balance tests](https://on.cypress.io/parallelization).
 
 ```yml
 name: Parallel Cypress Tests
@@ -770,13 +772,16 @@ jobs:
       fail-fast: false
       matrix:
         # run 3 copies of the current job in parallel
-        containers: [1, 2, 3]
+        recording-job: [1, 2, 3]
+    container:
+      image: cypress/browsers:latest
+      options: --user 1001
     steps:
       - name: Checkout
         uses: actions/checkout@v7
 
       # because of "record" and "parallel" parameters
-      # these containers will load balance all found tests among themselves
+      # these jobs will load balance all found tests among themselves
       - name: Cypress run
         uses: cypress-io/github-action@v7
         with:
@@ -786,14 +791,18 @@ jobs:
         env:
           # pass the Cypress Cloud record key as an environment variable
           CYPRESS_RECORD_KEY: ${{ secrets.EXAMPLE_RECORDING_KEY }}
-          # Recommended: pass the GitHub token lets this action correctly
+          # Recommended: passing the GitHub token lets this action correctly
           # determine the unique run id necessary to re-run the checks
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
 
 ![Parallel run](images/parallel.png)
 
-The Cypress GH Action does not spawn or create any additional containers - it only links the multiple containers spawned using the matrix strategy into a single logical Cypress Cloud run where it splits the specs amongst the machines. See the [Cypress Cloud Smart Orchestration](https://docs.cypress.io/cloud/features/smart-orchestration/overview/) guide for a detailed explanation.
+The Cypress GitHub Action does not spawn or create any additional jobs -
+it only links the multiple jobs spawned using the matrix strategy into a single logical Cypress Cloud run
+where it splits the specs amongst the machines.
+See the [Cypress Cloud Smart Orchestration](https://docs.cypress.io/cloud/features/smart-orchestration/overview/) guide
+for a detailed explanation.
 
 If you use the GitHub Actions facility for [Re-running workflows and jobs](https://docs.github.com/en/actions/managing-workflow-runs/re-running-workflows-and-jobs), note that [Re-running failed jobs in a workflow](https://docs.github.com/en/actions/managing-workflow-runs/re-running-workflows-and-jobs?tool=webui#re-running-failed-jobs-in-a-workflow) is not suited for use with parallel recording into Cypress Cloud. Re-running failed jobs in this situation does not simply re-run failed Cypress tests. Instead it re-runs **all** Cypress tests, load-balanced over the containers with failed jobs.
 
@@ -802,7 +811,17 @@ To optimize runs when there are failing tests present, refer to optional [Cypres
 - [Spec Prioritization](https://docs.cypress.io/cloud/features/smart-orchestration/spec-prioritization)
 - [Auto Cancellation](https://docs.cypress.io/guides/cloud/smart-orchestration/run-cancellation). See also [Auto cancel after failures](#auto-cancel-after-failures) for details of how to set this option in a Cypress GitHub Action workflow.
 
-During staged rollout of a new GitHub-hosted runner version, GitHub may provide a mixture of current and new image versions used by the container matrix. It is recommended to use a [Docker image](#docker-image) in the parallel job run which avoids any Cypress Cloud errors due to browser major version mismatch from the two different image versions. A [Docker image](#docker-image) is not necessary if testing against the default built-in Electron browser because this browser version is fixed by the Cypress version in use and it is unaffected by any GitHub runner image rollout.
+During staged rollout of a new [GitHub-hosted runner image](https://github.com/actions/runner-images#readme) version,
+GitHub may provide a mixture of current and new image versions used by the job matrix.
+When running parallel jobs under GitHub-hosted Ubuntu runner images,
+it is recommended to use a [Docker image](#docker-image)
+to avoid any Cypress Cloud errors due to browser major version mismatch between the current and new image versions.
+
+Avoid using parallel jobs with GitHub-hosted macOS or Windows runner images,
+since there is currently no workaround for the deployment mismatch issue.
+On macOS the problem can also occur when there is an upgrade to the macOS version.
+
+[![recording example](https://github.com/cypress-io/github-action/actions/workflows/example-recording.yml/badge.svg)](.github/workflows/example-recording.yml)
 
 ### Component and E2E Testing
 
@@ -1065,7 +1084,10 @@ jobs:
     strategy:
       matrix:
         # run 3 copies of the current job in parallel
-        containers: [1, 2, 3]
+        recording-job: [1, 2, 3]
+    container:
+      image: cypress/browsers:latest
+      options: --user 1001
     steps:
       - uses: actions/checkout@v7
       - uses: cypress-io/github-action@v7
@@ -1101,6 +1123,9 @@ jobs:
         run: echo "value=sha-$GITHUB_SHA-time-$(date +"%s")" >> $GITHUB_OUTPUT
   smoke-tests:
     needs: ['prepare']
+    container:
+      image: cypress/browsers:latest
+      options: --user 1001
     steps:
       - uses: actions/checkout@v7
       - uses: cypress-io/github-action@v7


### PR DESCRIPTION
- closes https://github.com/cypress-io/github-action/issues/1772

## Situation

[Cypress 16.0.0](https://docs.cypress.io/app/references/changelog#16-0-0) deprecates the built-in Electron browser.

As described in https://github.com/cypress-io/github-action/pull/1727 and in the README documentation [Parallel](https://github.com/cypress-io/github-action#parallel) section, parallel recording into Cypress Cloud using browsers provided by [GitHub Actions runners](https://github.com/actions/runner-images) can cause version mismatch errors during runner deployments that may span several days.

The advice has been to use a Cypress Docker image to ensure consistent versions across parallel runs.

Note that this is only applicable to Ubuntu runner images. Docker containers cannot run under macOS or Windows on GitHub Actions.

## Change

Update Cypress Cloud recording examples to use the [cypress/browsers](https://github.com/cypress-io/cypress-docker-images/tree/master/browsers#readme) Docker image.

Rename the `strategy: matrix` parameter from `container` to `recording-job` to avoid confusion with the Docker container.

- [README > Parallel](https://github.com/cypress-io/github-action#parallel)
- [.github/workflows/example-custom-ci-build-id.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-custom-ci-build-id.yml)
- [.github/workflows/example-recording.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-recording.yml)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and example workflow YAML only; no changes to the action runtime or user-facing API behavior.
> 
> **Overview**
> Updates **parallel Cypress Cloud recording** guidance and live examples to run matrix jobs inside **`cypress/browsers`** Docker (`options: --user 1001`) so parallel runs share consistent browser versions during GitHub-hosted Ubuntu runner rollouts.
> 
> Renames the matrix dimension from **`containers`** to **`recording-job`** to distinguish GitHub Actions job copies from the job’s Docker **`container`**. README **Parallel**, **Custom build id**, and **Robust custom build id** snippets match the workflow changes and add clearer notes to prefer Docker on Ubuntu parallel recording and to avoid parallel recording on macOS/Windows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fda44218e57b4471493a6b79910c9a3feed146a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->