### PR TITLE
test: add ubuntu-24.04-arm to Chrome for Testing example

### DIFF
--- a/.github/workflows/example-chrome-for-testing.yml
+++ b/.github/workflows/example-chrome-for-testing.yml
@@ -10,15 +10,21 @@ permissions:
 
 jobs:
   tests:
-    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-24.04
+          - ubuntu-24.04-arm
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
         uses: actions/checkout@v7
       - name: Install Chrome for Testing
-        # https://github.com/browser-actions/setup-chrome
+        # Installs from stable channel by default.
+        # See https://github.com/browser-actions/setup-chrome for other options.
+        # See https://github.com/GoogleChromeLabs/chrome-for-testing for available versions.
         uses: browser-actions/setup-chrome@v2
-        with:
-          chrome-version: 140
       - name: Cypress info
         uses: ./ # if copying, replace with cypress-io/github-action@v7
         with:

--- a/README.md
+++ b/README.md
@@ -188,7 +188,11 @@ jobs:
 
 ### Chrome for Testing
 
-To install [Google Chrome for Testing](https://developer.chrome.com/blog/chrome-for-testing/), specify a partial or full numerical Chrome for Testing version using [browser-actions/setup-chrome](https://github.com/browser-actions/setup-chrome). Refer to [Chrome for Testing availability](https://googlechromelabs.github.io/chrome-for-testing/) for current versions or [JSON API endpoints](https://github.com/GoogleChromeLabs/chrome-for-testing#json-api-endpoints) for all available versions.
+To install [Google Chrome for Testing](https://developer.chrome.com/blog/chrome-for-testing/)
+use [browser-actions/setup-chrome](https://github.com/browser-actions/setup-chrome).
+Refer to [Chrome for Testing availability](https://googlechromelabs.github.io/chrome-for-testing/) for current versions
+or [JSON API endpoints](https://github.com/GoogleChromeLabs/chrome-for-testing#json-api-endpoints)
+for all available versions.
 
 ```yml
 name: Chrome for Testing
@@ -200,8 +204,6 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: browser-actions/setup-chrome@v2
-        with:
-          chrome-version: 140
       - uses: cypress-io/github-action@v7
         with:
           browser: chrome-for-testing


### PR DESCRIPTION
- closes https://github.com/cypress-io/github-action/issues/1861

## Situation

- The workflow [example-chrome-for-testing.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-chrome-for-testing.yml) runs a specific Chrome for Testing version `140` in the `ubuntu-24.04` GitHub Actions runner image.

- The latest `stable` version of [Chrome for Testing](https://googlechromelabs.github.io/chrome-for-testing/) is `153.0.8010.36`

- Cypress supports the latest 3 major versions: 153, 152 & 151

- According to [Chrome for Testing > Supported platforms](https://github.com/GoogleChromeLabs/chrome-for-testing#supported-platforms) `linux-arm64` is supported since v153.0.8001.0

- [browser-actions/setup-chrome@v2.2.0](https://github.com/browser-actions/setup-chrome/releases/tag/v2.2.0) added support for Linux arm64

## Change

Add a matrix to [example-chrome-for-testing.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-chrome-for-testing.yml) and test under

- [ubuntu-24.04](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md)
- [ubuntu-24.04-arm](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Arm64-Readme.md)

Remove the explicit Chrome for Testing version selection:

```yaml
        with:
          chrome-version: 140
```

so that the default `stable` channel is used.

Align the [README documentation section](https://github.com/cypress-io/github-action#chrome-for-testing) accordingly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI and documentation-only changes; no runtime changes to the GitHub Action itself.
> 
> **Overview**
> Expands the **Chrome for Testing** example workflow to run Cypress on both `ubuntu-24.04` and `ubuntu-24.04-arm` via a matrix with `fail-fast: false`, covering linux-arm64 Chrome for Testing support.
> 
> **`browser-actions/setup-chrome`** no longer pins `chrome-version: 140`; it relies on the action’s default **stable** channel. Workflow comments and the README **Chrome for Testing** section are updated to match (example YAML and wording only).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f13d0e86b5797d67f8c3a02dc7a24e4add39f9f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->