### PR TITLE
test: set defaultBrowser to chrome

### DIFF
--- a/.github/workflows/example-basic.yml
+++ b/.github/workflows/example-basic.yml
@@ -41,6 +41,7 @@ jobs:
         # because we are running these examples in a monorepo
         with:
           working-directory: examples/basic
+          browser: ${{ contains(matrix.os, 'ubuntu') && contains(matrix.os, '-arm') && 'firefox' || '' }}
           # just for full picture after installing Cypress
           # print information about detected browsers, etc
           # see https://on.cypress.io/command-line#cypress-info
@@ -77,4 +78,5 @@ jobs:
         with:
           package-manager-cache: false
           working-directory: examples/basic
+          browser: ${{ contains(matrix.os, 'ubuntu') && contains(matrix.os, '-arm') && 'firefox' || '' }}
           build: npx cypress info

--- a/.github/workflows/example-docker.yml
+++ b/.github/workflows/example-docker.yml
@@ -21,7 +21,6 @@ jobs:
           # Available browsers listed on https://github.com/cypress-io/cypress-docker-images#browsers
           - chrome
           - edge
-          - electron
           - firefox
         exclude:
           - os: ubuntu-24.04-arm

--- a/examples/basic-pnpm/cypress.config.js
+++ b/examples/basic-pnpm/cypress.config.js
@@ -1,6 +1,7 @@
 import { defineConfig } from 'cypress'
 
 export default defineConfig({
+  defaultBrowser: 'chrome',
   fixturesFolder: false,
   e2e: {
     supportFile: false,

--- a/examples/basic/cypress.config.js
+++ b/examples/basic/cypress.config.js
@@ -1,6 +1,7 @@
 import { defineConfig } from 'cypress'
 
 export default defineConfig({
+  defaultBrowser: 'chrome',
   fixturesFolder: false,
   e2e: {
     supportFile: false,

--- a/examples/browser/cypress.config.js
+++ b/examples/browser/cypress.config.js
@@ -2,6 +2,7 @@ import { defineConfig } from 'cypress'
 import os from 'node:os'
 
 export default defineConfig({
+  defaultBrowser: 'chrome',
   fixturesFolder: false,
   e2e: {
     setupNodeEvents (on) {

--- a/examples/component-tests/cypress.config.js
+++ b/examples/component-tests/cypress.config.js
@@ -1,6 +1,7 @@
 import { defineConfig } from 'cypress'
 
 export default defineConfig({
+  defaultBrowser: 'chrome',
   component: {
     devServer: {
       framework: 'react',

--- a/examples/config/cypress.config-alternate.js
+++ b/examples/config/cypress.config-alternate.js
@@ -1,6 +1,7 @@
 import { defineConfig } from 'cypress'
 
 export default defineConfig({
+  defaultBrowser: 'chrome',
   fixturesFolder: false,
   e2e: {
     baseUrl: 'http://localhost:3333',

--- a/examples/config/cypress.config.js
+++ b/examples/config/cypress.config.js
@@ -1,6 +1,7 @@
 import { defineConfig } from 'cypress'
 
 export default defineConfig({
+  defaultBrowser: 'chrome',
   fixturesFolder: false,
   e2e: {
     supportFile: false,

--- a/examples/custom-command/cypress.config.js
+++ b/examples/custom-command/cypress.config.js
@@ -1,6 +1,7 @@
 import { defineConfig } from 'cypress'
 
 export default defineConfig({
+  defaultBrowser: 'chrome',
   fixturesFolder: false,
   e2e: {
     supportFile: false,

--- a/examples/env/cypress.config.js
+++ b/examples/env/cypress.config.js
@@ -1,6 +1,7 @@
 import { defineConfig } from 'cypress'
 
 export default defineConfig({
+  defaultBrowser: 'chrome',
   fixturesFolder: false,
   e2e: {
     setupNodeEvents (on, config) {

--- a/examples/install-command/cypress.config.js
+++ b/examples/install-command/cypress.config.js
@@ -1,6 +1,7 @@
 import { defineConfig } from 'cypress'
 
 export default defineConfig({
+  defaultBrowser: 'chrome',
   fixturesFolder: false,
   e2e: {
     supportFile: false,

--- a/examples/nextjs/cypress.config.js
+++ b/examples/nextjs/cypress.config.js
@@ -1,6 +1,7 @@
 import { defineConfig } from 'cypress'
 
 export default defineConfig({
+  defaultBrowser: 'chrome',
   fixturesFolder: false,
   e2e: {
     supportFile: false,

--- a/examples/node-versions/cypress.config.js
+++ b/examples/node-versions/cypress.config.js
@@ -1,6 +1,7 @@
 import { defineConfig } from 'cypress'
 
 export default defineConfig({
+  defaultBrowser: 'chrome',
   fixturesFolder: false,
   e2e: {
     supportFile: false,

--- a/examples/quiet/cypress.config.js
+++ b/examples/quiet/cypress.config.js
@@ -1,6 +1,7 @@
 import { defineConfig } from 'cypress'
 
 export default defineConfig({
+  defaultBrowser: 'chrome',
   fixturesFolder: false,
   e2e: {
     setupNodeEvents (on) {

--- a/examples/recording/cypress.config.js
+++ b/examples/recording/cypress.config.js
@@ -1,6 +1,7 @@
 import { defineConfig } from 'cypress'
 
 export default defineConfig({
+  defaultBrowser: 'chrome',
   fixturesFolder: false,
   projectId: '3tb7jn',
   e2e: {

--- a/examples/start-and-pnpm-workspaces/packages/workspace-1/cypress.config.js
+++ b/examples/start-and-pnpm-workspaces/packages/workspace-1/cypress.config.js
@@ -1,6 +1,7 @@
 import { defineConfig } from 'cypress'
 
 export default defineConfig({
+  defaultBrowser: 'chrome',
   fixturesFolder: false,
   e2e: {
     supportFile: false,

--- a/examples/start-and-pnpm-workspaces/packages/workspace-2/cypress.config.js
+++ b/examples/start-and-pnpm-workspaces/packages/workspace-2/cypress.config.js
@@ -1,6 +1,7 @@
 import { defineConfig } from 'cypress'
 
 export default defineConfig({
+  defaultBrowser: 'chrome',
   fixturesFolder: false,
   e2e: {
     supportFile: false,

--- a/examples/start-and-yarn-workspaces/workspace-1/cypress.config.js
+++ b/examples/start-and-yarn-workspaces/workspace-1/cypress.config.js
@@ -1,6 +1,7 @@
 import { defineConfig } from 'cypress'
 
 export default defineConfig({
+  defaultBrowser: 'chrome',
   fixturesFolder: false,
   e2e: {
     supportFile: false,

--- a/examples/start-and-yarn-workspaces/workspace-2/cypress.config.js
+++ b/examples/start-and-yarn-workspaces/workspace-2/cypress.config.js
@@ -1,6 +1,7 @@
 import { defineConfig } from 'cypress'
 
 export default defineConfig({
+  defaultBrowser: 'chrome',
   fixturesFolder: false,
   e2e: {
     supportFile: false,

--- a/examples/start/cypress.config.js
+++ b/examples/start/cypress.config.js
@@ -1,6 +1,7 @@
 import { defineConfig } from 'cypress'
 
 export default defineConfig({
+  defaultBrowser: 'chrome',
   fixturesFolder: false,
   e2e: {
     supportFile: false,

--- a/examples/wait-on-vite/cypress.config.js
+++ b/examples/wait-on-vite/cypress.config.js
@@ -1,6 +1,7 @@
 import { defineConfig } from 'cypress'
 
 export default defineConfig({
+  defaultBrowser: 'chrome',
   fixturesFolder: false,
   e2e: {
     supportFile: false,

--- a/examples/wait-on/cypress.config.js
+++ b/examples/wait-on/cypress.config.js
@@ -1,6 +1,7 @@
 import { defineConfig } from 'cypress'
 
 export default defineConfig({
+  defaultBrowser: 'chrome',
   fixturesFolder: false,
   e2e: {
     supportFile: false,

--- a/examples/webpack/cypress.config.js
+++ b/examples/webpack/cypress.config.js
@@ -1,6 +1,7 @@
 import { defineConfig } from 'cypress'
 
 export default defineConfig({
+  defaultBrowser: 'chrome',
   fixturesFolder: false,
   e2e: {
     supportFile: false,

--- a/examples/yarn-classic/cypress.config.js
+++ b/examples/yarn-classic/cypress.config.js
@@ -1,6 +1,7 @@
 import { defineConfig } from 'cypress'
 
 export default defineConfig({
+  defaultBrowser: 'chrome',
   fixturesFolder: false,
   e2e: {
     supportFile: false,

--- a/examples/yarn-modern-pnp/cypress.config.js
+++ b/examples/yarn-modern-pnp/cypress.config.js
@@ -1,6 +1,7 @@
 import { defineConfig } from 'cypress'
 
 export default defineConfig({
+  defaultBrowser: 'chrome',
   fixturesFolder: false,
   e2e: {
     supportFile: false,

--- a/examples/yarn-modern/cypress.config.js
+++ b/examples/yarn-modern/cypress.config.js
@@ -1,6 +1,7 @@
 import { defineConfig } from 'cypress'
 
 export default defineConfig({
+  defaultBrowser: 'chrome',
   fixturesFolder: false,
   e2e: {
     supportFile: false,


### PR DESCRIPTION
- partially addresses https://github.com/cypress-io/github-action/issues/1883

## Situation

Electron is used as the default browser throughout this repo.

With the release of [Cypress 16.0.0](https://docs.cypress.io/app/references/changelog#16-0-0) Electron has been deprecated:

> Deprecated the Electron browser as a test browser. The Electron browser will be removed in a future major version of Cypress; switch to Chrome or another installed browser to avoid a breaking change when you upgrade. See [Migrating away from the Electron browser](https://docs.cypress.io/app/references/migration-guide#Migrating-away-from-the-Electron-browser).

## Change

Chrome is the most used browser and is available in GitHub-hosted runners for each operating system, with the exception of [ubuntu-24.04-arm](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Arm64-Readme.md), for which it has been requested through https://github.com/actions/runner-images/issues/14567.

Use Firefox for `ubuntu*-arm` runner images.

For those examples that are not browser-specific, add the [Browsers](https://docs.cypress.io/app/references/configuration#Browser) configuration setting `defaultBrowsers: chrome`.

Remove tests that explicitly specify `electron`.

This re-applies https://github.com/cypress-io/github-action/commit/68be0d46e386460c28d16735c7a55a5bb5047ecd from PR https://github.com/cypress-io/github-action/pull/1713.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to example Cypress configs and workflow matrices; no runtime or security-sensitive application code is affected.
> 
> **Overview**
> Prepares the repo for **Cypress 16’s Electron browser deprecation** by making **Chrome** the default test browser in example projects and tightening CI browser selection.
> 
> **Example configs:** Adds `defaultBrowser: 'chrome'` to the shared `cypress.config.js` files under `examples/` (e2e, component, workspaces, etc.) so runs no longer rely on Electron when no browser is passed explicitly.
> 
> **GitHub Actions:** In `example-basic.yml`, both basic jobs pass a `browser` input of **Firefox** on `ubuntu*-arm` runners (where Chrome isn’t on the hosted image) and leave other OS matrix entries on the default. In `example-docker.yml`, **Electron** is dropped from the Docker browser matrix so container jobs only exercise Chrome, Edge, and Firefox (with existing arm64 Edge exclusion unchanged).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 963f97129cda8154331023baecdf2a04c85947c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->