### PR TITLE
test: restrict example/env to Cypress <15.10

### DIFF
--- a/.github/workflows/example-env.yml
+++ b/.github/workflows/example-env.yml
@@ -1,4 +1,9 @@
 name: example-env
+#
+# The API call Cypress.env() was deprecated in Cypress 15.10.0 and removed in Cypress 16.0.0.
+# See the workflow example-expose.yml for working with non-sensitive environment variables
+# in Cypress 15.10.0 and above.
+#
 # In the example jobs, the action is called with
 # uses: ./
 # which runs the action code from the current branch.
@@ -15,7 +20,6 @@ env:
   # pass an environment variable to Cypress
   # a test can get its value like this
   # Cypress.env('environmentName') // 'staging'
-  # see https://on.cypress.io/env
   CYPRESS_environmentName: staging
 permissions:
   contents: read
@@ -37,9 +41,10 @@ jobs:
 
   with-env:
     # in the tests below, in addition to 'environmentName'
-    # we are passing additional environment variables
-    # using "--env" command line option
-    # see https://on.cypress.io/configuration
+    # we are passing other environment variables
+    # using the action env option that maps to the option of the
+    # same name in Cypress Module API
+    # see https://docs.cypress.io/app/references/module-api
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout

--- a/README.md
+++ b/README.md
@@ -317,7 +317,9 @@ Refer to [cypress-io/cypress-docker-images](https://github.com/cypress-io/cypres
 
 ### Env
 
-Specify the env argument with `env` parameter
+To pass an environment variable to Cypress <15.10.0 use the action's `env` parameter.
+In Cypress 15.10.0 and above, the `env` is specified for use with secret environment variables.
+It is replaced with the [expose](#expose) action parameter for public, non-sensitive environment variables.
 
 ```yml
 name: Cypress tests

--- a/examples/env/cypress/e2e/spec.cy.js
+++ b/examples/env/cypress/e2e/spec.cy.js
@@ -1,24 +1,36 @@
-it('has all expected env variables', () => {
-  // environmentName is set as workflow environment variable
-  // as a precaution we can confirm the variable was set
-  expect(Cypress.env('environmentName'), 'environment').to.be.a(
-    'string',
-  )
-  // and we can confirm its value
-  expect(
-    Cypress.env('environmentName'),
-    'environment name is staging',
-  ).to.equal('staging')
+import semver from 'semver'
 
-  // host and port are set via action's "with: env:" parameter
-  expect(Cypress.env(), 'full env includes API info').to.deep.include(
-    {
-      host: 'http://api.dev.local',
-      apiPort: 4222,
-    },
-  )
-  // we can confirm that host is an url
-  expect(Cypress.env('host'), 'host is an URL').to.match(
-    /^https?:\/\//,
-  )
-})
+// Cypress.env is deprecated in Cypress 15.10.0 and removed in
+// Cypress 16.0.0. The test is retained as an example for Cypress <15.10.0 users
+// See the migration guide for more information:
+// https://docs.cypress.io/guides/references/migration-guide#Cypress-env
+
+if (semver.gte(Cypress.version, '15.10.0')) {
+  it('skipping Cypress.env tests for Cypress >=15.10.0', () => {})
+}
+else {
+  it('has all expected env variables', () => {
+    // environmentName is set as workflow environment variable
+    // as a precaution we can confirm the variable was set
+    expect(Cypress.env('environmentName'), 'environment').to.be.a(
+      'string',
+    )
+    // and we can confirm its value
+    expect(
+      Cypress.env('environmentName'),
+      'environment name is staging',
+    ).to.equal('staging')
+
+    // host and port are set via action's "with: env:" parameter
+    expect(Cypress.env(), 'full env includes API info').to.deep.include(
+      {
+        host: 'http://api.dev.local',
+        apiPort: 4222,
+      },
+    )
+    // we can confirm that host is an url
+    expect(Cypress.env('host'), 'host is an URL').to.match(
+      /^https?:\/\//,
+    )
+  })
+}

--- a/examples/env/cypress/e2e/spec.cy.js
+++ b/examples/env/cypress/e2e/spec.cy.js
@@ -3,7 +3,7 @@ import semver from 'semver'
 // Cypress.env is deprecated in Cypress 15.10.0 and removed in
 // Cypress 16.0.0. The test is retained as an example for Cypress <15.10.0 users
 // See the migration guide for more information:
-// https://docs.cypress.io/guides/references/migration-guide#Cypress-env
+// https://on.cypress.io/migration-guide#Migrating-away-from-Cypressenv
 
 if (semver.gte(Cypress.version, '15.10.0')) {
   it('skipping Cypress.env tests for Cypress >=15.10.0', () => {})

--- a/examples/env/cypress/e2e/without-env.cy.js
+++ b/examples/env/cypress/e2e/without-env.cy.js
@@ -1,7 +1,19 @@
-it('has all expected env variables', () => {
-  // environmentName is set as workflow environment variable
-  expect(
-    Cypress.env('environmentName'),
-    'has environment name',
-  ).to.equal('staging')
-})
+import semver from 'semver'
+
+// Cypress.env is deprecated in Cypress 15.10.0 and removed in
+// Cypress 16.0.0. The test is retained as an example for Cypress <15.10.0 users
+// See the migration guide for more information:
+// https://docs.cypress.io/guides/references/migration-guide#Cypress-env
+
+if (semver.gte(Cypress.version, '15.10.0')) {
+  it('skipping Cypress.env tests for Cypress >=15.10.0', () => {})
+}
+else {
+  it('has all expected env variables', () => {
+    // environmentName is set as workflow environment variable
+    expect(
+      Cypress.env('environmentName'),
+      'has environment name',
+    ).to.equal('staging')
+  })
+}

--- a/examples/env/cypress/e2e/without-env.cy.js
+++ b/examples/env/cypress/e2e/without-env.cy.js
@@ -3,7 +3,7 @@ import semver from 'semver'
 // Cypress.env is deprecated in Cypress 15.10.0 and removed in
 // Cypress 16.0.0. The test is retained as an example for Cypress <15.10.0 users
 // See the migration guide for more information:
-// https://docs.cypress.io/guides/references/migration-guide#Cypress-env
+// https://on.cypress.io/migration-guide#Migrating-away-from-Cypressenv
 
 if (semver.gte(Cypress.version, '15.10.0')) {
   it('skipping Cypress.env tests for Cypress >=15.10.0', () => {})

--- a/examples/env/package-lock.json
+++ b/examples/env/package-lock.json
@@ -6,9 +6,9 @@
   "packages": {
     "": {
       "name": "example-env",
-      "version": "2.0.0",
       "devDependencies": {
-        "cypress": "15.21.1"
+        "cypress": "15.21.1",
+        "semver": "7.8.5"
       }
     },
     "node_modules/@cypress/request": {
@@ -99,16 +99,13 @@
       }
     },
     "node_modules/ansi-regex": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
-      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+        "node": ">=8"
       }
     },
     "node_modules/ansi-styles": {
@@ -436,10 +433,23 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/cli-truncate/node_modules/ansi-regex": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
+      "integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
     "node_modules/cli-truncate/node_modules/string-width": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.1.tgz",
-      "integrity": "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==",
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.2.tgz",
+      "integrity": "sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -451,6 +461,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
     "node_modules/color-convert": {
@@ -615,9 +641,9 @@
       }
     },
     "node_modules/dayjs": {
-      "version": "1.11.21",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.21.tgz",
-      "integrity": "sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==",
+      "version": "1.11.23",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.23.tgz",
+      "integrity": "sha512-QDTCU0M0MxR3hQfnlDJfwekQiaanm1ubOD231u73WBckQ/fsamwRLiE2GBz6D3a/xF1NgfiDLJjXBa1hYOYTtQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -1115,19 +1141,13 @@
       }
     },
     "node_modules/is-fullwidth-code-point": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
-      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "get-east-asian-width": "^1.3.1"
-      },
       "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=8"
       }
     },
     "node_modules/is-installed-globally": {
@@ -1323,6 +1343,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/log-update/node_modules/ansi-regex": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
+      "integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
     "node_modules/log-update/node_modules/ansi-styles": {
       "version": "6.2.3",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
@@ -1334,6 +1367,22 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/is-fullwidth-code-point": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/log-update/node_modules/slice-ansi": {
@@ -1351,6 +1400,22 @@
       },
       "funding": {
         "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
     "node_modules/math-intrinsics": {
@@ -1568,13 +1633,14 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
-      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.1.0"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"
@@ -1673,6 +1739,19 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -1810,6 +1889,22 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/slice-ansi/node_modules/is-fullwidth-code-point": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/sshpk": {
       "version": "1.18.0",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.18.0.tgz",
@@ -1851,27 +1946,7 @@
         "node": ">=8"
       }
     },
-    "node_modules/string-width/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/string-width/node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/string-width/node_modules/strip-ansi": {
+    "node_modules/strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
@@ -1882,22 +1957,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/strip-ansi": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
-      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.2.2"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
     "node_modules/strip-final-newline": {
@@ -1927,9 +1986,9 @@
       }
     },
     "node_modules/systeminformation": {
-      "version": "5.31.7",
-      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.31.7.tgz",
-      "integrity": "sha512-/8NC53e5nP9nmhn42/ncdOkyJnOoue/Vy+tJOyUGd1Yv66G069wK4rrziwhrqDETgk78CudTQupw5z19S5uoZw==",
+      "version": "5.33.8",
+      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.33.8.tgz",
+      "integrity": "sha512-v4F6OGYGh7wDvV68YmjOmZwGixV9A/GQ7d2b84t0UF4CaOy9jipNWIJDkHqYDYiTPuiojqlwVQd0hfUKOUN7tQ==",
       "dev": true,
       "license": "MIT",
       "os": [
@@ -1946,7 +2005,7 @@
         "systeminformation": "lib/cli.js"
       },
       "engines": {
-        "node": ">=8.0.0"
+        "node": ">=10.0.0"
       },
       "funding": {
         "type": "Buy me a coffee",
@@ -2115,6 +2174,19 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/wrap-ansi/node_modules/ansi-regex": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
+      "integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
     "node_modules/wrap-ansi/node_modules/ansi-styles": {
       "version": "6.2.3",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
@@ -2151,6 +2223,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
     "node_modules/wrappy": {

--- a/examples/env/package.json
+++ b/examples/env/package.json
@@ -1,15 +1,14 @@
 {
   "name": "example-env",
-  "version": "2.0.0",
   "description": "example passing env variables to Cypress",
   "type": "module",
-  "main": "index.js",
   "scripts": {
     "test": "cypress run"
   },
   "private": true,
   "devDependencies": {
-    "cypress": "15.21.1"
+    "cypress": "15.21.1",
+    "semver": "7.8.5"
   },
   "allowScripts": {
     "cypress": true


### PR DESCRIPTION
**PREREQUISITE FOR CYPRESS 16 UPGRADE**

- relates to issue https://github.com/cypress-io/github-action/issues/1620

## Situation

- The example directory [examples/env](https://github.com/cypress-io/github-action/tree/master/examples/env) uses the [Cypress.env()](https://docs.cypress.io/api/cypress-api/env) API call to get environment variables in tests. These are non-secret environment variables. The related workflow [example-env.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-env.yml) refers to this usage in comments.

- In [cypress@15.10.0](https://docs.cypress.io/app/references/changelog#15-10-0)
  - [`Cypress.env()`](https://docs.cypress.io/api/cypress-api/env) was deprecated
  - the configuration option `allowCypressEnv` was introduced for the remaining lifetime of Cypress 15.x to enable explicitly disallowing `Cypress.env()`
  - [`cy.env()`](https://docs.cypress.io/api/commands/env) was added for sensitive configuration information
  - [Cypress Module API](https://docs.cypress.io/app/references/module-api#Options) option `env` corresponding to the action parameter `env` is now specified for use with secret environment variables
  - [`Cypress.expose()`](https://docs.cypress.io/api/cypress-api/expose) was added for non-sensitive configuration information

- In [cypress-io/github-action@7.3.0](https://github.com/cypress-io/github-action/tree/v7.3.0)
  - The action `expose` parameter was added to be able to pass this to the [Cypress Module API](https://docs.cypress.io/app/references/module-api)
  - [examples/expose](https://github.com/cypress-io/github-action/tree/master/examples/expose) and [.github/workflows/example-expose.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-expose.yml) were added to demonstrate the use of [`Cypress.expose()`](https://docs.cypress.io/api/cypress-api/expose)

- In [cypress@16.0.0](https://docs.cypress.io/app/references/changelog#16-10-0)
  - [`Cypress.env()`](https://docs.cypress.io/api/cypress-api/env) was removed
  - `allowCypressEnv` was removed

## Assessment

The `env` examples are still relevant for action users that have not upgraded to minimum Cypress 15.10. They are however incompatible with Cypress 16 and block upgrading the repo.

[`env`](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#env) continues to be available for GitHub Actions workflows for both secret and non-secret variables. Preserving various examples using `env` is therefore helpful for understanding how to use variables.

## Change

Skip the tests in [examples/env](https://github.com/cypress-io/github-action/tree/master/examples/env) for Cypress >=15.10.0

Update code inline comments and documentation accordingly.

## Verification

```shell
cd examples/env
npm install cypress@15.9.0
export CYPRESS_environmentName=staging CYPRESS_apiPort=4222 CYPRESS_host=http://api.dev.local
npm test
npm install cypress@15.10.0
npm test
npm install cypress@15
npm test
npm install cypress@16
npm test
```

Confirm that each test is successful.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to example tests, lockfile, and documentation; no production action behavior is modified.
> 
> **Overview**
> Prepares the repo for a Cypress 16 upgrade by keeping the legacy **`examples/env`** workflow and docs while stopping **`Cypress.env()`** assertions from running on Cypress **15.10.0+** (where that API is deprecated/removed).
> 
> The e2e specs in **`spec.cy.js`** and **`without-env.cy.js`** now use **`semver`** to run the original env checks only on older Cypress versions; on **≥15.10.0** they register a no-op test so CI still passes. **`example-env.yml`** and the README **Env** section are updated with migration notes and a pointer to **`example-expose.yml`** / the **`expose`** action input for non-sensitive config on modern Cypress.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c0051f24874ce25f60b1182c49a34e73bc5a302. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->